### PR TITLE
BLEVCOR to use new OSCNTAB (APPROVED)

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,5 @@
+ 22-Nov-2016:  CALACS 9.0.0 BLEVCORR now uses new OSCNTAB that correctly
+                            process all subarrays.
  21-Oct-2016:  CALACS 8.3.5 BLEVCORR can now process polarizer and ramp
                             subarrays using new readout format.
  07-Jul-2016:  CALACS 8.3.4 BLEVCORR modified to process new 2K subarrays.

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,7 @@
+### 22-Nov-2016 - PLL -- Version 9.0.0
+    BLEVCORR modified to correctly process all subarrays by using new OSCNTAB
+    that correctly define overscans for all WFC and HRC apertures.
+
 ### 21-Oct-2016 - PLL -- Version 8.3.5
     BLEVCORR modified to correctly process polarizer and ramp subarrays that
     use new readout format added by FSW change since Oct 2016.

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,7 @@
+Update for version 9.0.0 - 22-Nov-16 (PLL)
+    acsccd/findover.c
+    acsccd/doblev.c
+
 Update for version 8.3.5 - 21-Oct-16 (PLL)
     acsccd/findover.c
 

--- a/pkg/acs/calacs/acsccd/doblev.c
+++ b/pkg/acs/calacs/acsccd/doblev.c
@@ -195,7 +195,7 @@ int doBlev (ACSInfo *acs, SingleGroup *x, int chip, float *meanblev,
 
     /* Requirement: at least 1 section should be specified!	 */
     /* If both bias sections are specified,... */
-    if (acs->biassecta[1] >= 0 && acs->biassectb[1] >= 0) {
+    if (acs->biassecta[1] > 0 && acs->biassectb[1] > 0) {
       /* select section nearest the amp based on bias_amp */
       biassect[0] = (bias_ampx == 0) ? acs->biassecta[0] : acs->biassectb[0];
       biassect[1] = (bias_ampx == 0) ? acs->biassecta[1] : acs->biassectb[1];
@@ -295,8 +295,7 @@ int doBlev (ACSInfo *acs, SingleGroup *x, int chip, float *meanblev,
           deval = 0;
         }
         di = di + 1.0;
-        Pix (x->sci.data,i,j) =
-        Pix (x->sci.data,i,j) - biaslevel - deval;
+        Pix (x->sci.data,i,j) = Pix (x->sci.data,i,j) - biaslevel - deval;
       }
     }
     acs->blev[amp_indx] = sumbias / (double)sizey;

--- a/pkg/acs/calacs/acsccd/findover.c
+++ b/pkg/acs/calacs/acsccd/findover.c
@@ -193,16 +193,34 @@ int FindOverscan (ACSInfo *acs, int nx, int ny, int *overscan) {
         }
     }
 
-    if (foundit == NO) {
-        status = ROW_NOT_FOUND;
-        sprintf(MsgText, "Could not find appropriate row from OSCNTAB. ");
-        trlwarn(MsgText);
-    }
 
     if(CloseOverTab (&tabinfo))
         return(status);
 
