### PR TITLE
CTE sub-array 

### DIFF
--- a/pkg/wfc3/calwf3/wf3ccd/sink.c
+++ b/pkg/wfc3/calwf3/wf3ccd/sink.c
@@ -111,7 +111,7 @@ int SinkDetect(WF3Info *wf3, SingleGroup *x){
                 scipix = Pix(raz.sci.data,i,j);
                 
                 /*FLAG THE DOWNSTREAM PIXEL*/
-                if (PPix(&sinkraz,i,j-1) < 0 ){
+                if (j>0 && PPix(&sinkraz,i,j-1) < 0 ){
                     dqval = TRAP | DQPix (raz.dq.data, i, j-1);
                     DQSetPix (raz.dq.data, i, j-1, dqval);
                 }
@@ -135,7 +135,6 @@ int SinkDetect(WF3Info *wf3, SingleGroup *x){
         } /*end j*/
     }/*end i*/   
 
-    
     /*format the dq data back to expected orientation*/
     undodqRAZ(x,&raz);
 

--- a/pkg/wfc3/calwf3/wf3cte/cte_dobias.c
+++ b/pkg/wfc3/calwf3/wf3cte/cte_dobias.c
@@ -69,6 +69,13 @@ int doCteBias (WF3Info *wf3, SingleGroup *x) {
 	if (FindLine (x, &y, &same_size, &rx, &ry, &x0, &y0))
 		return (status);
 
+	/* CKJ: Going to force the same_size x0, y0 = 0,0
+	 *      as the sub-array data was put into a full-array format.
+	 */
+	same_size = 1;
+	x0 = 0;
+	y0 = 0;
+
 	/* Return with error if reference data not binned same as input */
 	if (rx != 1 || ry != 1) {
 		closeSingleGroupLine (&y);


### PR DESCRIPTION
The CTE sub-array changes were requested by Megan/Warren.  The code essentially reads in the sub-array data, creates AB and CD SingleGroups and puts the sub-array data into the appropriate AB/CD locations based on offset and size of the sub-array data. 

The code was validated in three ways:

1) The FLC and FLT results of the full-array data were compared from this code and from the original code and they were the same.  So this code did not affect the full-array data results.

2) A subset of the full-array data was cropped from chip 1, run through the new code and then the FLC and FLT were compared to cropped versions of the full-array data FLC / FLT from 1).

3) A subset of the full-array data was cropped from chip 2, run through the new code and then the FLC and FLT were compared to cropped versions of the full-array data FLC / FLT from 1).

An email will be sent to Megan that contains the Validation data. She will be the one (or will assign someone) to check and validate the code.

(I tried to attach the zip file of the validation code here but it would not attach)