### PR TITLE
Fixed memory allocation around print statement

### DIFF
--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,3 +1,6 @@
+26-Sep-2016 - MLS - Version 3.4
+    - Fixed memory allocation around prints
+    
 20-Sep-2016 - MLS - Version 3.4
     - Moved the init for the CTE params back to the top of the code, it had gotten moved below the header update for the information
 

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,3 +1,6 @@
+### 26-Sep-2016 - MLS - Version 3.4
+    - Fixed memory allocation around prints
+
 ### 20-Sep-2016 - MLS - Version 3.4
     - Moved the init for the CTE params back to the top of the code, it had gotten moved below the header update for the information
 

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,3 +1,6 @@
+Updates for Version 3.4 26-Sep-2016 - MLS 
+    - Fixed memory allocation around prints
+
 Updates for Version 3.4 20-Sep-2016 MLS
     - Moved the init for the CTE params back to the top of the code, it had gotten moved below the header update for the information
 

--- a/pkg/wfc3/calwf3/calwf3/calwf3.c
+++ b/pkg/wfc3/calwf3/calwf3/calwf3.c
@@ -141,7 +141,7 @@ int CalWf3Run (char *input, int printtime, int save_tmp, int verbose, int debug,
 
     /*because DTH had this hard coded and it varies with UVIS for CTE*/
    char suffix_flt[]="_flt.fits";
-   /*char suffix_flc[]="_flc.fits"; */   
+   char suffix_flc[]="_flc.fits";
 
 
 	/* Post error handler */

--- a/pkg/wfc3/calwf3/calwf3/procccd.c
+++ b/pkg/wfc3/calwf3/calwf3/procccd.c
@@ -44,23 +44,23 @@
    WF32d processing still takes place for individual exposures if
    EXPSCORR=PERFORM. (PR 68593; Trac #722)
 
-   M. Sosey, 2014 September: added CTE correction  and 
+   M. Sosey, 2014 September: added CTE correction  and
    indented the code to make it easier to parse. onecpu was added
    to the function signature so that the user can have more control over
    the number of threads/cpus that are used during parallel processing for CTE correction.
    (see #1193 UVIS2.0 update)
-   
-   M. Sosey, 2015: fixed some logic associated with crcorr processing and 
+
+   M. Sosey, 2015: fixed some logic associated with crcorr processing and
    removing the tmp files
-   
+
    M. Sosey 2016: updated the trailer file concatination; the trailer files for
    association files are not being concatinated correctly.
-    
+
  */
 
 int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int onecpu) {
 
-    extern int status; 
+    extern int status;
 
     RefFileInfo sciref;		    /* ref file keywords and names */
     CCD_Switch sci_sw;		    /* all cal switches for science file */
@@ -68,7 +68,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
     CCD_Switch wf32d_sci_sw;   	/* WF32D  switches for science file */
     CCD_Switch wf3cte_sci_sw;   /* CTE switches for science file */
 
-    int prod;			        /* which CR-split/Rptobs product 
+    int prod;			        /* which CR-split/Rptobs product
                                            are we working with?	*/
     int posid;			        /* counter for input products	*/
     int expid;			        /* counter for input exposures 	*/
@@ -85,7 +85,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
     void SetCCDSw   (CCD_Switch *, CCD_Switch *, CCD_Switch *,CCD_Switch *);
     void ResetCCDSw (CCD_Switch *, CCD_Switch *);
     void ResetSwitch (CCD_Switch *, CCD_Switch *);
-    void WF3Defaults (WF3Info *);	
+    void WF3Defaults (WF3Info *);
     void InitRefFile (RefFileInfo *);
     void FreeRefFile (RefFileInfo *);
     int  CCDRefInit (WF3Info *, CCD_Switch *, RefFileInfo *);
@@ -102,8 +102,8 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
     posid=0;
     wf3rej_input=NULL;
     wf3rej_cte_input=NULL;
-    wf3rej_msgtext=NULL;		
-    
+    wf3rej_msgtext=NULL;
+
     /* Reset RPTCORR setting from ASN table to use CRCORR for UVIS */
     if (asn->rptcorr == PERFORM) {
         asn->crcorr = PERFORM;
@@ -114,9 +114,9 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
     /* LOOP OVER THE PRODUCTS/POSITIONS FOR EACH CR-SPLIT/REPEAT-OBS SET. */
     for (prod = 0; prod < asn->numprod; prod++) {
         if (asn->verbose){
-            sprintf (MsgText, "CALWF3: processing UVIS product %d, spmems is %i, total products is %i", prod,asn->spmems[posid], asn->numprod);	
+            sprintf (MsgText, "CALWF3: processing UVIS product %d, spmems is %i, total products is %i", prod,asn->spmems[posid], asn->numprod);
             trlmessage (MsgText);
-        }	
+        }
 
         /* PROCESS THIS PARTIAL/SINGLE/FULL PRODUCT... */
         for (posid = 1; posid <= asn->numsp; posid++) {
@@ -127,7 +127,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
 
             /*  Allocate space for WF3REJ NON-CTE input image list */
             if (asn->crcorr == PERFORM ) {
-                
+
                 nchars = asn->spmems[posid] * (SZ_FNAME+1);
                 wf3rej_input = (char *) calloc( nchars + 1, sizeof(char));
                 wf3rej_input[0] = '\0';
@@ -135,18 +135,18 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                 nchars = asn->spmems[posid] * (SZ_FNAME+1);
                 wf3rej_cte_input = (char *) calloc( nchars + 1, sizeof(char));
                 wf3rej_cte_input[0] = '\0';
-                
-            }           
-            
 
-            /*IS THIS A BUG? WITH 2 MEMBERS AND 1 PRODUCT IN THE ASN TABLE THE CODE IN WF3TABLE WHERE SPMEMS 
+            }
+
+
+            /*IS THIS A BUG? WITH 2 MEMBERS AND 1 PRODUCT IN THE ASN TABLE THE CODE IN WF3TABLE WHERE SPMEMS
               IS POPULATED ALWAYS SETS IT TO 1. EXPID ALWAYS ENDS UP AS 1 AND POSID INCREASES , BUT SPMEMS[POSID] IS ALWAYS 1
               SO THE THE FLT IMAGES GET CALIBRATED WITH THEIR OWN REFERENCE FILES INSTEAD OF THE INTENDED FIRST IMAGE REFERENCE
-              FILES. IF THERE WERE 2 PRODUCTS IN THE TABLE WOULD THIS BE DIFFERENT? IT ACTUALLY IS THE PREFERRED PROCESS NOW. */			
+              FILES. IF THERE WERE 2 PRODUCTS IN THE TABLE WOULD THIS BE DIFFERENT? IT ACTUALLY IS THE PREFERRED PROCESS NOW. */
             for (expid = 1; expid <= asn->spmems[posid]; expid++) {
 
-                /** FROM THIS POINT ON, WE ARE WORKING WITH ONE IMAGE AT A TIME... 
-                  READ IN MEMBER KEYWORD INFO FROM --FIRST-wf3rej- EXP ** IMAGE HEADER */	
+                /** FROM THIS POINT ON, WE ARE WORKING WITH ONE IMAGE AT A TIME...
+                  READ IN MEMBER KEYWORD INFO FROM --FIRST-wf3rej- EXP ** IMAGE HEADER */
 
                 if (expid == 1) {
                     /* (RE-)INITIALIZE THE LISTS OF REFERENCE FILE
@@ -159,11 +159,11 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                     if (asn->process == SINGLE ) {
                         if (GetSingle (asn, wf3hdr) )
                             return (status);
-                    } else {	
+                    } else {
                         if (GetAsnMember (asn, prod, posid, expid,
-                                    wf3hdr)) 
+                                    wf3hdr))
                             return (status);
-                    } 
+                    }
 
                     /* INITIALIZE VARIABLES, AND GET INFO (CALIBRATION
                      ** SWITCHES AND REFERENCE FILE NAMES) FROM PRIMARY
@@ -172,9 +172,9 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                         return (status);
 
                     /* MAKE SURE 'SAVE_TMP' NO LONGER
-                     ** SET TO 'DUMMY'. 
+                     ** SET TO 'DUMMY'.
                      **
-                     ** IF SAVE_TMP WAS SET FROM THE COMMAND-LINE, THEN 
+                     ** IF SAVE_TMP WAS SET FROM THE COMMAND-LINE, THEN
                      ** IGNORE WHAT IS SET IN THE HEADER KEYWORD
                      ** EXPSCORR. */
 
@@ -183,7 +183,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                     }
 
                     if (asn->verbose) {
-                        trlmessage 
+                        trlmessage
                             ("CALWF3: Got reference file information");
                     }
                     /* Store the trailer file comments into preface */
@@ -195,18 +195,18 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
 
                         if (GetSingle (asn, wf3hdr))
                             return (status);
-                    } else {	               
-                        if (GetAsnMember (asn, prod, posid, expid,wf3hdr)) 
+                    } else {
+                        if (GetAsnMember (asn, prod, posid, expid,wf3hdr))
                             return (status);
-                    } 
+                    }
 
                     /* CONSTRUCT OUTPUT AND TEMPORARY FILE NAMES. */
                     if (InsertWF3Suffix (wf3hdr))
-                        return (status);	    		
+                        return (status);
                 } /*END ELSE FOR EXPID != 1*/
 
 
-                /* CHECK ASN TABLE SETTINGS FOR CRCORR/RPTCORR 
+                /* CHECK ASN TABLE SETTINGS FOR CRCORR/RPTCORR
                  ** AGAINST IMAGE HEADER VALUES.  IF THEY ARE NOT
                  ** CONSISTENT, PRINT OUT A ERROR MESSAGE AND QUIT.
                  ** ONLY NEED TO PERFORM THIS CHECK ON THE FIRST IMAGE
@@ -214,7 +214,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                 if (prod == 0 && posid == 1 && expid == 1) {
                     if (CheckCorr(asn, wf3hdr))
                         return (status);
-                }                
+                }
 
                 /* COPY SWITCH VALUES FOR WF3CCD AND WF32D AND WF3CTE ARGUMENT
                  ** LISTS. */
@@ -236,7 +236,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                     FreeRefFile (&sciref);
                     return (status = NOTHING_TO_DO);
 
-                }   
+                }
 
                 /* COPY ALL MESSAGES UP TO HERE INTO PREFACE BUFFER
                    TO BE PREPENDED TO ALL INPUT FILE TRAILER FILES */
@@ -249,11 +249,11 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
 
                     /*correct for CTE issues and THEN complete the calibration
                       also run through the pipeline completely without CTE corr after,
-                      so in this case, two sets of fully calibrated output images will be created                 
+                      so in this case, two sets of fully calibrated output images will be created
 
                       This step processes both chips together
                       and has some of its own calibration files so it's
-                      outside the single chip loop below 
+                      outside the single chip loop below
 
                       This also occurs before DoCCD which populates
                       all the useful data structures :/
@@ -263,11 +263,11 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                       happens after acsccd and the blevcorr step.
 
                      */
-                    
-                    
+
+
                     if ( WF3cte(wf3hdr->rawfile, wf3hdr->rac_tmp, &sci_sw, &sciref, printtime, asn->verbose, onecpu) )
-                        return (status);                
-                     
+                        return (status);
+
                     if (wf3hdr->sci_basic_ccd == PERFORM) {
 
                         /* THIS IS CALWF3CCD; NOTE WE USE WF3CCD_SCI_SW. */
@@ -275,9 +275,9 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                         /*DO WF3CCD STUFF ON THE RAC IMAGE */
                         if (WF3ccd (wf3hdr->rac_tmp, wf3hdr->blc_tmp,
                                     &wf3ccd_sci_sw, &sciref, printtime,
-                                    asn->verbose)) 		
+                                    asn->verbose))
                                 return (status);
