### PR TITLE
Infrastructure changes, inc. hstio

### DIFF
--- a/hstio/hstio.c
+++ b/hstio/hstio.c
@@ -110,9 +110,10 @@
 # include <time.h>
 # include <unistd.h>
 # include <assert.h>
-#include <stdlib.h>
+# include <stdlib.h>
 
 # include "hstio.h"
+# include "hstcalerr.h"
 
 /*
 ** String defined to allow determination of the HSTIO library version
@@ -405,6 +406,7 @@ void initFloatData(FloatTwoDArray *x) {
         x->tot_ny = 0;
         x->nx = 0;
         x->ny = 0;
+        x->storageOrder = ROWMAJOR;
         x->data = NULL;
 # if defined (DEBUG)
         printf("initFloatData: %x %x %d\n",
@@ -412,16 +414,23 @@ void initFloatData(FloatTwoDArray *x) {
 # endif
 }
 
-int allocFloatData(FloatTwoDArray *x, int i, int j) {
+int allocFloatData(FloatTwoDArray *x, int i, int j, Bool zeroInitialize) {
+    //WARNING: target (x) must be initialized by caller
 # if defined (DEBUG)
         printf("allocFloatData-1: %x %x %d\n",
                 (int)x,(int)(x->buffer),x->buffer_size);
 # endif
         if (x->buffer == NULL || x->buffer_size != (i * j)) {
             if (x->buffer != NULL)
+            {
                 free(x->buffer);
+                x->buffer = NULL;
+            }
             x->buffer_size = i * j;
-            x->buffer = (float *)calloc(x->buffer_size, sizeof(float));
+            if (zeroInitialize)
+                x->buffer = calloc(x->buffer_size, sizeof(*x->buffer));
+            else
+                x->buffer = malloc(x->buffer_size * sizeof(*x->buffer));
             if (x->buffer == NULL) {
                 initFloatData(x);
                 error(NOMEM,"Allocating SciData");
@@ -441,6 +450,8 @@ int allocFloatData(FloatTwoDArray *x, int i, int j) {
 }
 
 void freeFloatData(FloatTwoDArray *x) {
+        if (!x)
+            return;
 # if defined (DEBUG)
         printf("freeFloatData: %x %x %d\n",
                 (int)x,(int)(x->buffer),x->buffer_size);
@@ -450,6 +461,88 @@ void freeFloatData(FloatTwoDArray *x) {
         initFloatData(x);
 }
 
+int copyFloatData(FloatTwoDArray * target, const FloatTwoDArray * source, enum StorageOrder targetStorageOrder)
+{
+    if (!target || !source)
+        return -1;
+
+    //should this check be raise higher up the call stack also?
+    if (targetStorageOrder != source->storageOrder)
+    {
+        //assumes target initialized
+        if (!target->buffer)
+        {
+            if (allocFloatData(target, source->nx, source->ny, False))
+                return ALLOCATION_PROBLEM; //allocFloatData() initializes before returning
+        }
+        return swapFloatStorageOrder(target, source, targetStorageOrder);
+        //fall through and copy normally
+    }
+
+    if (allocFloatData(target, source->nx, source->ny, False))
+        return ALLOCATION_PROBLEM; //allocFloatData() initializes before returning
+
+    //allocFloatData() correctly initializes all other members leaving only buffer (data points to buffer)
+    memcpy(target->buffer, source->buffer, source->nx*source->ny*sizeof(*source->buffer));
+    return 0;
+}
+
+int swapFloatStorageOrder(FloatTwoDArray * target, const FloatTwoDArray * source, enum StorageOrder targetStorageOrder)
+{
+    //this probably breaks use of Pix on target? Do we need to swap nx & ny?
+    if (!target || !source)
+        return -1;
+
+    target->storageOrder = targetStorageOrder;
+    if (targetStorageOrder == source->storageOrder)
+        return 0;
+
+    const unsigned nRows = target->ny;
+    const unsigned nCols = target->nx;
+
+    {unsigned j;
+    for (j = 0; j < nCols; ++j)
+    {
+        {unsigned i;
+        for (i = 0; i < nRows; ++i)
+        {
+            if (targetStorageOrder == COLUMNMAJOR)
+                target->data[j*nRows + i] = source->data[i*nCols + j];
+            else
+                target->data[i*nCols + j] = source->data[j*nRows + i];
+        }}
+    }}
+    return 0;
+}
+
+int swapShortStorageOrder(ShortTwoDArray * target, const ShortTwoDArray * source, enum StorageOrder targetStorageOrder)
+{
+    //this probably breaks use of Pix on target? Do we need to swap nx & ny?
+    if (!target || !source)
+        return -1;
+
+    target->storageOrder = targetStorageOrder;
+    if (targetStorageOrder == source->storageOrder)
+        return 0;
+
+    const unsigned nRows = target->ny;
+    const unsigned nCols = target->nx;
+
+    {unsigned j;
+    for (j = 0; j < nCols; ++j)
+    {
+        {unsigned i;
+        for (i = 0; i < nRows; ++i)
+        {
+            if (targetStorageOrder == COLUMNMAJOR)
+                target->data[j*nRows + i] = source->data[i*nCols + j];
+            else
+                target->data[i*nCols + j] = source->data[j*nRows + i];
+        }}
+    }}
+    return 0;
+}
+
 void initShortData(ShortTwoDArray *x) {
         x->buffer = NULL;
         x->buffer_size = 0;
@@ -457,6 +550,7 @@ void initShortData(ShortTwoDArray *x) {
         x->tot_ny = 0;
         x->nx = 0;
         x->ny = 0;
+        x->storageOrder = ROWMAJOR;
         x->data = NULL;
 # if defined (DEBUG)
         printf("initShortData: %x %x %d\n",
@@ -464,7 +558,7 @@ void initShortData(ShortTwoDArray *x) {
 # endif
 }
 
-int allocShortData(ShortTwoDArray *x, int i, int j) {
+int allocShortData(ShortTwoDArray *x, int i, int j, Bool zeroInitialize) {
 # if defined (DEBUG)
         printf("allocShortData-1: %x %x %d\n",
                 (int)x,(int)(x->buffer),x->buffer_size);
@@ -473,7 +567,10 @@ int allocShortData(ShortTwoDArray *x, int i, int j) {
             if (x->buffer != NULL)
                 free(x->buffer);
             x->buffer_size = i * j;
-            x->buffer = (short *)calloc(x->buffer_size, sizeof(short));
+            if (zeroInitialize)
+                x->buffer = calloc(x->buffer_size, sizeof(*x->buffer));
+            else
+                x->buffer = malloc(x->buffer_size * sizeof(*x->buffer));
             if (x->buffer == NULL) {
                 initShortData(x);
                 error(NOMEM,"Allocating DQData");
@@ -500,6 +597,31 @@ void freeShortData(ShortTwoDArray *x) {
         if (x->buffer != NULL)
             free(x->buffer);
         initShortData(x);
+}
+int copyShortData(ShortTwoDArray * target, const ShortTwoDArray * source, enum StorageOrder targetStorageOrder)
+{
+    if (!target || !source)
+        return -1;
+
+    //should this check be raise higher up the call stack also?
+    if (targetStorageOrder != source->storageOrder)
+    {
+        //assumes target initialized
+        if (!target->buffer)
+        {
+            if (allocShortData(target, source->nx, source->ny, False))
+                return ALLOCATION_PROBLEM; //allocShortData() initializes before returning
+        }
+        return swapShortStorageOrder(target, source, targetStorageOrder);
+        //fall through and copy normally
+    }
+
+    if (allocShortData(target, source->nx, source->ny, False))
+        return ALLOCATION_PROBLEM; //allocShortData() initializes before returning
+
+    //allocShortData() correctly initializes all other members leaving only buffer (data points to buffer)
+    memcpy(target->buffer, source->buffer, source->nx*source->ny*sizeof(*source->buffer));
+    return 0;
 }
 
 void initFloatLine (FloatHdrLine *x) {
@@ -588,7 +710,7 @@ void initHdr(Hdr *h) {
         h->array = NULL;
 }
 
-int allocHdr(Hdr *h, int n) {
+int allocHdr(Hdr *h, int n, Bool zeroInitialize) {
 # if defined (DEBUG)
         printf("allocHdr-1: %x %d %d %x %d\n",
                 (int)h,h->nlines,h->nalloc,(int)(h->array),n);
@@ -598,7 +720,11 @@ int allocHdr(Hdr *h, int n) {
             if (h->array != NULL)
                 free(h->array);
             h->nalloc = n;
-            h->array = (HdrArray *)calloc(n,sizeof(HdrArray));
+            if (zeroInitialize)
+                h->array = calloc(n,sizeof(*h->array));
+            else
+                h->array = malloc(n * sizeof(*h->array));
+
             if (h->array == NULL) {
                 h->nalloc = 0;
                 error(NOMEM,"Allocating Hdr");
@@ -642,17 +768,19 @@ void freeHdr(Hdr *h) {
         printf("freeHdr: %x %d %d %x\n",
                 (int)h,h->nlines,h->nalloc,(int)(h->array));
 # endif
-        if (h != NULL && h->array != NULL)
+        if (!h)
+        	return;
+        if (h->array)
             free(h->array);
-        if (h != NULL)
-            initHdr(h);
+        initHdr(h);
 }
 
-int copyHdr(Hdr *to, Hdr *from) {
-        int i;
-        if (allocHdr(to,from->nalloc)) return -1;
-        for (i = 0; i < from->nlines; ++i)
-            strcpy(to->array[i],from->array[i]);
+int copyHdr(Hdr *to, const Hdr *from) {
+        if (!to || !from)
+            return -1;
+        //allcoHdr only allocates if to->array == NULL or sizes differ
+        if (allocHdr(to,from->nalloc, False)) return -1;
+        memcpy(to->array, from->array, to->nalloc*sizeof(*to->array));
         to->nlines = from->nlines;
         return 0;
 }
@@ -670,9 +798,9 @@ void initFloatHdrData(FloatHdrData *x) {
         initFloatData(&(x->data));
 }
 
-int allocFloatHdrData(FloatHdrData *x, int i, int j) {
-        if (allocFloatData(&(x->data),i,j)) return -1;
-        if (allocHdr(&(x->hdr),HdrUnit)) return -1;
+int allocFloatHdrData(FloatHdrData *x, int i, int j, Bool zeroInitialize) {
+        if (allocFloatData(&(x->data),i,j, zeroInitialize)) return -1;
+        if (allocHdr(&(x->hdr),HdrUnit, zeroInitialize)) return -1;
         x->section.x_beg = 0;
         x->section.y_beg = 0;
         x->section.sx = i;
@@ -680,10 +808,34 @@ int allocFloatHdrData(FloatHdrData *x, int i, int j) {
         return 0;
 }
 
+int copyFloatHdrData(FloatHdrData * target, const FloatHdrData * src, enum StorageOrder targetStorageOrder)
+{
+    if (!target || !src)
+        return -1;
+
+    target->iodesc = src->iodesc;
+
+    //Since DataSection section refers to image IO, keep as source (I think?).
+    copyDataSection(&target->section, &src->section);//No allocations
+
+    if (copyHdr(&target->hdr, &src->hdr))//This allocates
+        return ALLOCATION_PROBLEM;
+
+    return copyFloatData(&target->data, &src->data, targetStorageOrder);
+}
+
 void freeFloatHdrData(FloatHdrData *x) {
         freeFloatData(&(x->data));
         freeHdr(&(x->hdr));
         initFloatHdrData(x);
+}
+
+void copyDataSection(DataSection * dest, const DataSection * src)
+{
+    dest->x_beg = src->x_beg;
+    dest->y_beg = src->y_beg;
+    dest->sx = src->sx;
+    dest->sy = src->sy;
 }
 
 void initShortHdrData(ShortHdrData *x) {
@@ -696,14 +848,30 @@ void initShortHdrData(ShortHdrData *x) {
         initShortData(&(x->data));
 }
 
-int allocShortHdrData(ShortHdrData *x, int i, int j) {
-        if (allocShortData(&(x->data),i,j)) return -1;
-        if (allocHdr(&(x->hdr),HdrUnit)) return -1;
+int allocShortHdrData(ShortHdrData *x, int i, int j, Bool zeroInitialize) {
+        if (allocShortData(&(x->data),i,j, zeroInitialize)) return -1;
+        if (allocHdr(&(x->hdr),HdrUnit, zeroInitialize)) return -1;
         x->section.x_beg = 0;
         x->section.y_beg = 0;
         x->section.sx = i;
         x->section.sy = j;
         return 0;
+}
+
+int copyShortHdrData(ShortHdrData * target, const ShortHdrData * src, enum StorageOrder targetStorageOrder)
+{
+    if (!target || !src)
+        return -1;
+
+    target->iodesc = src->iodesc;
+
+    //Since DataSection section refers to image IO, keep as source (I think?).
+    copyDataSection(&target->section, &src->section);//No allocations
+
+    if (copyHdr(&target->hdr, &src->hdr))//This allocates
+        return ALLOCATION_PROBLEM;
+
+    return copyShortData(&target->data, &src->data, targetStorageOrder);
 }
 
 void freeShortHdrData(ShortHdrData *x) {
@@ -722,7 +890,7 @@ void initFloatHdrLine (FloatHdrLine *x) {
 
 int allocFloatHdrLine (FloatHdrLine *x, int i) {
         if (allocFloatLine (x, i)) return (-1);
-        if (allocHdr (&(x->hdr),HdrUnit)) return (-1);
+        if (allocHdr (&(x->hdr),HdrUnit, True)) return (-1);
         return (0);
 }
 
@@ -743,7 +911,7 @@ void initShortHdrLine (ShortHdrLine *x) {
 
 int allocShortHdrLine (ShortHdrLine *x, int i) {
         if (allocShortLine (x, i)) return (-1);
-        if (allocHdr (&(x->hdr),HdrUnit)) return (-1);
+        if (allocHdr (&(x->hdr),HdrUnit, True)) return (-1);
         return (0);
 }
 
@@ -763,16 +931,178 @@ void initSingleGroup(SingleGroup *x) {
         initFloatHdrData(&(x->err));
 }
 
-int allocSingleGroup(SingleGroup *x, int i, int j) {
-        if (x->globalhdr == NULL) {
-            x->globalhdr = (Hdr *)calloc(1,sizeof(Hdr));
-            if (x->globalhdr == NULL) return -1;
-            initHdr(x->globalhdr);
+int allocSingleGroup(SingleGroup *x, int i, int j, Bool zeroInitialize)
+{
+    if (allocSingleGroupHeader(&x->globalhdr, zeroInitialize) ||
+            allocFloatHdrData(&(x->sci),i,j, zeroInitialize)  ||
+            allocShortHdrData(&(x->dq),i,j, zeroInitialize)   ||
+            allocFloatHdrData(&(x->err),i,j, zeroInitialize))
+        return ALLOCATION_PROBLEM;
+    return 0;
+}
+
+int allocSingleGroupHeader(Hdr ** hdr, Bool zeroInitialize)
+{
+    if (!hdr)
+        return ALLOCATION_PROBLEM;
+
+    if (*hdr)
+        return 0; //Already allocated
+
+    if (zeroInitialize)
+        *hdr = calloc(1,sizeof(*hdr));
+    else
+        *hdr = malloc(sizeof(*hdr));
+
+    if (!*hdr)
+        return ALLOCATION_PROBLEM;
+
+    initHdr(*hdr);
+    return HSTCAL_OK;
+}
+
+int allocSingleGroupExts(SingleGroup *x, int i, int j, unsigned extension, Bool zeroInitialize)
+{
+    if (allocSingleGroupHeader(&x->globalhdr, zeroInitialize))
+        return ALLOCATION_PROBLEM;
+
+    if (extension & SCIEXT)
+    {
+        if (allocFloatHdrData(&(x->sci),i,j, zeroInitialize))
+            return ALLOCATION_PROBLEM;
+    }
+    if (extension & ERREXT)
+    {
+        if (allocFloatHdrData(&(x->err),i,j, zeroInitialize))
+            return ALLOCATION_PROBLEM;
+    }
+    if (extension & DQEXT)
+    {
+        if (allocShortHdrData(&(x->dq),i,j, zeroInitialize))
+            return ALLOCATION_PROBLEM;
+    }
+    return 0;
+}
+
+void setStorageOrder(SingleGroup * group, enum StorageOrder storageOrder)
+{
+    if (!group)
+        return;
+
+    group->sci.data.storageOrder = storageOrder;
+    group->err.data.storageOrder = storageOrder;
+    group->dq.data.storageOrder = storageOrder;
+
+}
+
+void copyOffsetFloatData(float * output, const float * input,
+        unsigned nRows, unsigned nColumns,
+        unsigned outputOffset, unsigned inputOffset,
+        unsigned outputSkipLength, unsigned inputSkipLength)
+{
+    //WARNING - assumes row major storage
+    {unsigned ithRow;
+#ifdef _OPENMP
+    #pragma omp parallel for shared(output, input) private(ithRow) schedule(static)
+#endif
+    for (ithRow = 0; ithRow < nRows; ++ithRow)
+        memcpy(output + outputOffset + ithRow*outputSkipLength, input + inputOffset + ithRow*inputSkipLength, nColumns*sizeof(*output));
+    }
+}
+void copyOffsetShortData(short * output, const short * input,
+        unsigned nRows, unsigned nColumns,
+        unsigned outputOffset, unsigned inputOffset,
+        unsigned outputSkipLength, unsigned inputSkipLength)
+{
+    //WARNING - assumes row major storage
+    {unsigned ithRow;
+#ifdef _OPENMP
+    #pragma omp parallel for shared(output, input) private(ithRow) schedule(static)
+#endif
+    for (ithRow = 0; ithRow < nRows; ++ithRow)
+        memcpy(output + outputOffset + ithRow*outputSkipLength, input + inputOffset + ithRow*inputSkipLength, nColumns*sizeof(*output));
+    }
+}
+
+void copyOffsetSingleGroup(SingleGroup * output, const SingleGroup * input,
+        unsigned nRows, unsigned nColumns,
+		unsigned outputOffset, unsigned inputOffset,
+		unsigned outputSkipLength, unsigned inputSkipLength)
+{
+    if (!output || !input)
+        return;
+    //WARNING - assumes row major storage
+    assert(output->sci.data.storageOrder == ROWMAJOR && output->sci.data.storageOrder == ROWMAJOR);
+
+    //sci data
+    if (output->sci.data.data && input->sci.data.data)
+        copyOffsetFloatData(output->sci.data.data, input->sci.data.data, nRows, nColumns, outputOffset, inputOffset, outputSkipLength, inputSkipLength);
+    //err data
+    if (output->err.data.data && input->err.data.data)
+        copyOffsetFloatData(output->err.data.data, input->err.data.data, nRows, nColumns, outputOffset, inputOffset, outputSkipLength, inputSkipLength);
+    //dq data
+    if (output->dq.data.data && input->dq.data.data)
+        copyOffsetShortData(output->dq.data.data, input->dq.data.data, nRows, nColumns, outputOffset, inputOffset, outputSkipLength, inputSkipLength);
+}
+
+
+int copySingleGroup(SingleGroup * target, const SingleGroup * source, enum StorageOrder targetStorageOrder)
+{
+    //WARNING assumes target pre allocated and initialized (entire tree). This way data can be copied to pre
+    //allocated target, i.e. copy(a, b) .. do something .. copy(b, a)
+    //NOTE: If structs contained total size we could just use malloc & memcpy and be done with it.
+
+    if (!target || !source)
+        return ALLOCATION_PROBLEM;
+
+    setStorageOrder(target, targetStorageOrder);
+
+    if (source->filename)
+    {
+        size_t filenameLength = strlen(source->filename)+1;
+        if (!target->filename || (target->filename && strlen(target->filename) != filenameLength))
+        {
+            if (target->filename)
+                free(target->filename);
+            target->filename = malloc(filenameLength*sizeof(*source->filename));
         }
-        if (allocFloatHdrData(&(x->sci),i,j)) return -1;
-        if (allocShortHdrData(&(x->dq),i,j)) return -1;
-        if (allocFloatHdrData(&(x->err),i,j)) return -1;
-        return 0;
+        if (!target->filename)
+        {
+            initSingleGroup(target);
+            return ALLOCATION_PROBLEM;
+        }
+        memcpy(target->filename, source->filename, filenameLength);
+    }
+
+    target->group_num = source->group_num;
+
+    copyHdr(target->globalhdr, source->globalhdr); //This allocates
+
+    if (source->sci.data.data)
+    {
+        if (copyFloatHdrData(&target->sci, &source->sci, targetStorageOrder))
+        {
+            initSingleGroup(target);
+            return ALLOCATION_PROBLEM;
+        }
+    }
+    if (source->err.data.data)
+    {
+        if (copyFloatHdrData(&target->err, &source->err, targetStorageOrder))
+        {
+            initSingleGroup(target);
+            return ALLOCATION_PROBLEM;
+        }
+    }
+    if (source->dq.data.data)
+    {
+        if (copyShortHdrData(&target->dq, &source->dq, targetStorageOrder))
+        {
+            initSingleGroup(target);
+            return ALLOCATION_PROBLEM;
+        }
+    }
+    return 0;
 }
 
 void freeSingleGroup(SingleGroup *x) {
@@ -843,11 +1173,11 @@ int allocSingleNicmosGroup(SingleNicmosGroup *x, int i, int j) {
             if (x->globalhdr == NULL) return -1;
             initHdr(x->globalhdr);
         }
-        if (allocFloatHdrData(&(x->sci),i,j)) return -1;
-        if (allocFloatHdrData(&(x->err),i,j)) return -1;
-        if (allocShortHdrData(&(x->dq),i,j)) return -1;
-        if (allocShortHdrData(&(x->smpl),i,j)) return -1;
-        if (allocFloatHdrData(&(x->intg),i,j)) return -1;
+        if (allocFloatHdrData(&(x->sci),i,j, True)) return -1;
+        if (allocFloatHdrData(&(x->err),i,j, True)) return -1;
+        if (allocShortHdrData(&(x->dq),i,j, True)) return -1;
+        if (allocShortHdrData(&(x->smpl),i,j, True)) return -1;
+        if (allocFloatHdrData(&(x->intg),i,j, True)) return -1;
         return 0;
 }
 
@@ -1079,6 +1409,7 @@ void closeSingleGroupLine (SingleGroupLine *x) {
 
 int getFloatHD(char *fname, char *ename, int ever, FloatHdrData *x) {
         IODesc *xio;
+        assert(x);
         x->iodesc = openInputImage(fname,ename,ever);
         xio = (IODesc *)(x->iodesc);
         if (hstio_err()) return -1;
@@ -2129,7 +2460,7 @@ int getHeader(IODescPtr iodesc_, Hdr *hd) {
         }
 
         /* allocate space for the header cards */
