### PR TITLE
Platform check

### DIFF
--- a/wscript
+++ b/wscript
@@ -246,7 +246,6 @@ def configure(conf):
     # cfitsio/wscript
     conf.recurse('cfitsio')
 
-
     # check whether the compiler supports -02 and add it to CFLAGS if it does
     if conf.options.debug:
         if conf.check_cc(cflags='-g'):

--- a/wscript
+++ b/wscript
@@ -10,7 +10,6 @@ from waflib import Scripting
 from waflib import Task
 from waflib import Utils
 from waflib import TaskGen
-from waflib import Tools
 
 APPNAME = 'hstcal'
 VERSION = '0.1.1'
@@ -168,7 +167,6 @@ def _determine_architecture(conf):
                 if arg == arch:
                     return arch
 
-
     conf.start_msg('Checking architecture')
     if platform.architecture()[0] == '64bit':
         arch_mode = '-m64'
@@ -184,13 +182,15 @@ def _determine_architecture(conf):
     conf.end_msg(get_forced_arch('LDFLAGS'))
 
     if get_forced_arch('CFLAGS') is None:
-        if ('CFLAGS' not in conf.env) or \
-            ('CFLAGS' in conf.env and arch_modes not in conf.env['CFLAGS']):
+        if (('CFLAGS' not in conf.env) or
+                ('CFLAGS' in conf.env and
+                    arch_modes not in conf.env['CFLAGS'])):
             conf.env.append_value('CFLAGS', arch_mode)
 
     if get_forced_arch('LDFLAGS') is None:
-        if ('LDFLAGS' not in conf.env) or \
-            ('LDFLAGS' in conf.env and arch_modes not in conf.env['LDFLAGS']):
+        if (('LDFLAGS' not in conf.env) or
+                ('LDFLAGS' in conf.env and
+                    arch_modes not in conf.env['LDFLAGS'])):
             conf.env.append_value('LDFLAGS', arch_mode)
 
 def configure(conf):


### PR DESCRIPTION
Removes the need to maintain a list of valid operating system versions, and their cutesy names over time. Instead, now we check whether the host operating system (OS X) is greater than or equal to 10.5.0. If not, the configuration step will fail out to the shell (i.e. exit 1). The probability of external users compiling `hstcal` on 10.4.x "Tiger" is rather low anyway at this point.

Due to subtle ambiguities we have experienced recently in the Conda world I added a visual dump for each compiler's `FLAGS` variable. This allows us to immediately determine whether C/FC/LDFLAGS were set correctly at compile-time or not.

The configuration order has changed slightly as well. CFITSIO is now configured after the global CFLAGS are defined. This allows the hidden CFITSIO `./configure` call to assimilate the FLAGS it needs to match the parent program's linkage. After moving it to the bottom I stopped receiving linker errors (I used to have to set `CFLAGS=-m64` and `LDFLAGS=-m64` manually as a workaround).

### Previous Order

- C compiler check
- Fortran compiler check
- Check OSX version
- Determine sizeof `int`
- Setup OpenMP
- Configure CFITSIO
- Setup FLAGS

### New Order

- C compiler check
- Fortran compiler check
- Check OSX version
- Setup OpenMP
- Determine sizeof `int`
- Setup FLAGS
- Dump FLAGS
- Configure CFITSIO
