### PR TITLE
Update ACS gen2 CTE algorithm to version 1.2

### DIFF
--- a/ctegen2/ctegen2.c
+++ b/ctegen2/ctegen2.c
@@ -195,7 +195,7 @@ int inverseCTEBlur(const SingleGroup * input, SingleGroup * output, SingleGroup 
     return (status);
 }
 
-int simulatePixelReadout(double * const pixelColumn, const float * const traps, const CTEParamsFast * const ctePars,
+int simulatePixelReadout_v1_1(double * const pixelColumn, const float * const traps, const CTEParamsFast * const ctePars,
         const FloatTwoDArray * const rprof, const FloatTwoDArray * const cprof, const unsigned nRows)
 {
     //For performance this does not NULL check passed in ptrs
@@ -293,7 +293,7 @@ int simulatePixelReadout(double * const pixelColumn, const float * const traps, 
     return HSTCAL_OK;
 }
 
-int simulatePixelReadout_2(double * const pixelColumn, const float * const traps, const CTEParamsFast * const ctePars,
+int simulatePixelReadout_v1_2(double * const pixelColumn, const float * const traps, const CTEParamsFast * const ctePars,
         const FloatTwoDArray * const rprof, const FloatTwoDArray * const cprof, const unsigned nRows)
 {
     //NOTE: this version of the function, simulatePixelReadout, matches Jay Anderson's update
@@ -343,16 +343,12 @@ int simulatePixelReadout_2(double * const pixelColumn, const float * const traps
         for (i = 0; i < nRows; ++i)
         {
             pixel = pixelColumn[i];
-            Bool isInsideTrailLength = nTransfersFromTrap < ctePars->cte_len;
-            //Bool isAboveChargeThreshold = pixel >= ctePars->qlevq_data[w] - 1.;
+            Bool isInsideTrailLength = nTransfersFromTrap <= ctePars->cte_len;
 
             //check if this are needed
             chargeToAdd = 0;
             extraChargeToAdd = 0;
             chargeToRemove = 0;
-
-            //if (!isInsideTrailLength && !isAboveChargeThreshold)
-              //  continue;
 
             /*HAPPENS AFTER FIRST PASS*/
             /*SHUFFLE CHARGE IN*/
@@ -371,8 +367,9 @@ int simulatePixelReadout_2(double * const pixelColumn, const float * const traps
                     chargeToAdd = rprof->data[w*rprof->ny + nTransfersFromTrap-1] * trappedFlux;
                     extraChargeToAdd = cprof->data[w*cprof->ny + nTransfersFromTrap-1] * trappedFlux;
                 }
-                chargeToRemove = ctePars->dpdew_data[w] / ctePars->n_par * (double)traps[i];
-                trappedFlux = 0;
+                trappedFlux = ctePars->dpdew_data[w] / ctePars->n_par * (double)traps[i];
+                chargeToRemove = trappedFlux;
+                nTransfersFromTrap = 0;
             }
             else
             {
@@ -399,7 +396,7 @@ int simulateColumnReadout(double * const pixelColumn, const float * const traps,
     {unsigned shift;
     for (shift = 1; shift <= nPixelShifts; ++shift)
     {
-        if ((localStatus = simulatePixelReadout(pixelColumn, traps, cte, rprof, cprof, nRows)))
+        if ((localStatus = simulatePixelReadout_v1_2(pixelColumn, traps, cte, rprof, cprof, nRows)))
             return localStatus;
     }}
 

--- a/ctegen2/ctegen2.h
+++ b/ctegen2/ctegen2.h
@@ -80,10 +80,10 @@ typedef struct {
 int inverseCTEBlurWithRowMajorIput(const SingleGroup * rsz, SingleGroup * rsc, const SingleGroup * trapPixelMap, CTEParamsFast * cte);
 int inverseCTEBlur(const SingleGroup * rsz, SingleGroup * rsc, SingleGroup * trapPixelMap, CTEParamsFast * cte);
 
-int simulatePixelReadout(double * const pixelColumn, const float * const traps, const CTEParamsFast * const cte,
+int simulatePixelReadout_v1_1(double * const pixelColumn, const float * const traps, const CTEParamsFast * const cte,
         const FloatTwoDArray * const rprof, const FloatTwoDArray * const cprof, const unsigned nRows);
 
-int simulatePixelReadout_2(double * const pixelColumn, const float * const traps, const CTEParamsFast * const cte,
+int simulatePixelReadout_v1_2(double * const pixelColumn, const float * const traps, const CTEParamsFast * const cte,
         const FloatTwoDArray * const rprof, const FloatTwoDArray * const cprof, const unsigned nRows);
 
 int simulateColumnReadout(double * const pixelColumn, const float * const traps, const CTEParamsFast * const cte,

--- a/pkg/acs/calacs/acscte/docte.c
+++ b/pkg/acs/calacs/acscte/docte.c
@@ -182,19 +182,6 @@ int DoCTE (ACSInfo *acs_info) {
         else
             cteAlgorithmGen = 1;
 
-        /*###################################################
-         *#                                                 #
-         *#   Short circuit to existing gen 1 algorithm     #
-         *#   for initial 2017.2 release to DMS.            #
-         *#   Remove this as a quick fix once the ACS       #
-         *#   team is sure of what they are doing and have  #
-         *#   a completely pinned PCTETAB reference file.   #
-         *#                                                 #
-         *###################################################
-         */
-        acs_info->cteAlgorithmGen = 1;
-        //###################################################
-
         if (acs_info->cteAlgorithmGen && (acs_info->cteAlgorithmGen != cteAlgorithmGen))
         {
             char msgBuffer[256];
@@ -275,7 +262,7 @@ int DoCTE (ACSInfo *acs_info) {
                     return status;
             }
             double time_spent = ((double) clock()- begin +0.0) / CLOCKS_PER_SEC;
-            sprintf(MsgText,"(pctecorr) CTE run time for current amp: %.2f(s) with %i procs/threads\n", time_spent/acs_info->nThreads, acs_info->nThreads);
+            sprintf(MsgText,"(pctecorr) CTE run time for current chip: %.2f(s) with %i procs/threads\n", time_spent/acs_info->nThreads, acs_info->nThreads);
             trlmessage(MsgText);
         }
         freeOnExit(&ptrReg);


### PR DESCRIPTION
This also alows the gen2 algorithm to be used as it
reverts "Short circuit CTE algoithm to previous gen1 for initial 2017.2 release to DMS"

Resolves #110

Signed-off-by: James Noss <jnoss@stsci.edu>