### PR TITLE
Remove non-existent --yes option from install target

### DIFF
--- a/configure
+++ b/configure
@@ -88,7 +88,7 @@ all-progress:
 	$WAF -p build
 
 install:
-	$WAF install --yes;
+	$WAF install
 
 uninstall:
 	$WAF uninstall


### PR DESCRIPTION
Fixes:

```bash
$ make install
[...]
waf: error: no such option: --yes
make: *** [install] Error 2
```