### PR TITLE
CALACS to have new SINKCORR in ACSCCD (APPROVED)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .waf*
 bin.*
 build.*
+Makefile

--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,4 @@
+ 21-Feb-2017:  CALACS 9.1.0 New SINKCORR step added in ACSCCD for WFC.
  22-Nov-2016:  CALACS 9.0.0 BLEVCORR now uses new OSCNTAB that correctly
                             process all subarrays.
  21-Oct-2016:  CALACS 8.3.5 BLEVCORR can now process polarizer and ramp

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,6 @@
+### 21-Feb-2017 - PLL -- Version 9.1.0
+    New SINKCORR step is added to ACSCCD for WFC.
+
 ### 22-Nov-2016 - PLL -- Version 9.0.0
     BLEVCORR modified to correctly process all subarrays by using new OSCNTAB
     that correctly define overscans for all WFC and HRC apertures.

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,10 @@
+Update for version 9.1.0 - 21-Feb-17 (PLL)
+    acsccd/doccd.c
+    acsccd/dosink.c
+    acsccd/getacsflag.c
+    acsccd/getccdsw.c
+    include/acsinfo.h
+
 Update for version 9.0.0 - 22-Nov-16 (PLL)
     acsccd/findover.c
     acsccd/doblev.c

--- a/pkg/acs/calacs/acsccd/dosink.c
+++ b/pkg/acs/calacs/acsccd/dosink.c
@@ -46,7 +46,7 @@ int SinkDetect(ACSInfo *acs, SingleGroup *x) {
     int rx, ry;      /* for binning sink image down to size of x */
     int x0, y0;      /* offsets of sci image */
     int same_size;   /* true if no binning of ref image required */
-    float cur_sinkpix;
+    float cur_sinkpix, cur_sci;
     FloatHdrData sinkref;  /* array to store sink image */
 
     int FindLineHdr(Hdr *, Hdr *, int, int, int *, int *, int *, int *, int *);
@@ -63,6 +63,7 @@ int SinkDetect(ACSInfo *acs, SingleGroup *x) {
     same_size = 1;
     jdone = 0;
     n = 0;
+    cur_sci = 0.0;
 
     /* Compute correct extension version number to extract from
        reference image to correspond to CHIP in science data. */
@@ -131,6 +132,8 @@ int SinkDetect(ACSInfo *acs, SingleGroup *x) {
             if (cur_sinkpix < 0) {
                 if (keep_going[i] == 0)
                     keep_going[i] = 1;
+                if (cur_sinkpix < -1)  /* The actual sink pixel */
+                    cur_sci = Pix(x->sci.data, i, j);
                 dqval = SINKPIXEL | DQPix(x->dq.data, i, j);
                 DQSetPix(x->dq.data, i, j, dqval);
                 n++;
@@ -139,8 +142,8 @@ int SinkDetect(ACSInfo *acs, SingleGroup *x) {
             } else if (cur_sinkpix > 0) {
                 /* Tail is still continuous. */
                 if (keep_going[i] == 1) {
-                    /* This upstream pixel > SCI, flag it. */
-                    if (cur_sinkpix > Pix(x->sci.data, i, j)) {
+                    /* This upstream pixel > SCI at sink pixel, flag it. */
+                    if (cur_sinkpix > cur_sci) {
                         dqval = SINKPIXEL | DQPix(x->dq.data, i, j);
                         DQSetPix(x->dq.data, i, j, dqval);
                         n++;

--- a/pkg/acs/calacs/acsccd/dosink.c
+++ b/pkg/acs/calacs/acsccd/dosink.c
@@ -1,0 +1,248 @@
+/* ACS -- Detect and mark SINK pixels in the DQ array. */
+# include <stdio.h>
+
+# include "hstio.h"
+# include "acs.h"
+# include "acsinfo.h"
+# include "acserr.h"
+
+/* local mask values */
+# define SINKPIXEL (short)1024
+
+static int DetSinkChip (char *, int, int *);
+
+
+/* See Section 6 of ACS ISR by Ryon & Grogin (2017).
+   SINKCORR is based on WFC3/UVIS but not identical.
+   We do not mark flags by dates nor use crazy RAZ format.
+   This should be the last step in ACSCDD, before ACSCTE.
+   Also see https://github.com/spacetelescope/hstcal/issues/44
+
+   Relevant info from Section 6:
+
+   * Pix value from SNKCFILE = sink pixel depth from INS calib
+   * Downstream pixel (-1, closer to amp) = -1.0 (optional)
+   * Upstream pixel (+1) = 999.0 (always)
+   * Upstream pixels (+2 to +12) depends on sink pixel depth.
+
+   Algorithm from Section 6 along a column:
+
+   1. Look for pixel < -1 in SNKCFILE, set DQ to 1024.
+   2. If downstream (-1) pixel == -1, set DQ to 1024.
+   3. If upstream (+1 to +n) pixel > SCI, set DQ to 1024 until
+      pixel <= SCI or pixel == 0 or pixel == another sink pixel.
+*/
+int SinkDetect(ACSInfo *acs, SingleGroup *x) {
+    /* arguments:
+       ACSInfo *acs       i: calibration switches, etc
+       SingleGroup *x    io: image to be calibrated; written to in-place
+    */
+    extern int status;
+
+    int i, j, jdone, jend, jstep, n;  /* counters */
+    short *keep_going, dqval;
+    int extver;      /* get this imset from sink image */
+    int dimx, refx, dimy;
+    int rx, ry;      /* for binning sink image down to size of x */
+    int x0, y0;      /* offsets of sci image */
+    int same_size;   /* true if no binning of ref image required */
+    float cur_sinkpix;
+    FloatHdrData sinkref;  /* array to store sink image */
+
+    int FindLineHdr(Hdr *, Hdr *, int, int, int *, int *, int *, int *, int *);
+
+    if (acs->sinkcorr != PERFORM)
+        return (status);
+
+    /* Initialize local variables */
+    extver = 1;
+    rx = 1;
+    ry = 1;
+    x0 = 0;
+    y0 = 0;
+    same_size = 1;
+    jdone = 0;
+    n = 0;
+
+    /* Compute correct extension version number to extract from
+       reference image to correspond to CHIP in science data. */
+    if (DetSinkChip(acs->sink.name, acs->chip, &extver))
+        return (status);
+
+    /* Get sink reference image. */
+    initFloatHdrData(&sinkref);
+    getFloatHD(acs->sink.name, "SCI", extver, &sinkref);
+
+    /* Extract relevant portion from reference image. */
+    dimx = x->sci.data.tot_nx;
+    dimy = x->sci.data.tot_ny;
+    refx = sinkref.data.tot_nx;
+
+    if (FindLineHdr (&x->sci.hdr, &sinkref.hdr, dimx, refx,
+                     &same_size, &rx, &ry, &x0, &y0))
+        return (status);
+
+    if (acs->verbose) {
+        sprintf(MsgText, "Ratio of (%d,%d) with offset =(%d,%d)",
+                rx, ry, x0, y0);
+        trlmessage(MsgText);
+        if (same_size) {
+            sprintf(MsgText, "SINK image and input are the same size ");
+        } else {
+            sprintf(MsgText, "SINK image and input are NOT the same size ");
+        }
+        trlmessage(MsgText);
+    }
+
+    if ((rx != 1) || (ry != 1)) {
+        trlerror ("(sinkcorr) binned data is not supported.");
+        return (status = INVALID_VALUE);
+    }
+
+    /* Always traverse from sink pixel head to tail. */
+    if (extver == 1) {
+        j = 0;
+        jend = dimy - 1;
+        jstep = 1;
+    } else {  /* extver == 2 */
+        j = dimy - 1;
+        jend = 0;
+        jstep = -1;
+    }
+
+    /* Allocate data array */
+    keep_going = (short *) calloc (dimx, sizeof(short));
+    if (keep_going == NULL) {
+        trlerror ("Couldn't allocate memory for scratch array in SINKCORR.");
+        return (status = OUT_OF_MEMORY);
+    }
+
+    /* Flag sink pixels in input DQ. */
+    while (jdone == 0) {
+        for (i = 0; i < dimx; i++) {
+
+            /* Sink image is always untrimmed fullframe.
+               While, since image at this point is still untrimmed. */
+            cur_sinkpix = Pix(sinkref.data, i + x0, j + y0);
+
+            /* This is either sink or downstream pixel, flag it.
+               It comes with a tail upstream.
+               Does not matter if it sits on another tail. */
+            if (cur_sinkpix < 0) {
+                if (keep_going[i] == 0)
+                    keep_going[i] = 1;
+                dqval = SINKPIXEL | DQPix(x->dq.data, i, j);
+                DQSetPix(x->dq.data, i, j, dqval);
+                n++;
+
+            /* This is upstream pixel. */
+            } else if (cur_sinkpix > 0) {
+                /* Tail is still continuous. */
+                if (keep_going[i] == 1) {
+                    /* This upstream pixel > SCI, flag it. */
+                    if (cur_sinkpix > Pix(x->sci.data, i, j)) {
+                        dqval = SINKPIXEL | DQPix(x->dq.data, i, j);
+                        DQSetPix(x->dq.data, i, j, dqval);
+                        n++;
+                    /* Tail ended, stop flagging. */
+                    } else {
+                        keep_going[i] = 0;
+                    }
+                }
+
+            /* No sink pixel, stop flagging. */
+            } else if (keep_going[i] == 1) {
+                keep_going[i] = 0;
+            }
+        } /* end i loop */
+
+        j += jstep;
+        if (jstep >= 0) {
+            if (j > jend)
+                jdone = 1;
+        } else {
+            if (j < jend)
+                jdone = 1;
+        }
+    } /* end j loop */
+
+    if (acs->verbose) {
+        sprintf(MsgText, "Sink pixels flagged = %d", n);
+        trlmessage(MsgText);
+    }
+
+    free(keep_going);
+    freeFloatHdrData(&sinkref);
+
+    return (status);
+}
+
+
+/* Find the corresponding EXT from SNKCFILE. Adapted from DetCCDChip. */
+static int DetSinkChip (char *fname, int chip, int *extver) {
+    /* parameters:
+       char *fname   i: name of file
+       int chip      i: CHIP ID to be found
+       int nimsets;  i: number of IMSETS in image
+       int *extver   o: extension (IMSET) from file corresponding
+       to input image chip ID
+    */
+    extern int status;
+
+    Hdr scihdr, prihdr;
+    IODescPtr ip;
+    int ccdchip;        /* CHIP id from reference header */
+    int n, foundit;
+    int nextend;
+
+    int GetKeyInt (Hdr *, char *, int, int, int *);
+
+    initHdr (&scihdr);
+    initHdr (&prihdr);
+    *extver = 0;
+    ip = NULL;
+    foundit = NO;
+    ip = openInputImage (fname, "", 0);
+    getHeader (ip, &prihdr);
+    closeImage (ip);
+
+    /* Find out how many extensions there are in this file. */
+    if (GetKeyInt (&prihdr, "NEXTEND", USE_DEFAULT, 1, &nextend))
+        return (status);
+
+    /* Loop over all the extensions in the reference file
+       to search for the extension which corresponds to the desired
+       CCDCHIP id of the exposure. */
+    for (n = 1; n <= nextend ; n++) {
+        ip = openInputImage (fname, "SCI", n);
+
+        getHeader (ip, &scihdr);
+
+        if (ip != NULL)
+            closeImage (ip);
+
+        /* Get CCD-specific parameters. */
+        if (GetKeyInt (&scihdr, "CCDCHIP", USE_DEFAULT, 1, &ccdchip))
+            return (status);
+
+        if (ccdchip == chip) {
+            /* Found it! */
+            *extver = n;
+            foundit = YES;
+            break;
+        } else {
+            /* Check next extension for CHIP id */
+            ccdchip = 0;
+        }
+    }
+
+    freeHdr(&scihdr);
+    freeHdr(&prihdr);
+
+    if (foundit == NO) {
+        sprintf (MsgText, "No Reference Data found for chip %d", chip);
+        trlerror (MsgText);
+        return (status = NO_CHIP_FOUND);
+    }
+    return (status);
+}

--- a/pkg/acs/calacs/acsccd/getccdsw.c
+++ b/pkg/acs/calacs/acsccd/getccdsw.c
@@ -19,6 +19,7 @@ static int GetSw (Hdr *, char *, int *);
  08 Mar 2011 MRD - Added code to read PCTECORR keyword.
  12 Dec 2012 PLL - Moved FLSHCORR to ACS2D.
  12 Aug 2013 PLL - Separated PCTECORR from ACSCCD.
+ 21 Feb 2017 PLL - Added SINKCORR.
  */
 int GetccdSw (ACSInfo *acs, Hdr *phdr) {
 
@@ -32,6 +33,8 @@ int GetccdSw (ACSInfo *acs, Hdr *phdr) {
     if (GetSw (phdr, "BIASCORR", &acs->biascorr))
         return (status);
     if (GetSw (phdr, "BLEVCORR", &acs->blevcorr))
+        return (status);
+    if (GetSw (phdr, "SINKCORR", &acs->sinkcorr))
         return (status);
 
     return (status);

--- a/pkg/acs/calacs/cfiles.log
+++ b/pkg/acs/calacs/cfiles.log
@@ -3,7 +3,7 @@
 ../acs2d/getlintab.c   ../acs2d/getspottab.c   ../acs2d/main2d.c   ../acs2d/photmode.c
 ../acs2d/sanity2d.c  ../acs2d/get2dsw.c
 
-../acsccd/acsccd.c   ../acsccd/blevdrift.c   ../acsccd/blevfit.c
+../acsccd/acsccd.c   ../acsccd/blevdrift.c   ../acsccd/blevfit.c   ../acsccd/dosink.c
 ../acsccd/doatod.c   ../acsccd/dobias.c   ../acsccd/doblev.c   ../acsccd/doblev_v504.c
 ../acsccd/doccd.c   ../acsccd/doflash.c   ../acsccd/findblev.c   ../acsccd/findover.c
 ../acsccd/getacsflag.c   ../acsccd/getccdsw.c   ../acsccd/mainccd.c

--- a/pkg/acs/calacs/include/acsinfo.h
+++ b/pkg/acs/calacs/include/acsinfo.h
@@ -2,12 +2,13 @@
 
     Warren Hack, 1998 June 10:
     Initial ACS version.
-    
-    29-Oct-2001 WJH: Replaced 'ccdbias' with an array 'ccdbias[4]' to
+
+    2001-10-29 WJH: Replaced 'ccdbias' with an array 'ccdbias[4]' to
         be applied for each AMP.  Added 'graph' and 'comp' to
         replace 'phottab' and 'apertab' and removed 'filtcorr'. Simplified
         PhotInfo to only contain a single set of arrays for wave and thru.
-    4-Dec-2001 WJH: Added expstart and expend.
+    2001-12-04 WJH: Added expstart and expend.
+    2017-02-21 PLL: Added SINKCORR varibles.
 */
 
 # define NAMPS  4    /* Maximum number of amps for a single readout */
@@ -83,16 +84,19 @@ typedef struct {
     float flashdur; 	/* duration of post-flash (in seconds) */
     char flashstatus[ACS_CBUF+1];		/* status of post-flash exposure */
 
-    /* calibration flags (switches) for ACSCCD*/
+    /* calibration flags (switches) for ACSCCD */
     int dqicorr;        /* data quality initialization */
     int atodcorr;       /* analog to digital correction */
     int blevcorr;       /* subtract bias from overscan */
     int biascorr;       /* subtract bias image */
     int flashcorr;      /* subtract post-flash image */
     int noisecorr;      /* initialize error array? (yes) */
+    int sinkcorr;       /* flag sink pixels */
+
+    /* calibration flags (switches) for ACSCTE */
     int pctecorr;       /* perform pixel CTE correction */
 
-    /* calibration flags (switches) for ACS2D*/
+    /* calibration flags (switches) for ACS2D */
     int glincorr;       /* global nonlinearity correction */
     int lflgcorr;       /* flag local nonlinearity */
     int darkcorr;       /* subtract dark image */
@@ -105,16 +109,19 @@ typedef struct {
     int photcorr;       /* compute photometry header keyword values */
     int expscorr;       /* calibrate blv_tmp products?  */
 
-    /* calibration images and tables for ACSCCD*/
+    /* calibration images and tables for ACSCCD */
     RefImage bias;      /* bias image */
     RefTab bpix;        /* bad pixel table */
     RefTab ccdpar;      /* CCD parameters table */
     RefTab oscn;        /* Overscan parameters table */
     RefTab atod;        /* analog to digital correction table */
     RefTab spot;        /* Spotflat offset table */
+    RefImage sink;      /* sink pixel image */
+
+    /* calibration images and tables for ACSCTE */
     RefTab pcte;        /* Pixel CTE parameters table */
 
-    /* calibration images and tables for ACS2D*/
+    /* calibration images and tables for ACS2D */
     RefImage dark;      /* dark image */
     RefImage darkcte;   /* cte corrected dark */
     RefImage flash;     /* post-flash image */

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -1,6 +1,6 @@
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "9.0.0 (15-Dec-2016)"
-#define ACS_CAL_VER_NUM "9.0.0"
+#define ACS_CAL_VER "9.1.0 (21-Feb-2017)"
+#define ACS_CAL_VER_NUM "9.1.0"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_CTE_NAME "PixelCTE 2012"

--- a/pkg/acs/calacs/lib/wscript
+++ b/pkg/acs/calacs/lib/wscript
@@ -29,7 +29,7 @@ def build(bld):
 
             ../acsccd/acsccd.c   ../acsccd/blevdrift.c ../acsccd/blevfit.c
             ../acsccd/doatod.c   ../acsccd/dobias.c ../acsccd/doblev.c
-            ../acsccd/doccd.c    ../acsccd/findblev.c
+            ../acsccd/doccd.c    ../acsccd/findblev.c ../acsccd/dosink.c
             ../acsccd/findover.c ../acsccd/getacsflag.c
             ../acsccd/getccdsw.c ../acsccd/blev_funcs_postsm4.c
 


### PR DESCRIPTION
**Approved by Jenna Ryon from ACS Team.**

Fixes #44 

**Instructions to install this branch for testing**

1. Create a directory to store the source codes and `cd` into it.

2. `git clone https://github.com/pllim/hstcal.git ./` (this makes a copy of my HSTCAL fork on your disk)

3. `git fetch origin new-sinkcorr`

4. `git checkout origin/new-sinkcorr -b new-sinkcorr` (if this does not work, your `git` version is too old, so you will need to update `git` first or install a newer version using `conda install git`)

5. `git status` (if this shows that you are now in `new-sinkcorr` branch, then proceed)

6. `./waf configure --debug --prefix=$CONDA_PREFIX` (this only works if you use `conda env`)

7. `./waf build` (make sure there is no error)

8. `./waf install`

9. Now `cd` into your working directory with data files.

10. `calacs.e --version` (only proceed if this says version 9.1.0 and is dated Feb 21, 2017)

11. `calacs.e your_file_name -v` (`-v` gives verbose output in trailer file and screen, which is useful for debugging)

**Instructions to grab updates from existing branch checkout**

1. `cd` into source checkout directory.

2. `git checkout new-sinkcorr` to switch to this branch, if not already on it (you can check with `git status`)

3. `git fetch origin new-sinkcorr` (picks up updates)

4. `git rebase origin/new-sinkcorr` (applies the updates locally)

5. Continue from Step 8 above.

**Todo after merge**

- [ ] Add WFC test data (fullframe and subarray) from Jenna Ryon to regression test suite.
- [x] All the other existing input RAW files for WFC and HRC need to have `SINKCORR = OMIT` in their primary headers.