-    if (acs->verbose == YES) {
+    if (foundit == NO) {
+        /* Error message is commented so that if no row found
+           (e.g., for user defined subarrays), simply skip BLEVCORR
+           and proceed to next step. */
+        /*status = ROW_NOT_FOUND;*/
+
+        /* Comment these init out if error message is enabled above. */
+        acs->trimx[0] = 0;
+        acs->trimx[1] = 0;
+        acs->trimy[0] = 0;
+        acs->trimy[1] = 0;
+        acs->vx[0] = 0;
+        acs->vx[1] = 0;
+        acs->vy[0] = 0;
+        acs->vy[1] = 0;
+        acs->biassecta[0] = 0;
+        acs->biassecta[1] = 0;
+        acs->biassectb[0] = 0;
+        acs->biassectb[1] = 0;
+
+        sprintf(MsgText, "Could not find appropriate row from OSCNTAB. ");
+        trlwarn(MsgText);
+    }
+    else if (acs->verbose == YES) {
         sprintf(MsgText, "Found trim values of: x(%d,%d) y(%d,%d)",
                 acs->trimx[0], acs->trimx[1], acs->trimy[0], acs->trimy[1]);
         trlmessage(MsgText);

--- a/pkg/acs/calacs/acsccd/findover.c
+++ b/pkg/acs/calacs/acsccd/findover.c
@@ -70,7 +70,7 @@ static int CloseOverTab (TblInfo *);
         |
         |
         v
-    (VX1,VX2)     (VX2,VY2)
+    (VX1,VY1)     (VX2,VY2)
   A       /         \     B
     -----/-----------+---
    |   |/     |      |   | } TRIMY2
@@ -125,6 +125,9 @@ static int CloseOverTab (TblInfo *);
                            subarrays added by FSW change in May 2016.
    2016-10-21 P. L. Lim    Expand 2016-07-07 logic to polarizer and ramp
                            subarrays.
+   2016-11-22 P. L. Lim    Use fullframe logic for everything. New OSCNTAB is
+                           needed for all WFC and HRC exposures as this is not
+                           backward compatible.
 */
 int FindOverscan (ACSInfo *acs, int nx, int ny, int *overscan) {
     /* arguments:
@@ -138,13 +141,6 @@ int FindOverscan (ACSInfo *acs, int nx, int ny, int *overscan) {
     TblInfo tabinfo;
     TblRow tabrow;
     int foundit;
-    int is_newsub;
-    const double fsw_change_mjd = 57662.0;  /* 2016-10-01 */
-
-    int cx0, cx1, tx1, tx2;
-    int cy0, cy1, ty1, ty2;
-    int full_nx;
-    int full_ny;
 
     int SameInt (int, int);
     int SameString (char *, char *);
@@ -157,7 +153,6 @@ int FindOverscan (ACSInfo *acs, int nx, int ny, int *overscan) {
        binx, and biny, and get info from the matching row. */
 
     foundit = NO;
-    is_newsub = NO;
     *overscan = NO;
 
     for (row = 1; row <= tabinfo.nrows; row++) {
@@ -170,158 +165,29 @@ int FindOverscan (ACSInfo *acs, int nx, int ny, int *overscan) {
         if (SameString (tabrow.ccdamp, acs->ccdamp) &&
                 SameInt (tabrow.chip, acs->chip) &&
                 SameInt (tabrow.bin[0], acs->bin[0]) &&
-                SameInt (tabrow.bin[1], acs->bin[1])) {
+                SameInt (tabrow.bin[1], acs->bin[1]) &&
+                SameInt (tabrow.nx, nx) &&
+                SameInt (tabrow.ny, ny)) {
 
             foundit = YES;
             *overscan = YES;
 
-            /* We are working with a subarray.
-               There is never any virtual overscan EXCEPT for new subarrays
-               added by FSW change in May 2016 and polarizer/ramp after
-               Oct 2016.
-
-               NOTE: In the future, all overscan info should be properly
-               defined within OSCNTAB for all apertures for both WFC and HRC.
-               When that happens, only keep the fullframe logic below to be
-               used for both fullframe and subarrays and discard all these
-               special subarray calculations. This change is not backward
-               compatible and will require new OSCNTAB to be used for all
-               WFC and HRC exposures ever taken.
-            */
-            if (acs->subarray == YES) {
-                if (SameString(acs->aperture, "WFC1A-512") ||
-                    SameString(acs->aperture, "WFC1A-1K") ||
-                    SameString(acs->aperture, "WFC1A-2K") ||
-                    SameString(acs->aperture, "WFC1B-512") ||
-                    SameString(acs->aperture, "WFC1B-1K") ||
-                    SameString(acs->aperture, "WFC1B-2K") ||
-                    SameString(acs->aperture, "WFC2C-512") ||
-                    SameString(acs->aperture, "WFC2C-1K") ||
-                    SameString(acs->aperture, "WFC2C-2K") ||
-                    SameString(acs->aperture, "WFC2D-512") ||
-                    SameString(acs->aperture, "WFC2D-1K") ||
-                    SameString(acs->aperture, "WFC2D-2K") ||
-                    (SameString(acs->aperture, "WFC1-POL0V") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-POL60V") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-POL120V") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-POL0UV") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-POL60UV") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-POL120UV") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-IRAMPQ") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC1-MRAMPQ") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC2-MRAMPQ") &&
-                     (acs->expstart >= fsw_change_mjd)) ||
-                    (SameString(acs->aperture, "WFC2-ORAMPQ") &&
-                     (acs->expstart >= fsw_change_mjd))) {
-                    is_newsub = YES;
-                } else {
-                    acs->trimy[0] = 0;
-                    acs->trimy[1] = 0;
-                }
-
-                acs->vx[0] = 0;
-                acs->vx[1] = 0;
-                acs->vy[0] = 0;
-                acs->vy[1] = 0;
-
-                /* Virtual overscan processing is similar to physical
-                   overscan processing below. */
-                if (is_newsub == YES) {
-                    /* Determine whether the subarray extends into the
-                       virtual overscan regions on either side of the chip */
-                    ty1 = (int)(ny - acs->offsety);
-                    cy1 = tabrow.ny - tabrow.trimy[1] - tabrow.trimy[0];
-                    cy0 = (int)(tabrow.trimy[0] - acs->offsety);
-
-                    /* Subarray starts in the first overscan region... */
-                    if (acs->offsety > 0) {
-                        acs->trimy[0] = (acs->offsety < tabrow.trimy[0]) ?
-                            acs->offsety : tabrow.trimy[0];
-                        /* Check to see if it extends into second overscan
-                           region. */
-                        full_ny = tabrow.ny - (tabrow.trimy[0] +
-                                               tabrow.trimy[1]);
-                        ty2 = (int)(ny - acs->trimy[0]) - full_ny;
-                        acs->trimy[1] = (ty2 < 0) ? 0 : ty2;
-
-                    /* Subarray overlaps second overscan region */
-                    } else if ( ty1 > cy1 && ty1 <= tabrow.ny) {
-                        acs->trimy[0] = 0;
-                        acs->trimy[1] = ty1 - cy1;
-
-                    /* Subarray does not have virtual overscan */
-                    } else {
-                        acs->trimy[0] = 0;
-                        acs->trimy[1] = 0;
-                    }
-                }
-
-                /* Determine whether the subarray extends into the
-                   physical overscan regions on either side of the chip */
-                tx1 = (int)(nx - acs->offsetx);
-                cx1 = tabrow.nx - tabrow.trimx[1] - tabrow.trimx[0];
-                cx0 = (int)(tabrow.trimx[0] - acs->offsetx);
-
-                /* Subarray starts in the first overscan region... */
-                if (acs->offsetx > 0) {
-                    acs->trimx[0] = (acs->offsetx < tabrow.trimx[0]) ?
-                        acs->offsetx : tabrow.trimx[0];
-                    /* Check to see if it extends into second overscan region.
-                       Fixed 24 July 2001 WJH. */
-                    full_nx = tabrow.nx - (tabrow.trimx[0] + tabrow.trimx[1]);
-                    tx2 = (int)(nx - acs->trimx[0]) - full_nx;
-                    acs->trimx[1] = (tx2 < 0) ? 0 : tx2;
-                    acs->biassecta[0] = (tabrow.biassecta[0] - 1 - cx0 > 0) ?
-                        (tabrow.biassecta[0] - 1 - cx0) : 0;
-                    acs->biassecta[1] = tabrow.biassecta[1] - 1 - cx0;
-                    acs->biassectb[0] = 0;
-                    acs->biassectb[1] = 0;
-
-                /* ... then the subarray overlaps biassectb... */
-                } else if ( tx1 > cx1 && tx1 <= tabrow.nx) {
-                    acs->trimx[0] = 0;
-                    acs->trimx[1] = tx1 - cx1;
-                    acs->biassecta[0] = 0;
-                    acs->biassecta[1] = 0;
-                    acs->biassectb[0] = nx - (tx1 - cx1);
-                    acs->biassectb[1] = nx - 1;
-
-                /* Subarray doesn't overlap either physical overscan region */
-                } else {
-                    acs->trimx[0] = 0;
-                    acs->trimx[1] = 0;
-                    acs->biassecta[0] = 0;
-                    acs->biassecta[1] = 0;
-                    acs->biassectb[0] = 0;
-                    acs->biassectb[1] = 0;
-                    *overscan = NO;
-                }
-
-            /* We are working with a full chip image... */
-            } else {
-                acs->trimx[0] = tabrow.trimx[0];
-                acs->trimx[1] = tabrow.trimx[1];
-                acs->trimy[0] = tabrow.trimy[0];
-                acs->trimy[1] = tabrow.trimy[1];
-                /* Subtract one from table values to
-                   conform to C array indexing... */
-                acs->vx[0] = tabrow.vx[0]-1;
-                acs->vx[1] = tabrow.vx[1]-1;
-                acs->vy[0] = tabrow.vy[0]-1;
-                acs->vy[1] = tabrow.vy[1]-1;
-                acs->biassecta[0] = tabrow.biassecta[0] - 1;
-                acs->biassecta[1] = tabrow.biassecta[1] - 1;
-                acs->biassectb[0] = tabrow.biassectb[0] - 1;
-                acs->biassectb[1] = tabrow.biassectb[1] - 1;
-            }
+            /* Overscan info now completely defined in OSCNTAB.
+               Everything now uses fullframe logic. */
+            acs->trimx[0] = tabrow.trimx[0];
+            acs->trimx[1] = tabrow.trimx[1];
+            acs->trimy[0] = tabrow.trimy[0];
+            acs->trimy[1] = tabrow.trimy[1];
+            /* Subtract one from table values to
+               conform to C array indexing... */
+            acs->vx[0] = tabrow.vx[0]-1;
+            acs->vx[1] = tabrow.vx[1]-1;
+            acs->vy[0] = tabrow.vy[0]-1;
+            acs->vy[1] = tabrow.vy[1]-1;
+            acs->biassecta[0] = tabrow.biassecta[0] - 1;
+            acs->biassecta[1] = tabrow.biassecta[1] - 1;
+            acs->biassectb[0] = tabrow.biassectb[0] - 1;
+            acs->biassectb[1] = tabrow.biassectb[1] - 1;
 
             break;
         }

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -1,5 +1,5 @@
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "9.0.0 (22-Nov-2016)"
+#define ACS_CAL_VER "9.0.0 (15-Dec-2016)"
 #define ACS_CAL_VER_NUM "9.0.0"
 
 /* name and version number of the CTE correction algorithm */

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -1,6 +1,6 @@
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "8.3.5 (21-Oct-2016)"
-#define ACS_CAL_VER_NUM "8.3.5"
+#define ACS_CAL_VER "9.0.0 (22-Nov-2016)"
+#define ACS_CAL_VER_NUM "9.0.0"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
**Approved by ACS Team on Feb 28, 2017.**

**IMPORTANT: This must go together with new OSCNTAB delivery to CRDS!**

This is the purist way to address true overscan subtraction of subarrays. Supersedes #21 and #22. Fixes #23.

**Instructions to install this branch for testing**

1. Create a directory to store the source codes and `cd` into it.

2. `git clone https://github.com/pllim/hstcal.git ./` (this makes a copy of my HSTCAL fork on your disk)

3. `git fetch origin new-oscntab`

4. `git checkout origin/new-oscntab -b new-oscntab` (if this does not work, your `git` version is too old, so you will need to update `git` first or install a newer version using `conda install git`)

5. `git status` (if this shows that you are now in `new-oscntab` branch, then proceed)

6. `./waf configure --debug --prefix=$CONDA_PREFIX` (this only works if you use `conda env`)

7. `./waf build` (make sure there is no error)

8. `./waf install`

9. Now `cd` into your working directory with data files.

10. `calacs.e --version` (only proceed if this says version 9 and is dated Dec 15, 2016)

11. `calacs.e your_file_name -v` (`-v` gives verbose output in trailer file and screen, which is useful for debugging)

**Instructions to grab updates from existing branch checkout**

1. `cd` into source checkout directory.

2. `git checkout new-oscntab` to switch to this branch, if not already on it (you can check with `git status`)

3. `git fetch origin new-oscntab` (picks up updates)

4. `git rebase origin/new-oscntab` (applies the updates locally)

5. Continue from Step 8 above.

**Todo after merge**

- [ ] All the existing RAW files for WFC and HRC in regression test suite need to use the new OSCNTAB.