### PR TITLE
Fix CALACS version reporting

### DIFF
--- a/pkg/acs/calacs/calacs/acsmain.c
+++ b/pkg/acs/calacs/calacs/acsmain.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
 	void c_irafinit (int, char **);
 	int CalAcsRun (char *, int, int, int, int, int);
     void WhichError (int);
-    
+
 	/* Initialize status to OK and MsgText to null */
 	status = ACS_OK;
 	MsgText[0] = '\0';
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 	/* Initialize IRAF environment */
 	c_irafinit(argc, argv);
 
-	/* Command line arguments: 
+	/* Command line arguments:
 	**       0. Check for --version option
   **
   **       1. input file name
@@ -47,16 +47,19 @@ int main(int argc, char **argv) {
 	*/
 	for (i = 1;  i < argc;  i++) {
 		if (!(strcmp(argv[i],"--version"))) {
-      printf("%s\n",ACS_CAL_VER);
+      printf("%s\n",ACS_CAL_VER_NUM);
       exit(0);
     }
-    
+
     if (argv[i][0] == '-') {
 		  for (j = 1;  argv[i][j] != '\0';  j++) {
 		    if (argv[i][j] == 't') {
           printtime = YES;
 		    } else if (argv[i][j] == 's') {
           save_tmp = YES;
+		    } else if (argv[i][j] == 'r') {
+	  printf ("Current version: %s\n", ACS_CAL_VER);
+	  exit(0);
 		    } else if (argv[i][j] == 'v') {
           verbose = YES;
 		    } else if (argv[i][j] == 'd') {
@@ -76,10 +79,10 @@ int main(int argc, char **argv) {
 		too_many = YES;
 	    }
 	}
-	
+
 	if (input[0] == '\0' || too_many) {
         printf ("CALACS Version %s\n",ACS_CAL_VER_NUM);
-	    printf ("syntax:  calacs.e [-t] [-s] [-v] [-q] [-1] input \n");
+	    printf ("syntax:  calacs.e [-t] [-s] [-v] [-q] [-r] [-1] input \n");
 	    exit (ERROR_RETURN);
 	}
 
@@ -88,17 +91,17 @@ int main(int argc, char **argv) {
 
 	/* Copy command-line value for QUIET to structure */
 	SetTrlQuietMode(quiet);
-	
+
 	/* Call the CALACS main program */
 	if (CalAcsRun (input, printtime, save_tmp, verbose, debug, onecpu)) {
 
         if (status == NOTHING_TO_DO){
-            /* If there is just nothing to do, 
+            /* If there is just nothing to do,
                 as for ACQ images, just quit...     WJH 27Apr1999 */
             status = 0;
 	        sprintf (MsgText, "CALACS did NOT process %s", input);
 	        trlmessage (MsgText);
-            exit(0); 
+            exit(0);
         } else {
 	        /* Error during processing */
 	        sprintf (MsgText, "CALACS processing NOT completed for %s", input);
@@ -115,7 +118,7 @@ int main(int argc, char **argv) {
 	trlmessage (MsgText);
 
 	CloseTrlBuf ();
-	
+
 	/* Exit the program */
 	exit(0);
 }


### PR DESCRIPTION
`calacs.e --version` now only reports the number. Added `calacs.e -r` to report version number and date.

Fix #75 

c/c @jamienoss 