-                                
+
                             /* RESET SWITCHES FOR NON-CTE PROCESSING RUN */
                             ResetSwitch(&sci_sw, &wf3ccd_sci_sw);
 
@@ -292,7 +292,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                     }
 
 
-                    
+
                     /* WE ARE NOW WORKING WITH BLC_TMP HERE... */
                     /* COPY BLC_TMP NAME TO WF3REJ_INPUT STRING */
                     if (wf3hdr->sci_crcorr == PERFORM ||  wf3hdr->sci_rptcorr == PERFORM) {
@@ -307,18 +307,18 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                                 wf3hdr->blc_tmp);
                         strcpy (asn->product[prod].subprod[posid].exp[expid].rac_tmp,
                                 wf3hdr->rac_tmp);
-                                
+
                     }
 
                 }  /*END CTE PROCESSING TO BLC_TMP LEVEL*/
-                
-                
+
+
                 /*ALWAYS REPEAT THE PROCESS WITHOUT THE CTE CORRECTION SO BOTH ARE PRODUCED*/
                 if (wf3hdr->sci_basic_ccd == PERFORM) {
-                                    
+
                     if (WF3ccd (wf3hdr->rawfile, wf3hdr->blv_tmp,
                                 &wf3ccd_sci_sw, &sciref, printtime,
-                                asn->verbose)) 		
+                                asn->verbose))
                         return (status);
 
                         /* RESET SWITCHES */
