### PR TITLE
[WIP] Enable BLEVCORR for new polarizer/ramp format

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,4 @@
+ 19-Oct-2016:  CALACS 8.3.5 BLEVCORR modified to process new POL/RAMP.
  07-Jul-2016:  CALACS 8.3.4 BLEVCORR modified to process new 2K subarrays.
  27-Jul-2015:  CALACS 8.3.3 ACSREJ can now process input list of any length.
  02-Mar-2015:  CALACS 8.3.2 ACSREJ can now process longer input list.

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,7 @@
+### 19-Oct-2016 - PLL -- Version 8.3.5
+    BLEVCORR modified to correctly process polarizer and ramp subarrays using
+    new subarray format.
+
 ### 07-Jul-2016 - PLL -- Version 8.3.4
     BLEVCORR modified to correctly process new subarrays added by FSW change in
     May 2016.

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,6 @@
+Update for version 8.3.5 - 19-Oct-16 (PLL)
+    acsccd/findover.c
+
 Update for version 8.3.4 - 07-Jul-16 (PLL)
     acsccd/findover.c
 

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -1,6 +1,6 @@
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "8.3.4 (07-Jul-2016)"
-#define ACS_CAL_VER_NUM "8.3.4"
+#define ACS_CAL_VER "8.3.5 (19-Oct-2016)"
+#define ACS_CAL_VER_NUM "8.3.5"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
**DO NOT MERGE** (Pending discussions with ACS Team.)

Expand virtual overscan calculations to all subarrays. Need new OSCNTAB for old subarrays without virtual overscan for this to work.

Fixes #19.