### PR TITLE
wf3cte unessacary re-computation of cte correction due to over-subtra…

### DIFF
--- a/pkg/wfc3/calwf3/wf3cte/wf3cte.c
+++ b/pkg/wfc3/calwf3/wf3cte/wf3cte.c
@@ -1263,8 +1263,8 @@ int inverse_cte_blur(SingleGroup *rsz, SingleGroup *rsc, SingleGroup *fff, CTEPa
 
         if (totflux >= 1) {/*make sure the column has flux in it*/
             NREDO=0; /*START OUT NOT NEEDING TO MITIGATE CRS*/
-            REDO=0; /*FALSE*/
             do { /*replacing goto 9999*/
+                REDO=0; /*FALSE*/
                 /*STARTING WITH THE OBSERVED IMAGE AS MODEL, ADOPT THE SCALING FOR THIS COLUMN*/
                 for (j=0; j<RAZ_ROWS; j++){
                     pix_modl[j] =  Pix(rz.sci.data,i,j);


### PR DESCRIPTION
…cted tails

As is, the code checks whether the cte correction has over-subtracted a tail, if so it downscales the cte scaling and re-runs the correction for that given column, however, it is possible for it to re-run the exact same column correction 4 times - 'exact' because it's possible for the conditional checking for the tails to not be reentered (i.e. the first re-run was enough) and thus never downgrading the cte scaling on subsequent re-runs, thus nothing having changed for the other 3 re-runs.

It could be possible that the first re-run was sufficient and as such should prevent further re-computations of the columns correction.

Fixes #46 

Signed-off-by: James Noss <jnoss@stsci.edu>