@@ -343,18 +343,18 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                         /* DON'T ADD A COMMA TO THE END OF THE LAST FILENAME */
                         strcat(wf3rej_input, ",");
                     }
- 
+
                     /* ALSO ADD BLV_TMP TO LIST OF FILES TO BE DELETED */
                     strcpy (asn->product[prod].subprod[posid].exp[expid].blv_tmp,
                             wf3hdr->blv_tmp);
                 }
-                
-                
+
+
 
                 /* IF WE ARE NOT PERFORMING CRCORR OR RPTCORR, THEN
-                   FINISH PROCESSING INDIVIDUAL FILES WITH WF32D. */ 
+                   FINISH PROCESSING INDIVIDUAL FILES WITH WF32D. */
 
-                if (wf3hdr->sci_crcorr != PERFORM && wf3hdr->sci_rptcorr != PERFORM) { 
+                if (wf3hdr->sci_crcorr != PERFORM && wf3hdr->sci_rptcorr != PERFORM) {
                     if (asn->debug) {
                         trlmessage ("UVIS crcorr/rptcorr not set to Perform...");
                     }
@@ -364,17 +364,17 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                         SetTrlPrefaceMode (NO);
 
                         /* BASIC 2-D PROCESSING (FLAT FIELD, ETC). */
-                        if (WF32d (wf3hdr->blv_tmp, wf3hdr->fltfile, 
+                        if (WF32d (wf3hdr->blv_tmp, wf3hdr->fltfile,
                                     &wf32d_sci_sw, &sciref, printtime,
-                                    asn->verbose)) 
+                                    asn->verbose))
                             return(status);
 
 
-                    } else {  
+                    } else {
                         /* REMEMBER BLV_TMP AS FINAL OUTPUT...*/
                         if (CopyFFile (wf3hdr->blv_tmp, wf3hdr->fltfile))
                             return (status);
-                    }    
+                    }
 
 
                     /* PROCESS CTE DATA */
