### PR TITLE
fixes #63, double statement

### DIFF
--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,3 +1,7 @@
+02-Apr-2016 - MLS - Version 3.4.1
+    - Fixed logic brackets in subarray prescan bias call which didn't explicitly do the gain correction in the if loop, see Issue #55
+    - Fixed double statement, see Issue #63
+    
 28-Sep-2016 - MLS - Version 3.4
     - Fixed memory allocation around one more print
 

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,3 +1,7 @@
+### 02-Apr-2016 - MLS - Version 3.4.1
+    - Fixed logic brackets in subarray prescan bias call which didn't explicitly do the gain correction in the if loop, see Issue #55
+    - Fixed double statement, see Issue #63
+    
 ### 28-Sep-2016 - MLS - Version 3.4
     - Fixed memory allocation around one more print
 

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,3 +1,7 @@
+Updates for Version 3.4.1 02-Apr-2017 - MLS
+    - Fixed logic brackets in subarray prescan bias call which didn't explicitly do the gain correction in the if loop, see Issue #55
+    - Fixed double statement, see Issue #63
+
 Updates for Version 3.4 28-Sep-2016 - MLS
     - Fixed memory allocation around one more print
 

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -1,4 +1,4 @@
 /* This string is written to the output primary header as CAL_VER. */
 
-# define WF3_CAL_VER "3.4(28-Sep-2016)"
-# define WF3_CAL_VER_NUM "3.4"
+# define WF3_CAL_VER "3.4.1(02-Apr-2017)"
+# define WF3_CAL_VER_NUM "3.4.1"

--- a/pkg/wfc3/calwf3/wf3cte/wf3cte.c
+++ b/pkg/wfc3/calwf3/wf3cte/wf3cte.c
@@ -365,7 +365,6 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
                 return (status);
 
             start = sci_corner[0] - ref_corner[0];
-            finish = start + subab.sci.data.nx + 2103;
             finish = start + subab.sci.data.nx;
             if ( start >= 25 &&  finish + 60 <= (RAZ_COLS/2) - 25){
                 sprintf(MsgText,"Subarray not taken with physical overscan (%i %i)\nCan't perform CTE correction\n",start,finish);


### PR DESCRIPTION
Removed double statement, probably left over from last testing round. Quick data checks show correct and unchanged results. 