### PR TITLE
Moved the init for the CTE params back to the top of the code

### DIFF
--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,3 +1,6 @@
+20-Sep-2016 - MLS - Version 3.4
+    - Moved the init for the CTE params back to the top of the code, it had gotten moved below the header update for the information
+
 14-Sep-2016 - MLS - Version 3.4
     - CTE subarrays enabled for user supported subarrays with physical overscan
 

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,3 +1,6 @@
+### 20-Sep-2016 - MLS - Version 3.4
+    - Moved the init for the CTE params back to the top of the code, it had gotten moved below the header update for the information
+
 ### 14-Sep-2016 - MLS - Version 3.4
     - CTE subarrays enabled for user supported subarrays with physical overscan
 

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,3 +1,6 @@
+Updates for Version 3.4 20-Sep-2016 MLS
+    - Moved the init for the CTE params back to the top of the code, it had gotten moved below the header update for the information
+
 Updates for Version 3.4 14-Sep-2016 MLS
     - CTE subarrays enabled for user supported subarrays with physical overscan
 

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -1,4 +1,4 @@
 /* This string is written to the output primary header as CAL_VER. */
 
-# define WF3_CAL_VER "3.4(14-Sep-2016)"
+# define WF3_CAL_VER "3.4(20-Sep-2016)"
 # define WF3_CAL_VER_NUM "3.4"

--- a/pkg/wfc3/calwf3/wf3cte/wf3cte.c
+++ b/pkg/wfc3/calwf3/wf3cte/wf3cte.c
@@ -242,6 +242,16 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
         }
     }
 
+    /*READ IN THE CTE PARAMETER TABLE*/
+    initCTEParams(&cte_pars);
+    if (GetCTEPars (wf3.pctetab.name, &cte_pars))
+        return (status);
+
+    if (verbose){
+        PrRefInfo ("pctetab", wf3.pctetab.name, wf3.pctetab.pedigree,
+                wf3.pctetab.descrip, wf3.pctetab.descrip2);
+    }
+
     /* Full frame and subarrays always have group 1
        If it's a subarray, the group can be from either chip
        and will still be labled group 1 because it's the FIRST
@@ -439,15 +449,6 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
 
     }
 
-    /*READ IN THE CTE PARAMETER TABLE*/
-    initCTEParams(&cte_pars);
-    if (GetCTEPars (wf3.pctetab.name, &cte_pars))
-        return (status);
-
-    if (verbose){
-        PrRefInfo ("pctetab", wf3.pctetab.name, wf3.pctetab.pedigree,
-                wf3.pctetab.descrip, wf3.pctetab.descrip2);
-    }
 
     /*CONVERT TO RAZ, SUBTRACT BIAS AND CORRECT FOR GAIN*/
     if (raw2raz(&wf3, &cd, &ab, &raz))


### PR DESCRIPTION
… it had gotten moved below the header update for the information so the header keywords weren't always being populated correctly. Found during my association testing. 