@@ -382,17 +382,17 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                         SetTrlPrefaceMode (NO);
 
                         /* Basic 2-D processing (flat field, etc). */
-                        if (WF32d (wf3hdr->blc_tmp, wf3hdr->flcfile, 
+                        if (WF32d (wf3hdr->blc_tmp, wf3hdr->flcfile,
                                     &wf32d_sci_sw, &sciref, printtime,
-                                    asn->verbose)) 
-                            return (status);				
+                                    asn->verbose))
+                            return (status);
 
                     } else {/* REMEMBER BLC_TMP AS FINAL OUTPUT...*/
                         if ( wf3hdr->sci_basic_cte == PERFORM){
                             if (CopyFFile (wf3hdr->blc_tmp, wf3hdr->flcfile))
                                 return (status);
                         }
-                    }/*END PROCESS CTE WITH WF32D*/ 
+                    }/*END PROCESS CTE WITH WF32D*/
 
                     if (*save_tmp == NO){
                         if (wf3hdr->sci_basic_cte == PERFORM) {
@@ -400,15 +400,15 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                             remove (wf3hdr->rac_tmp);
                         }
                         remove (wf3hdr->blv_tmp);
-                    }                
-                } 
+                    }
+                }
 
             }/* END EXPID  LOOP OVER INDIVIDUAL EXPOSURES,GO ON TO CREATE PRODUCTS */