-        if (allocHdr(hd, ncards) == -1) return -1;
+        if (allocHdr(hd, ncards, True) == -1) return -1;
 
         /* translate the data */
         hd->nlines = 0;
@@ -2343,7 +2674,7 @@ int getFloatData(IODescPtr iodesc_, FloatTwoDArray *da) {
                 iodesc->dims[1] = getIntKw(kw);
             }
 
-            if (allocFloatData(da, iodesc->dims[0], iodesc->dims[1])) return -1;
+            if (allocFloatData(da, iodesc->dims[0], iodesc->dims[1], False)) return -1;
             for (j = 0; j < iodesc->dims[1]; ++j) {
                 for (i = 0; i < iodesc->dims[0]; ++i) {
                     PPix(da, i, j) = val;
@@ -2355,7 +2686,7 @@ int getFloatData(IODescPtr iodesc_, FloatTwoDArray *da) {
             /* CFITSIO TODO: Should we verify the type is correct
                here?  Original code gets type, but then does nothing
                with it. */
-            if (allocFloatData(da, iodesc->dims[0], iodesc->dims[1])) return -1;
+            if (allocFloatData(da, iodesc->dims[0], iodesc->dims[1], True)) return -1;
             fpixel[0] = 1;
             fpixel[1] = 1;
             if (fits_read_pix(iodesc->ff, TFLOAT, fpixel, iodesc->dims[0], 0,
@@ -2368,16 +2699,41 @@ int getFloatData(IODescPtr iodesc_, FloatTwoDArray *da) {
             /* CFITSIO TODO: Should we verify the type is correct
                here?  Original code gets type, but then does nothing
                with it. */
-            if (allocFloatData(da, iodesc->dims[0], iodesc->dims[1])) return -1;
+            if (allocFloatData(da, iodesc->dims[0], iodesc->dims[1], True)) return -1;
 
             fpixel[0] = 1;
-            for (i = 0; i < iodesc->dims[1]; ++i) {
-                fpixel[1] = i + 1;
-                if (fits_read_pix(iodesc->ff, TFLOAT, fpixel, iodesc->dims[0], 0,
-                                  (float *)&(PPix(da, 0, i)), &anynul, &status)) {
-                    ioerr(BADREAD,iodesc, status);
-                    return -1;
+            if (da->storageOrder == ROWMAJOR)
+            {
+                for (i = 0; i < iodesc->dims[1]; ++i) {
+                    fpixel[1] = i + 1;
+                    if (fits_read_pix(iodesc->ff, TFLOAT, fpixel, iodesc->dims[0], 0,
+                            &(PPix(da, 0, i)), &anynul, &status)) {
+                        ioerr(BADREAD,iodesc, status);
+                        return -1;
+                    }
                 }
+            }
+            else
+            {
+                unsigned nColumns = iodesc->dims[0];
+                float * row = malloc(nColumns*sizeof(float));
+                if (!row)
+                    return OUT_OF_MEMORY;
+                for (i = 0; i < iodesc->dims[1]; ++i)
+                {
+                    fpixel[1] = i + 1;
+                    if (fits_read_pix(iodesc->ff, TFLOAT, fpixel, nColumns, 0,
+                            row, &anynul, &status)) {
+                        ioerr(BADREAD,iodesc, status);
+                        return -1;
+                    }
+                    {unsigned j;
+                    for (j = 0; j < nColumns; ++j)
+                        PPixColumnMajor(da, i, j) = row[j];
+                    }
+                }
+                if (row)
+                    free(row);
             }
         } else {
             ioerr(BADDIMS,iodesc,0);
@@ -2682,7 +3038,7 @@ int getShortData(IODescPtr iodesc_, ShortTwoDArray *da) {
                 iodesc->dims[1] = getIntKw(kw);
             }
 
-            if (allocShortData(da, iodesc->dims[0], iodesc->dims[1])) return -1;
+            if (allocShortData(da, iodesc->dims[0], iodesc->dims[1], True)) return -1;
             for (j = 0; j < iodesc->dims[1]; ++j)
                 for (i = 0; i < iodesc->dims[0]; ++i)
                     PPix(da, i, j) = val;
@@ -2691,7 +3047,7 @@ int getShortData(IODescPtr iodesc_, ShortTwoDArray *da) {
             /* CFITSIO TODO: Should we verify the type is correct
                here?  Original code gets type, but then does nothing
                with it. */
-            if (allocShortData(da, iodesc->dims[0], iodesc->dims[1])) return -1;
+            if (allocShortData(da, iodesc->dims[0], iodesc->dims[1], True)) return -1;
             fpixel[0] = 1;
             fpixel[1] = 1;
             if (fits_read_pix(iodesc->ff, TSHORT, fpixel, iodesc->dims[0], NULL,
@@ -2703,7 +3059,7 @@ int getShortData(IODescPtr iodesc_, ShortTwoDArray *da) {
             /* CFITSIO TODO: Should we verify the type is correct
                here?  Original code gets type, but then does nothing
                with it. */
-            if (allocShortData(da, iodesc->dims[0], iodesc->dims[1])) return -1;
+            if (allocShortData(da, iodesc->dims[0], iodesc->dims[1], True)) return -1;
             fpixel[0] = 1;
             for (i = 0; i < iodesc->dims[1]; ++i) {
                 fpixel[1] = i + 1;

--- a/hstio/keyword.c
+++ b/hstio/keyword.c
@@ -228,7 +228,7 @@ static int insertname(FitsKwInfo *kw, char *nm) {
         int orig_nlines = 0;
 
         if (kw->hdr->nalloc == 0) {
-            if (allocHdr(kw->hdr,HdrUnit) != 0)
+            if (allocHdr(kw->hdr,HdrUnit, True) != 0)
             return -1;
         }
         if (kw->hdr->nlines == kw->hdr->nalloc) {
@@ -275,7 +275,7 @@ static int addcommentary(Hdr *h, char *text, char *type) {
         int  nblankline  = 0;
         char *t;
         if (h->nalloc == 0) {
-            if (allocHdr(h,HdrUnit) != 0)
+            if (allocHdr(h,HdrUnit, True) != 0)
                 return -1;
         }
         if (h->nlines == h->nalloc) {
@@ -1165,7 +1165,7 @@ FitsKw  insertFitsCard(FitsKw kw_, char *card) {
 
         /* make sure we have room */
         if (kw->hdr->nalloc == 0) {
-            if (allocHdr(kw->hdr,HdrUnit) != 0)
+            if (allocHdr(kw->hdr,HdrUnit, True) != 0)
                 { error(NOMEM,""); return NULL; }
         }
         if (kw->hdr->nlines == kw->hdr->nalloc) {

--- a/include/hstio.h
+++ b/include/hstio.h
@@ -5,6 +5,8 @@
 extern "C" {
 # endif
 
+# include <stdlib.h>
+
 # define HSTIO_VERSION "HSTIO Version 2.6 (11-Mar-2010)"
 
 /*
@@ -117,8 +119,6 @@ extern "C" {
 **
 */
 
-# include <stdlib.h>
-
 /* Below is a general use pointer register (book keeping) to allow easy cleanup upon exit (pseudo C++ destructor)
  * Use example:
  *
@@ -166,6 +166,16 @@ enum Bool_ { False = 0, True = 1 };
 typedef enum Bool_ Bool;
 # endif
 
+enum StorageOrder
+{
+    ROWMAJOR,
+    COLUMNMAJOR
+};
+
+#define SCIEXT 0x01
+#define ERREXT 0x02
+#define DQEXT 0x04
+
 typedef struct {
         short *buffer;          /* the pointer to the beg. of the buffer */
         int buffer_size;        /* the size of the full 2-d array in the */
@@ -173,6 +183,7 @@ typedef struct {
         int tot_ny;             /*     buffer_size = tot_nx*tot_ny       */
         int nx;                 /* The size of the current "view" of the */
         int ny;                 /* full 2-d array.                       */
+        enum StorageOrder storageOrder;
         short *data;            /* The pointer to the beginning of the   */
                                 /* subsection of the full 2-d array.     */
 } ShortTwoDArray;
@@ -184,6 +195,7 @@ typedef struct {
         int tot_ny;
         int nx;
         int ny;
+        enum StorageOrder storageOrder;
         float *data;
 } FloatTwoDArray;
 
@@ -208,10 +220,12 @@ typedef struct {
 */
 
 # define Pix(a,i,j)      (a).data[(j)*(a).tot_nx + (i)]
+# define PixColumnMajor(a,i,j) (a).data[(j)*(a).tot_ny + (i)]
 # define DQPix(a,i,j)    (a).data[(j)*(a).tot_nx + (i)]
 # define DQSetPix(a,i,j,value) (a).data[(j)*(a).tot_nx + (i)] = (value)
 
 # define PPix(a,i,j)      (a)->data[(j)*(a)->tot_nx + (i)]
+# define PPixColumnMajor(a,i,j) (a)->data[(j)*(a)->tot_ny + (i)]
 # define PDQPix(a,i,j)    (a)->data[(j)*(a)->tot_nx + (i)]
 # define PDQSetPix(a,i,j,value) (a)->data[(j)*(a)->tot_nx + (i)] = (value)
 
@@ -251,6 +265,8 @@ typedef struct {
         int sx;                 /* The sizes of the X and Y dimensions  */
         int sy;                 /* of the section.                      */
 } DataSection;
+void copyDataSection(DataSection * dest, const DataSection * src);
+
 
 # define HDRSize 81
 typedef char HdrArray[HDRSize]; /* Headers are simply an array of fixed */
@@ -707,12 +723,14 @@ void updateWCS (Hdr *hdr, int xbeg, int ybeg);
 */
 # define IFloatData { NULL, 0, 0, 0, 0, 0, NULL }
 void initFloatData(FloatTwoDArray *);
-int allocFloatData(FloatTwoDArray *, int, int);
+int allocFloatData(FloatTwoDArray *, int, int, Bool zeroInitialize);
 void freeFloatData(FloatTwoDArray *);
+int swapFloatStorageOrder(FloatTwoDArray * target, const FloatTwoDArray * source, enum StorageOrder targetStorageOrder);
 # define IShortData { NULL, 0, 0, 0, 0, 0, NULL }
 void initShortData(ShortTwoDArray *);
-int allocShortData(ShortTwoDArray *, int, int);
+int allocShortData(ShortTwoDArray *, int, int, Bool zeroInitialize);
 void freeShortData(ShortTwoDArray *);
+int swapShortStorageOrder(ShortTwoDArray * target, const ShortTwoDArray * source, enum StorageOrder targetStorageOrder);
 
 # define IFloatLine { NULL, 0 }
 void initFloatLine  (FloatHdrLine *);
@@ -729,18 +747,20 @@ int  allocDQLine  (SingleGroupLine *);
 
 # define IHdr { 0, 0, NULL }
 void initHdr(Hdr *);
-int allocHdr(Hdr *, int);
+int allocHdr(Hdr *, int, Bool zeroInitialize);
 int reallocHdr(Hdr *, int);
 void freeHdr(Hdr *);
-int copyHdr(Hdr *to, Hdr *from);
+int copyHdr(Hdr *to, const Hdr *from);
 
 # define IFloatHdrData { NULL, { 0, 0, 0, 0 }, IHdr, IFloatData }
 void initFloatHdrData(FloatHdrData *);
-int allocFloatHdrData(FloatHdrData *, int, int);
+int allocFloatHdrData(FloatHdrData *, int, int, Bool zeroInitialize);
+int copyFloatHdrData(FloatHdrData * target, const FloatHdrData * src, enum StorageOrder targetStorageOrder);
 void freeFloatHdrData(FloatHdrData *);
 # define IShortHdrData { NULL, { 0, 0, 0, 0 }, IHdr, IShortData }
 void initShortHdrData(ShortHdrData *);
-int allocShortHdrData(ShortHdrData *, int, int);
+int allocShortHdrData(ShortHdrData *, int, int, Bool zeroInitialize);
+int copyShortHdrData(ShortHdrData * target, const ShortHdrData * src, enum StorageOrder targetStorageOrder);
 void freeShortHdrData(ShortHdrData *);
 
 # define IFloatHdrLine { NULL, IHdr, False, 0, NULL }
@@ -755,12 +775,22 @@ void freeShortHdrLine  (ShortHdrLine *);
 # define ISingleGroup { NULL, 0, NULL, IFloatHdrData, IFloatHdrData, \
 IShortHdrData }
 void initSingleGroup(SingleGroup *);
-int allocSingleGroup(SingleGroup *, int, int);
+int allocSingleGroup(SingleGroup *, int, int, Bool zeroInitialize);
+int allocSingleGroupHeader(Hdr ** hdr, Bool zeroInitialize);
+int allocSingleGroupExts(SingleGroup *x, int i, int j, unsigned extension, Bool zeroInitialize);
 void freeSingleGroup(SingleGroup *);
+void setStorageOrder(SingleGroup * group, enum StorageOrder storageOrder);
+int copySingleGroup(SingleGroup * target, const SingleGroup * source, enum StorageOrder targetStorageOrder);
+void copyOffsetSingleGroup(SingleGroup * output, const SingleGroup * input, unsigned nRows, unsigned nColumns, unsigned outputOffset, unsigned inputOffset, unsigned outputSkipLength, unsigned inputSkipLength);
 # define IMultiGroup { 0, NULL }
 void initMultiGroup(MultiGroup *);
 int allocMultiGroup(MultiGroup *, int);
 void freeMultiGroup(MultiGroup *);
+
+int copyFloatData(FloatTwoDArray * target, const FloatTwoDArray * source, enum StorageOrder targetStorageOrder);
+void copyOffsetFloatData(float * output, const float * input, unsigned nRows, unsigned nColumns, unsigned outputOffset, unsigned inputOffset, unsigned outputSkipLength, unsigned inputSkipLength);
+int copyShortData(ShortTwoDArray * target, const ShortTwoDArray * source, enum StorageOrder targetStorageOrder);
+void copyOffsetShortData(short * output, const short * input, unsigned nRows, unsigned nColumns, unsigned outputOffset, unsigned inputOffset, unsigned outputSkipLength, unsigned inputSkipLength);
 
 # define ISingleNicmosGroup { NULL, 0, NULL, IFloatHdrData, IFloatHdrData, \
 IShortHdrData, IShortHdrData, IFloatHdrData }

--- a/include/xtables.h
+++ b/include/xtables.h
@@ -57,6 +57,8 @@ void c_imtclose (IRAFPointer imt);
 IRAFPointer c_tbtopn (char *tablename, int iomode, IRAFPointer template);
 void c_tbtcre (IRAFPointer tp);
 void c_tbtclo (IRAFPointer tp);
+void c_tbtClose (IRAFPointer * tp);
+
 int c_tbtacc (char *tablename);
 void c_tbtnam (IRAFPointer tp, char *tablename, int maxch);
 void c_tbfpri (char *intable, char *outtable, int *copied);
@@ -68,6 +70,7 @@ int c_tbpsta (IRAFPointer tp, int param);
 void c_tbcdef1 (IRAFPointer tp, IRAFPointer *cp,
         char *colname, char *colunits, char *colfmt, int datatype, int nelem);
 void c_tbcfnd1 (IRAFPointer tp, const char *colname, IRAFPointer *cp);
+IRAFPointer c_tbcfnd1_retPtr (IRAFPointer tp, const char *colname);
 IRAFPointer c_tbcnum (IRAFPointer tp, int colnum);
 
 int c_tbcigi (IRAFPointer cp, int param);
@@ -102,13 +105,16 @@ void c_tbrcsc (IRAFPointer itp, IRAFPointer otp,
                 int irow, int orow, int ncols);
 void c_tbrudf (IRAFPointer tp, IRAFPointer *cp, int numcols, int row);
 
-void c_tbegtb (IRAFPointer tp, IRAFPointer cp, int rownum, Bool *buffer);
-void c_tbegtd (IRAFPointer tp, IRAFPointer cp, int rownum, double *buffer);
-void c_tbegtr (IRAFPointer tp, IRAFPointer cp, int rownum, float *buffer);
-void c_tbegti (IRAFPointer tp, IRAFPointer cp, int rownum, int *buffer);
-void c_tbegts (IRAFPointer tp, IRAFPointer cp, int rownum, short *buffer);
-void c_tbegtt (IRAFPointer tp, IRAFPointer cp, int rownum, char *buffer,
+void c_tbegtb (const IRAFPointer tp, const IRAFPointer cp, int rownum, Bool *buffer);
+void c_tbegtd (const IRAFPointer tp, const IRAFPointer cp, int rownum, double *buffer);
+void c_tbegtr (const IRAFPointer tp, const IRAFPointer cp, int rownum, float *buffer);
+void c_tbegti (const IRAFPointer tp, const IRAFPointer cp, int rownum, int *buffer);
+void c_tbegts (const IRAFPointer tp, const IRAFPointer cp, int rownum, short *buffer);
+void c_tbegtt (const IRAFPointer tp, const IRAFPointer cp, int rownum, char *buffer,
                 int maxch);
+int c_tbeGetInt(const IRAFPointer tp, const IRAFPointer cp, int rownum);
+double c_tbeGetDouble(const IRAFPointer tp, const IRAFPointer cp, int rownum);
+
 void c_tbeptb (IRAFPointer tp, IRAFPointer cp, int rownum, Bool buffer);
 void c_tbeptd (IRAFPointer tp, IRAFPointer cp, int rownum, double buffer);
 void c_tbeptr (IRAFPointer tp, IRAFPointer cp, int rownum, float buffer);

--- a/pkg/acs/calacs/acs2d/doflat.c
+++ b/pkg/acs/calacs/acs2d/doflat.c
@@ -258,7 +258,7 @@ static int divFlat (SingleGroup *x, char *flatname, ACSInfo *acs2d) {
     
     /* Initialize shifted spot arrays */
     initSingleGroup(&outspot);
-    allocSingleGroup(&outspot, inspot.sci.data.nx, inspot.sci.data.ny);
+    allocSingleGroup(&outspot, inspot.sci.data.nx, inspot.sci.data.ny, True);
     
     parseObsDate(x->globalhdr, &date);
     status = GetSpotTab(acs2d->spot.name, date, &shiftx, &shifty);

--- a/pkg/acs/calacs/acsrej/acsrej_loop.c
+++ b/pkg/acs/calacs/acsrej/acsrej_loop.c
@@ -315,7 +315,7 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr ipdq[],
        back into the input DQ arrays at the end of processing, while dq
        will hold values to write to the output CRJ DQ extension */
     initShortData (&dq2);
-    allocShortData (&dq2, dim_x, dim_y);
+    allocShortData (&dq2, dim_x, dim_y, True);
     for (j = 0; j < dim_y; j++) {
         for (i = 0; i < dim_x; i++) {
             PDQSetPix(dq,i,j,crflag);

--- a/pkg/stis/calstis/cs1/dobias.c
+++ b/pkg/stis/calstis/cs1/dobias.c
@@ -90,7 +90,7 @@ SingleGroup *x    io: image to be calibrated; written to in-place
 	    /* First bin the bias image down to the actual size of x. */
 
 	    initSingleGroup (&z);
-	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny);
+	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny, True);
 	    if ((status = bin2d (&y, x0, y0, rx, ry, avg, &z))) {
 		printf ("ERROR    (biascorr) size mismatch.\n");
 		return (status);

--- a/pkg/stis/calstis/cs1/doblev.c
+++ b/pkg/stis/calstis/cs1/doblev.c
@@ -140,7 +140,7 @@ int *driftcorr    o: true means correction for drift along lines was applied
 	initSingleGroup (out);
 	allocSingleGroup (out,
 		in->sci.data.nx - (trimx1 + trimx2),
-		in->sci.data.ny - (trimy1 + trimy2));
+		in->sci.data.ny - (trimy1 + trimy2), True);
 	if (hstio_err())
 	    return (OUT_OF_MEMORY);
 

--- a/pkg/stis/calstis/cs1/dodark.c
+++ b/pkg/stis/calstis/cs1/dodark.c
@@ -217,7 +217,7 @@ int sci_extver     i: IMSET number in input (science) file
 	    /* Bin the dark image down to the actual size of x. */
 
 	    initSingleGroup (&z);
-	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny);
+	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny, True);
 	    if ((status = bin2d (&y, x0, y0, rx, ry, avg, &z))) {
 		printf ("ERROR    (darkcorr) size mismatch.\n");
 		return (status);

--- a/pkg/stis/calstis/cs1/dodqi.c
+++ b/pkg/stis/calstis/cs1/dodqi.c
@@ -347,7 +347,7 @@ SingleGroup *x    io: image to be calibrated; DQ array written to in-place
 
 	if (!in_place) {
 	    /* Allocate space for a scratch array. */
-	    allocShortData (&ydq, snpix[0], snpix[1]);
+	    allocShortData (&ydq, snpix[0], snpix[1], True);
 	    if (hstio_err()) {
 		printf (
 		"ERROR    (doDQI) couldn't allocate data quality array.\n");

--- a/pkg/stis/calstis/cs1/doflat.c
+++ b/pkg/stis/calstis/cs1/doflat.c
@@ -98,7 +98,7 @@ SingleGroup *x    io: image to be calibrated; written to in-place
 		if (hstio_err())
 		    return (OPEN_FAILED);
 
-		allocSingleGroup (&z, y.sci.data.nx, y.sci.data.ny);
+		allocSingleGroup (&z, y.sci.data.nx, y.sci.data.ny, True);
 		if (hstio_err())
 		    return (ALLOCATION_PROBLEM);
 
@@ -126,7 +126,7 @@ SingleGroup *x    io: image to be calibrated; written to in-place
 		*/
 		nx = rx * z.sci.data.nx;
 		ny = ry * z.sci.data.ny;
-		allocSingleGroup (&y, nx, ny);
+		allocSingleGroup (&y, nx, ny, True);
 		if (hstio_err())
 		    return (ALLOCATION_PROBLEM);
 
@@ -198,7 +198,7 @@ SingleGroup *x    io: image to be calibrated; written to in-place
 
 	    /* Bin the flat field down to the actual size of x. */
 
-	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny);
+	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny, True);
 	    if ((status = bin2d (&y, x0, y0, rx, ry, avg, &z))) {
 		printf ("ERROR    (doFlat) size mismatch\n");
 		return (status);

--- a/pkg/stis/calstis/cs1/dolores.c
+++ b/pkg/stis/calstis/cs1/dolores.c
@@ -68,7 +68,7 @@ int *done         o: true if input image has been binned
 	if ((out = calloc (1, sizeof (SingleGroup))) == NULL)
 	    return (OUT_OF_MEMORY);
 	initSingleGroup (out);
-	allocSingleGroup (out, (in->sci.data.nx) / mx, (in->sci.data.ny) / my);
+	allocSingleGroup (out, (in->sci.data.nx) / mx, (in->sci.data.ny) / my, True);
 	if (hstio_err())
 	    return (OUT_OF_MEMORY);
 

--- a/pkg/stis/calstis/cs1/doshad.c
+++ b/pkg/stis/calstis/cs1/doshad.c
@@ -86,7 +86,7 @@ SingleGroup *x    io: image to be calibrated; written to in-place
 	    /* Bin the reference image down to the actual size of x. */
 
 	    initSingleGroup (&z);
-	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny);
+	    allocSingleGroup (&z, x->sci.data.nx, x->sci.data.ny, True);
 	    if ((status = bin2d (&y, x0, y0, rx, ry, avg, &z))) {
 		printf ("ERROR    (doShad) size mismatch.\n");
 		return (status);

--- a/pkg/stis/calstis/cs4/maketemplate.c
+++ b/pkg/stis/calstis/cs4/maketemplate.c
@@ -230,7 +230,7 @@ static void debugimg (char *dbgfile, CmplxArray *z) {
 	int i, j;
 
 	initFloatHdrData (&x);
-	allocFloatHdrData (&x, z->nx, z->ny);
+	allocFloatHdrData (&x, z->nx, z->ny, True);
 
 	for (j = 0;  j < z->ny;  j++) {
 	    for (i = 0;  i < z->nx;  i++)

--- a/pkg/stis/calstis/cs6/do1dx.c
+++ b/pkg/stis/calstis/cs6/do1dx.c
@@ -649,7 +649,7 @@ StisInfo6 *sts    i: calibration switches and info
             */
 	    if (sts->scatter) {
 	        if (allocSingleGroup (&holdraw, in.sci.data.nx,
-                                      in.sci.data.ny) == -1)
+                                      in.sci.data.ny, True) == ALLOCATION_PROBLEM)
 	            return (OUT_OF_MEMORY);
 	        for (i = 0; i < holdraw.sci.data.nx; i++) {
 	            for (j = 0; j < holdraw.sci.data.ny; j++) {
@@ -1158,7 +1158,7 @@ StisInfo6 *sts    i: calibration switches and info
                     */
 	            if (!outw_exists) {
 	                if (allocSingleGroup (&outw, in.sci.data.nx,
-                                                     in.sci.data.ny) == -1)
+                                                     in.sci.data.ny, True) == ALLOCATION_PROBLEM)
 	                    return (OUT_OF_MEMORY);
 	                outw_exists = 1;
 	            }

--- a/pkg/stis/calstis/cs6/idtalg/calstis6idt.c
+++ b/pkg/stis/calstis/cs6/idtalg/calstis6idt.c
@@ -459,12 +459,12 @@ int bks_order;		i: backgr. smoothing polynomial order
 	        return (OUT_OF_MEMORY);
 	    if (ltm[0] > 1.0) {
 	        allocSingleGroup (&win, in.sci.data.nx / 2,
-                                        in.sci.data.ny / 2);
+                                        in.sci.data.ny / 2, True);
 	        if (RebinData (&in, &win, x1d, wx1d, 2, tabptr.nrows))
 	            return (ERROR_RETURN);
 	    } else {
 	        allocSingleGroup (&win, in.sci.data.nx,
-                                        in.sci.data.ny);
+                                        in.sci.data.ny, True);
 	        if (RebinData (&in, &win, x1d, wx1d, 1, tabptr.nrows))
 	            return (ERROR_RETURN);
 	    }
@@ -1211,7 +1211,7 @@ int bks_order;		i: backgr. smoothing polynomial order
 	        }
 	        remove (temp_ima);
 	        initSingleGroup (&wout);
-	        allocSingleGroup (&wout, win.sci.data.nx, win.sci.data.ny);
+	        allocSingleGroup (&wout, win.sci.data.nx, win.sci.data.ny, True);
 	        for (j = 0; j < wout.sci.data.ny; j++) {
 	            for (i = 0; i < wout.sci.data.nx; i++)
 	                Pix (wout.sci.data, i, j) = im_mod[j][i];
@@ -1377,7 +1377,7 @@ int bks_order;		i: backgr. smoothing polynomial order
 	    initSingleGroup (&wout);
 	    if ((wx1d2 = AllocX1DTable (tabptr.nrows)) == NULL)
 	        return (OUT_OF_MEMORY);
-	    allocSingleGroup (&wout, in.sci.data.nx, in.sci.data.ny);
+	    allocSingleGroup (&wout, in.sci.data.nx, in.sci.data.ny, True);
 	    if (ltm[0] > 1.0) {
 	        if (RebinData (&win, &wout, wx1d, wx1d2, -2, tabptr.nrows))
 	            return (ERROR_RETURN);

--- a/pkg/stis/calstis/cs7/do2dx.c
+++ b/pkg/stis/calstis/cs7/do2dx.c
@@ -446,7 +446,7 @@ StisInfo7 *sts    i: calibration switches and info
 		AddOffsets (sts, &slit);
 
 		/* Create output imset. */
-		allocSingleGroup (out, coord_o->npix[0], coord_o->npix[1]);
+		allocSingleGroup (out, coord_o->npix[0], coord_o->npix[1], True);
 		if (hstio_err())
 		    return (OUT_OF_MEMORY);
 

--- a/pkg/wfc3/calwf3/lib/dodqi.c
+++ b/pkg/wfc3/calwf3/lib/dodqi.c
@@ -249,7 +249,7 @@ SingleGroup *x    io: image to be calibrated; DQ array written to in-place
 	/* Allocate space for scratch array */
 	initShortHdrData (&ydq);
 	if (!in_place) {
-	    allocShortHdrData (&ydq, snpix[0], snpix[1]);
+	    allocShortHdrData (&ydq, snpix[0], snpix[1], True);
 	    if (hstio_err()) {
 		trlerror ("doDQI couldn't allocate data quality array.");
 		return (status = OUT_OF_MEMORY);

--- a/pkg/wfc3/calwf3/wf3ccd/doccd.c
+++ b/pkg/wfc3/calwf3/wf3ccd/doccd.c
@@ -343,7 +343,7 @@ int DoCCD (WF3Info *wf3, int extver) {
                 sub2full will reset the pixel values
                 */
                 initSingleGroup(&fullarray);
-                allocSingleGroup(&fullarray,RAZ_COLS/2,RAZ_ROWS);
+                allocSingleGroup(&fullarray,RAZ_COLS/2,RAZ_ROWS, True);
                 fullarray.group_num=x.group_num;
                 CreateEmptyChip(wf3, &fullarray);
                 if (x.group_num == 2){ /*post blev*/

--- a/pkg/wfc3/calwf3/wf3ccd/sink.c
+++ b/pkg/wfc3/calwf3/wf3ccd/sink.c
@@ -76,7 +76,7 @@ int SinkDetect(WF3Info *wf3, SingleGroup *x){
 
     /* INIT THE SCIENCE INPUT  */
     initSingleGroup (&raz);
-    allocSingleGroup (&raz,RAZ_COLS/2, RAZ_ROWS);
+    allocSingleGroup (&raz,RAZ_COLS/2, RAZ_ROWS, True);
         
     /*CONVERT DQ DATA TO RAZ FORMAT FOR SCIENCE FILE*/
     makedqRAZ(x, &raz);
@@ -90,7 +90,7 @@ int SinkDetect(WF3Info *wf3, SingleGroup *x){
     /*NOW TURN THE SINK REFERENCE IMAGES INTO RAZ FORMAT*/
     FloatTwoDArray sinkraz;    
     initFloatData(&sinkraz); /*float 2d arrays*/
-    allocFloatData(&sinkraz,RAZ_COLS/2, RAZ_ROWS);     
+    allocFloatData(&sinkraz,RAZ_COLS/2, RAZ_ROWS, True);
 
     makeFloatRaz(&sinkref.data,&sinkraz,x->group_num);
 

--- a/pkg/wfc3/calwf3/wf3cte/wf3cte.c
+++ b/pkg/wfc3/calwf3/wf3cte/wf3cte.c
@@ -217,22 +217,22 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
 
     /*SET UP THE ARRAYS WHICH WILL BE PASSED AROUND*/
     initSingleGroup(&raz);
-    allocSingleGroup(&raz, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&raz, RAZ_COLS, RAZ_ROWS, True);
 
     initSingleGroup(&rsz);
-    allocSingleGroup(&rsz, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&rsz, RAZ_COLS, RAZ_ROWS, True);
 
     initSingleGroup(&rsc);
-    allocSingleGroup(&rsc, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&rsc, RAZ_COLS, RAZ_ROWS, True);
 
     initSingleGroup(&rzc);
-    allocSingleGroup(&rzc, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&rzc, RAZ_COLS, RAZ_ROWS, True);
 
     initSingleGroup(&raw);
-    allocSingleGroup(&raw, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&raw, RAZ_COLS, RAZ_ROWS, True);
 
     initSingleGroup(&chg);
-    allocSingleGroup(&chg, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&chg, RAZ_COLS, RAZ_ROWS, True);
 
     /*hardset the science arrays*/
     for (i=0;i<RAZ_COLS;i++){
@@ -297,7 +297,7 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
 
             /*create an empty full size chip for pasting*/
             initSingleGroup(&cd);
-            allocSingleGroup(&cd,RAZ_COLS/2,RAZ_ROWS);
+            allocSingleGroup(&cd,RAZ_COLS/2,RAZ_ROWS, True);
             cd.group_num=1;
             CreateEmptyChip(&wf3, &cd);
 
@@ -326,7 +326,7 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
 
             /* now create an empty chip 1*/
             initSingleGroup(&ab);
-            allocSingleGroup(&ab,RAZ_COLS/2,RAZ_ROWS);
+            allocSingleGroup(&ab,RAZ_COLS/2,RAZ_ROWS, True);
             ab.group_num=2;
             CreateEmptyChip(&wf3, &ab);
 
@@ -358,7 +358,7 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
 
             /*make an empty fullsize chip for pasting*/
             initSingleGroup(&ab);
-            allocSingleGroup(&ab,RAZ_COLS/2,RAZ_ROWS);
+            allocSingleGroup(&ab,RAZ_COLS/2,RAZ_ROWS, True);
             ab.group_num=2;
             CreateEmptyChip(&wf3, &ab);
 
@@ -387,7 +387,7 @@ int WF3cte (char *input, char *output, CCD_Switch *cte_sw,
 
             /* now create an empty chip 2*/
             initSingleGroup(&cd);
-            allocSingleGroup(&cd,RAZ_COLS/2,RAZ_ROWS);
+            allocSingleGroup(&cd,RAZ_COLS/2,RAZ_ROWS, True);
             cd.group_num=1;
             CreateEmptyChip(&wf3, &cd);
 
@@ -836,11 +836,11 @@ int raz2rsz(WF3Info *wf3, SingleGroup *raz, SingleGroup *rsz, double rnsig, int 
     /***INITIALIZE THE LOCAL IMAGE GROUPS***/
     SingleGroup rnz;
     initSingleGroup(&rnz);
-    allocSingleGroup(&rnz, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&rnz, RAZ_COLS, RAZ_ROWS, True);
 
     SingleGroup zadj;
     initSingleGroup(&zadj);
-    allocSingleGroup(&zadj, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&zadj, RAZ_COLS, RAZ_ROWS, True);
 
 
     /*COPY THE RAZ IMAGE INTO THE RSZ OUTPUT IMAGE
@@ -1095,7 +1095,7 @@ int rsz2rsc(WF3Info *wf3, SingleGroup *rsz, SingleGroup *rsc, CTEParams *cte) {
 
     SingleGroup pixz_fff;
     initSingleGroup(&pixz_fff);
-    allocSingleGroup(&pixz_fff, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&pixz_fff, RAZ_COLS, RAZ_ROWS, True);
 
     /*SCALE BY 1 UNLESS THE PCTETAB SAYS OTHERWISE, I IS THE PACKET NUM
       THIS IS A SAFETY LOOP INCASE NOT ALL THE COLUMNS ARE POPULATED
@@ -1200,15 +1200,15 @@ int inverse_cte_blur(SingleGroup *rsz, SingleGroup *rsc, SingleGroup *fff, CTEPa
     /*LOCAL IMAGES TO PLAY WITH, THEY WILL REPLACE THE INPUTS*/
     SingleGroup rz; /*pixz_raz*/
     initSingleGroup(&rz);
-    allocSingleGroup(&rz, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&rz, RAZ_COLS, RAZ_ROWS, True);
 
     SingleGroup rc; /*pixz_rac*/
     initSingleGroup(&rc);
-    allocSingleGroup(&rc, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&rc, RAZ_COLS, RAZ_ROWS, True);
 
     SingleGroup pixz_fff; /*pixz_fff*/
     initSingleGroup(&pixz_fff);
-    allocSingleGroup(&pixz_fff, RAZ_COLS, RAZ_ROWS);
+    allocSingleGroup(&pixz_fff, RAZ_COLS, RAZ_ROWS, True);
 
 
     /*USE EXPSTART YYYY-MM-DD TO DETERMINE THE CTE SCALING

--- a/pkg/wfc3/calwf3/wf3rej/rej_loop.c
+++ b/pkg/wfc3/calwf3/wf3rej/rej_loop.c
@@ -343,7 +343,7 @@ int rej_loop (IODescPtr ipsci[], IODescPtr ipdq[], char imgname[][SZ_FNAME+1],
        back into the input DQ arrays at the end of processing, while dq
        will hold values to write to the output CRJ DQ extension */
     initShortData (&dq2);
-    allocShortData (&dq2, dim_x, dim_y);
+    allocShortData (&dq2, dim_x, dim_y, True);
     for (j = 0; j < dim_y; j++) {
         for (i = 0; i < dim_x; i++) {
             PDQSetPix(dq,i,j,crflag);

--- a/tables/c_tbcfnd1.c
+++ b/tables/c_tbcfnd1.c
@@ -13,25 +13,29 @@ char *colname           i: column name
 IRAFPointer *cp         o: column descriptor
 */
 
-        char lc_colname[SZ_FITS_STR+1], lc_name[SZ_FITS_STR+1];
-        TableDescr *tbl_descr;
-        ColumnDescr *col_descr;
-        int foundit = 0;
-        int i;
+        *cp = NULL;
+        if (!tp || !colname || *colname == '\0')
+            return;
 
+        char lc_colname[SZ_FITS_STR+1], lc_name[SZ_FITS_STR+1];
         str_lower (lc_colname, colname);
 
-        tbl_descr = (TableDescr *)tp;
-        for (i = 0;  i < tbl_descr->ncols;  i++) {
-            col_descr = (ColumnDescr *)tbl_descr->columns[i];
+        TableDescr *tbl_descr = (TableDescr *)tp;
+
+        {unsigned i;
+        for (i = 0;  i < tbl_descr->ncols;  ++i) {
+            ColumnDescr * col_descr = (ColumnDescr *)tbl_descr->columns[i];
             str_lower (lc_name, col_descr->name);
             if (strcmp (lc_colname, lc_name) == 0) {
-                foundit = 1;
                 *cp = tbl_descr->columns[i];
-                break;
+                return;
             }
-        }
+        }}
+}
 
-        if (!foundit)
-            *cp = NULL;
+IRAFPointer c_tbcfnd1_retPtr (IRAFPointer tp, const char *colname)
+{
+    void * ptr = NULL;
+    c_tbcfnd1(tp, colname, &ptr);
+    return ptr;
 }

--- a/tables/c_tbegt.c
+++ b/tables/c_tbegt.c
@@ -11,7 +11,7 @@ function c_tbegtd:  table column of type boolean
 function c_tbegtr:  table column of type boolean
 */
 
-void c_tbegtb (IRAFPointer tp, IRAFPointer cp, int row, Bool *buffer) {
+void c_tbegtb (const IRAFPointer tp, const IRAFPointer cp, int row, Bool *buffer) {
 
 /* Read a boolean value from a table column.
 arguments:
@@ -86,7 +86,7 @@ Bool *buffer            o: value (True or False) read from table
         }
 }
 
-void c_tbegtd (IRAFPointer tp, IRAFPointer cp, int row, double *buffer) {
+void c_tbegtd (const IRAFPointer tp, const IRAFPointer cp, int row, double *buffer) {
 
 /* Read a value of type double from a table column.
 arguments:
@@ -145,7 +145,7 @@ double *buffer          o: value read from table
         }
 }
 
-void c_tbegtr (IRAFPointer tp, IRAFPointer cp, int row, float *buffer) {
+void c_tbegtr (const IRAFPointer tp, const IRAFPointer cp, int row, float *buffer) {
 
 /* Read a value of type float from a table column.
 arguments:
@@ -204,7 +204,7 @@ float *buffer           o: value read from table
         }
 }
 
-void c_tbegti (IRAFPointer tp, IRAFPointer cp, int row, int *buffer) {
+void c_tbegti (const IRAFPointer tp, const IRAFPointer cp, int row, int *buffer) {
 
 /* Read an integer value from a table column.
 arguments:
@@ -213,16 +213,13 @@ IRAFPointer cp          i: column descriptor
 int row                 i: row number (one indexed)
 int *buffer             o: value read from table
 */
-
-        TableDescr *tbl_descr;
-        ColumnDescr *col_descr;
         int anynul=0;
         long firstelem=1, nelem=1;
         int nulval=IRAF_INDEFI;
         int status = 0;
 
-        tbl_descr = (TableDescr *)tp;
-        col_descr = (ColumnDescr *)cp;
+        TableDescr *tbl_descr = (TableDescr *)tp;
+        ColumnDescr *col_descr = (ColumnDescr *)cp;
 
         if (col_descr->datatype < 0) {
             char *value;
@@ -263,7 +260,20 @@ int *buffer             o: value read from table
         }
 }
 
-void c_tbegts (IRAFPointer tp, IRAFPointer cp, int row, short *buffer) {
+int c_tbeGetInt (const IRAFPointer tp, const IRAFPointer cp, int row)
+{
+	int ret = 0;
+	c_tbegti(tp, cp, row, &ret);
+	return ret;
+}
+double c_tbeGetDouble (const IRAFPointer tp, const IRAFPointer cp, int row)
+{
+	double ret = 0;
+	c_tbegtd(tp, cp, row, &ret);
+	return ret;
+}
+
+void c_tbegts (const IRAFPointer tp, const IRAFPointer cp, int row, short *buffer) {
 
 /* Read a short integer value from a table column.
 arguments:
@@ -322,7 +332,7 @@ short *buffer           o: value read from table
         }
 }
 
-void c_tbegtt (IRAFPointer tp, IRAFPointer cp, int row, char *buffer,
+void c_tbegtt (const IRAFPointer tp, const IRAFPointer cp, int row, char *buffer,
                 int maxch) {
 
 /* Read a string value from a table column.

--- a/tables/c_tbtclo.c
+++ b/tables/c_tbtclo.c
@@ -7,19 +7,21 @@ void c_tbtclo (IRAFPointer tp) {
 argument:
 IRAFPointer tp          i: table descriptor
 */
+	if (!tp)
+		return;
 
-        TableDescr *tbl_descr;
-        fitsfile *fptr;         /* CFITSIO pointer */
-        int status = 0;
+	TableDescr * tbl_descr = (TableDescr *)tp;
+	fitsfile * fptr = tbl_descr->fptr; //CFITSIO pointer
+	int status = 0;
 
-        if (tp == NULL)
-            return;
+	/* fits_close_file = ffclos */
+	fits_close_file (fptr, &status);
 
-        tbl_descr = (TableDescr *)tp;
-        fptr = tbl_descr->fptr;
+	free_tp (tp);
+}
 
-        /* fits_close_file = ffclos */
-        fits_close_file (fptr, &status);
-
-        free_tp (tp);
+void c_tbtClose (IRAFPointer * tp)
+{
+	c_tbtclo(*tp);
+	*tp = NULL;
 }

--- a/tables/c_tbtopn.c
+++ b/tables/c_tbtopn.c
@@ -16,20 +16,20 @@ IRAFPointer template    i: usually NULL (or 0), but if iomode is IRAF_NEW_COPY
 function value          o: table descriptor
 */
 
-        IRAFPointer tp;
-        TableDescr *tbl_descr;
-        char *fullname;         /* name with environment variable resolved */
-        char *brackets;         /* expression in brackets, or NULL */
-        int hdunum;             /* HDU number (1 for primary HDU) */
-        int hdutype;            /* type of HDU */
-        fitsfile *fptr;         /* CFITSIO pointer */
-        int cf_iomode;          /* CFITSIO I/O mode */
+        IRAFPointer tp = NULL;
+        TableDescr *tbl_descr = NULL;
+        char *fullname = NULL;         /* name with environment variable resolved */
+        char *brackets = NULL;         /* expression in brackets, or NULL */
+        int hdunum;                    /* HDU number (1 for primary HDU) */
+        int hdutype;                   /* type of HDU */
+        fitsfile *fptr = NULL;         /* CFITSIO pointer */
+        int cf_iomode;                 /* CFITSIO I/O mode */
         int status = 0;
 
         clearError();
 
         /* expand environment variable (if any) in tablename */
-        fullname = (char *)calloc (SZ_FNAME+1, sizeof(char));
+        fullname = calloc (SZ_FNAME+1, sizeof(*fullname));
         status = c_vfn2osfn (tablename, fullname);
         if (status != 0) {
             setError (status, "c_tbtopn:  error from c_vfn2osfn");

--- a/wscript
+++ b/wscript
@@ -49,11 +49,11 @@ def options(opt):
     opt.load('compiler_fc')
 
     opt.add_option(
-        '--disable-openmp', action='store_true',
+        '--disable-openmp', action='store_true', default=False,
         help="Disable OpenMP")
 
     opt.add_option(
-        '--debug', action='store_true',
+        '--debug', action='store_true', default=False,
         help="Create a debug build")
 
     opt.add_option(
@@ -238,6 +238,10 @@ Press any key to continue or Ctrl+c to abort...\033[0m"""
             conf.env.append_value('CFLAGS','-Wall')
         if conf.check_cc(cflags='-fstack-protector-all'):
             conf.env.append_value('CFLAGS','-fstack-protector-all')
+
+    if conf.options.releaseWithSymbols and not conf.options.debug:
+        if conf.check_cc(cflags='-g'):
+            conf.env.append_value('CFLAGS', '-g')
 
     if conf.options.releaseWithSymbols and not conf.options.debug:
         if conf.check_cc(cflags='-g'):


### PR DESCRIPTION
This PR appends the boolean parameter 'zeroInitialize'
as an option to call malloc (false) rather than calloc (true)
for the following allocation rounties in hstio.c:

allocFloatData()
allocShortData()
allocHdr()
allocSingleGroup()
allocFloatHdrData()
allocShortHdrData()

It also adds the following new routines to hstio:

void copyDataSection(DataSection * dest, const DataSection * src)
int swapFloatStorageOrder(FloatTwoDArray * target, const FloatTwoDArray * source, enum StorageOrder targetStorageOrder)
int swapShortStorageOrder(ShortTwoDArray * target, const ShortTwoDArray * source, enum StorageOrder targetStorageOrder)
int copyFloatHdrData(FloatHdrData * target, const FloatHdrData * src, enum StorageOrder targetStorageOrder)
int copyShortHdrData(ShortHdrData * target, const ShortHdrData * src, enum StorageOrder targetStorageOrder)
int allocSingleGroupHeader(Hdr ** hdr, Bool zeroInitialize)
int allocSingleGroupExts(SingleGroup *x, int i, int j, unsigned extension, Bool zeroInitialize)
void setStorageOrder(SingleGroup * group, enum StorageOrder storageOrder)
int copySingleGroup(SingleGroup * target, const SingleGroup * source, enum StorageOrder targetStorageOrder)
void copyOffsetSingleGroup(SingleGroup * output, const SingleGroup * input, unsigned nRows, unsigned nColumns, unsigned outputOffset, unsigned inputOffset, unsigned outputSkipLength, unsigned inputSkipLength)
int copyFloatData(FloatTwoDArray * target, const FloatTwoDArray * source, enum StorageOrder targetStorageOrder)
void copyOffsetFloatData(float * output, const float * input, unsigned nRows, unsigned nColumns, unsigned outputOffset, unsigned inputOffset, unsigned outputSkipLength, unsigned inputSkipLength)
int copyShortData(ShortTwoDArray * target, const ShortTwoDArray * source, enum StorageOrder targetStorageOrder)
void copyOffsetShortData(short * output, const short * input, unsigned nRows, unsigned nColumns, unsigned outputOffset, unsigned inputOffset, unsigned outputSkipLength, unsigned inputSkipLength)

Where some allocation routines returned -1 upon error they now return ALLOCATION_PROBLEM

Some other changes exits to facilitate in the above.

void c_tbtClose (IRAFPointer * tp) was added as a wrapper to c_tbtclo(*tp)
such that tp can be set to NULL after being freed. This wrapper was not
swapped out for any existing calls to c_tbtclo(*tp). Though it should be.

Resolves #103 

Signed-off-by: James Noss <jnoss@stsci.edu>