-                               
-            /* Reset the trailer file preface to NULL since                   
+
+            /* Reset the trailer file preface to NULL since
             ** it has already been copied into trailer files */
             ResetTrlPreface();
-                                     
+
             /*** DO CRCORR/RPTCORR PROCESSING ***/
             if (wf3hdr->sci_crcorr == PERFORM ||  wf3hdr->sci_rptcorr == PERFORM) {
 
@@ -421,7 +421,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                 }
 
                 /* COPY SWITCH VALUES FOR WF3CCD AND WF32D ARGUMENT LISTS. */
-                SetCCDSw (&sci_sw, &wf3ccd_sci_sw, &wf3cte_sci_sw, &wf32d_sci_sw);	
+                SetCCDSw (&sci_sw, &wf3ccd_sci_sw, &wf3cte_sci_sw, &wf32d_sci_sw);
 
                 /* RESET DQICORR, SINCE IT WILL ALREADY HAVE BEEN DONE */
                 wf32d_sci_sw.dqicorr = COMPLETE;
@@ -429,13 +429,13 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                 if (asn->debug || asn->verbose) {
                     sprintf (MsgText,"Non-cte input to WF3REJ is:");
                     trlmessage (MsgText);
-                
+
 
                     /* NEED TO ALLOCATE MEMORY FOR A SEPARATE STRING TO
                      ** BE LONG ENOUGH TO HOLD ALL INPUT NAMES WHEN
                      ** PRINTING IT OUT. CAUSES PIPELINE PROBLEMS
                      ** OTHERWISE. HAB 20-JUN-2004 */
-                    wf3rej_msgtext = (char *) calloc(strlen(wf3rej_input)+25,sizeof(char));
+                    wf3rej_msgtext = (char *) calloc(strlen(wf3rej_cte_input)+25,sizeof(char));
                     sprintf (wf3rej_msgtext, "%s", wf3rej_input);
                     trlmessage (wf3rej_msgtext);
                     free (wf3rej_msgtext);
@@ -443,9 +443,9 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                             wf3hdr->crj_tmp);
                     trlmessage (MsgText);
                 }
-                
+
                 /* SET UP THE CORRECT VALUE OF ASN_MTYP FOR WF3REJ
-                   OUTPUT IMAGE. EXP-CRJ*/                
+                   OUTPUT IMAGE. EXP-CRJ*/
                 if (strncmp (wf3hdr->asn_table, wf3hdr->crj_tmp, 9) ) {
                     /* CRJ_TMP IS A SUB-PRODUCT */
                     strcpy (wf3hdr->mtype,
@@ -455,7 +455,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                     /* CRJ_TMP LEADS TO A PRODUCT WITH SAME ROOTNAME AS
                      ** ASN_TABLE */
                     strcpy (wf3hdr->mtype, asn->product[prod].mtype);
-                }   
+                }
 
                 /* REJECT COSMIC RAYS FOR NON-CTE DATA AND UPDATE THE OUTPUT SPT */
                 if (WF3Rej_0 (wf3rej_input, wf3hdr->crj_tmp,
@@ -468,39 +468,39 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                          ** with this condition */
                         status = WF3_OK;
                     } else {
-                        return (status); 
+                        return (status);
                     }
                 }
-                
+
                 /* FREE UP MEMORY USED BY WF3REJ_INPUT FOR THIS
                  ** SUBPRODUCT */
-                free(wf3rej_input); 
+                free(wf3rej_input);
 
                 /*THE ASN TABLE IS ONLY UPDATED FOR NON-CTE DATA*/
                 if (updateAsnTable (asn, prod, posid))
                     return (status);
-                
+
 
                 /*NOW DO CR-REJECTION FOR THE CTE DATA*/
                 if (wf3hdr->sci_basic_cte == PERFORM){
-                    
-                    if (asn->debug || asn->verbose) {                   
+
+                    if (asn->debug || asn->verbose) {
                         /* NEED TO ALLOCATE MEMORY FOR A SEPARATE STRING TO
                          ** BE LONG ENOUGH TO HOLD ALL INPUT NAMES WHEN
                          ** PRINTING IT OUT. CAUSES PIPELINE PROBLEMS
                          ** OTHERWISE. HAB 20-JUN-2004 */
 
                         wf3rej_msgtext = (char *) calloc(strlen(wf3rej_cte_input)+25,sizeof(char));
-                        sprintf (wf3rej_msgtext, "%s", wf3rej_input);
+                        sprintf (wf3rej_msgtext, "%s", wf3rej_cte_input);
                         trlmessage (wf3rej_msgtext);
                         free(wf3rej_msgtext);
                     }
-                    
+
                         /*the mtype was already set in the non-cte loop to EXP-CRJ*/
-                    
+
                     /* REJECT COSMIC RAYS. */
                     if (WF3Rej_0 (wf3rej_cte_input, wf3hdr->crc_tmp,
-                                wf3hdr->mtype, printtime, asn->verbose,0)) {
+                                wf3hdr->mtype, printtime, asn->verbose, 0)) {
                         if (status == NO_GOOD_DATA || status == NOTHING_TO_DO) {
                             /* SET CRCORR TO SKIPPED SO THAT WE DON'T TRY TO
                                APPLY WF32D TO CRC_TMP PRODUCT */
@@ -509,61 +509,61 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                              ** WITH THIS CONDITION */
                             status = WF3_OK;
                         } else {
-                            return (status); 
+                            return (status);
                         }
                     }
-
+                    
                     /* FREE UP MEMORY USED BY WF3REJ_INPUT FOR THIS
                      ** SUBPRODUCT */
-                    free(wf3rej_cte_input); 
-                    
+                    free(wf3rej_cte_input);
+
                 }/*END REJ FOR CTE DATA*/
 
                 trlmessage("Starting WF32D");
 
                 /* MOVE ON TO WF32D */
 
-                if (wf3hdr->sci_basic_2d == PERFORM &&  wf3hdr->sci_crcorr == PERFORM) { 
+                if (wf3hdr->sci_basic_2d == PERFORM &&  wf3hdr->sci_crcorr == PERFORM) {
 
                    /* FLATFIELD THE SUMMED, COSMIC RAY REJECTED IMAGE. */
-                        
+
                     if (WF32d (wf3hdr->crj_tmp, wf3hdr->crjfile,
                                 &wf32d_sci_sw, &sciref, printtime, asn->verbose))
                         return (status);
-                    
+
                     printf("\n**** wf3hdr->sci_basic_cte is %i *****\n\n",wf3hdr->sci_basic_cte);
-                    
+
                     if (wf3hdr->sci_basic_cte == PERFORM){
                         /* Flatfield the summed, cosmic ray rejected CTE image. */
                         if (WF32d (wf3hdr->crc_tmp, wf3hdr->crcfile,
                                     &wf32d_sci_sw, &sciref, printtime, asn->verbose))
                             return (status);
                     }
-               
+
                 } else if ( wf3hdr->sci_crcorr == PERFORM){
 
                     if (wf3hdr->sci_basic_cte == PERFORM) {
                         /* REMEMBER CR-COMBINED IMAGE AS FINAL OUTPUT NAME,
                          ** SINCE WF32D WAS NOT RUN. */
                         if (CopyFFile (wf3hdr->crc_tmp, wf3hdr->crcfile))
-                            return (status);                            
-                    } 
-                    
-                    if (CopyFFile (wf3hdr->crj_tmp, wf3hdr->crjfile)) 
-                        return (status);                    
+                            return (status);
+                    }
+
+                    if (CopyFFile (wf3hdr->crj_tmp, wf3hdr->crjfile))
+                        return (status);
                 }
-                
+
                 /* REMEMBER WHAT CRC_TMP FILES TO DELETE */
                 if (wf3hdr->sci_basic_cte == PERFORM) {
                     strcpy (asn->product[prod].subprod[posid].crc_tmp,
                         wf3hdr->crc_tmp);
                 }
-                        
+
                 /* REMEMBER WHAT CRJ_TMP FILES TO DELETE */
                 strcpy (asn->product[prod].subprod[posid].crj_tmp,   wf3hdr->crj_tmp);
-                
+
                 trlmessage("Starting EXPSCORR loops...");
-                
+
                 /* IF EXPSCCORR = PERFORM, FINISH PROCESSING INDIVIDUAL EXPOSURES*/
                 if (sci_sw.expscorr == PERFORM) {
 
@@ -583,16 +583,16 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
 
                         if (wf3hdr->sci_basic_2d == PERFORM){
                             SetTrlPrefaceMode(YES);
-                                    
+
                             /* RESET SWITCHES*/
                             ResetCCDSw (&wf3ccd_sci_sw, &wf32d_sci_sw);
-                            
+
                             /* Basic 2-D processing (flat field, etc). */
                             if (WF32d (wf3hdr->blv_tmp, wf3hdr->fltfile,
                                         &wf32d_sci_sw, &sciref, printtime,
                                         asn->verbose))
                                 return (status);
-                            
+
                             if (wf3hdr->sci_basic_cte == PERFORM){
                                 if (WF32d (wf3hdr->blc_tmp, wf3hdr->flcfile,
                                         &wf32d_sci_sw, &sciref, printtime,
@@ -606,7 +606,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                             if (CopyFFile (wf3hdr->blv_tmp,
                                         wf3hdr->fltfile))
                                 return (status);
-                        
+
                             if (wf3hdr->sci_basic_cte == PERFORM){
                                 if (CopyFFile (wf3hdr->blc_tmp,
                                         wf3hdr->flcfile))
@@ -623,7 +623,7 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                     for (expid=1; expid <= asn->spmems[posid]; expid++) {
                         remove (asn->product[prod].subprod[posid].exp[expid].blv_tmp);
                     }
-                }                
+                }
 
                 if (wf3hdr->sci_basic_cte == PERFORM) {
                     /* Delete intermediate files */
@@ -632,9 +632,9 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
                             remove (asn->product[prod].subprod[posid].exp[expid].blc_tmp);
                             remove (asn->product[prod].subprod[posid].exp[expid].rac_tmp);
                         }
-                    }    
+                    }
                  }
-             
+
              } /* End of CRCORR/RPTCORR processing*/
 
         }  /* End of processing for SINGLE/PARTIAL product, END POSID */
@@ -661,4 +661,3 @@ int ProcessCCD (AsnInfo *asn, WF3Info *wf3hdr, int *save_tmp, int printtime, int
     FreeRefFile (&sciref);
     return (status);
 }
-

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -1,4 +1,4 @@
 /* This string is written to the output primary header as CAL_VER. */
 
-# define WF3_CAL_VER "3.4(20-Sep-2016)"
+# define WF3_CAL_VER "3.4(26-Sep-2016)"
 # define WF3_CAL_VER_NUM "3.4"


### PR DESCRIPTION
does not effect cte results, just memory cleanup which reared it's ugly head  in nightlys