### PR TITLE
ACS CTE: correct PCTETAB in corrected image file header from --pctetab <file>

### DIFF
--- a/ctegen2/ctehelpers.c
+++ b/ctegen2/ctehelpers.c
@@ -339,7 +339,6 @@ No.    Name         Type      Cards   Dimensions   Format
         status = KEYWORD_MISSING;
         return status;
     }
-
     sprintf(MsgText,"PCTETRSH: %g",pars->thresh);
     trlmessage(MsgText);
 
@@ -349,11 +348,8 @@ No.    Name         Type      Cards   Dimensions   Format
         status = KEYWORD_MISSING;
         return status;
     }
-
-    /*
     sprintf(MsgText,"FIXROCR: %d",pars->fix_rocr);
     trlmessage(MsgText);
-    */
 
 
     /* DONE READING STUFF FROM THE PRIMARY HEADER */
@@ -628,68 +624,68 @@ int populateHeaderWithCTEKeywordValues(SingleGroup *group, CTEParamsFast *pars)
 
     if ((status = PutKeyStr(group->globalhdr,"CTE_NAME", pars->cte_name, "CTE algorithm name")))
     {
-        trlmessage("(pctecorr) Error updating CTE_NAME keyword in image header");
+        trlerror("(pctecorr) failed to update CTE_NAME keyword in image header");
         return status;
     }
 
     if ((status = PutKeyStr(group->globalhdr,"CTE_VER", pars->cte_ver, "CTE algorithm version")))
     {
-        trlmessage("(pctecorr) Error updating CTE_VER keyword in image header");
+        trlerror("(pctecorr) failed to update CTE_VER keyword in image header");
         return status;
     }
 
     if ((status = PutKeyDbl(group->globalhdr, "CTEDATE0", pars->cte_date0,"Date of UVIS installation")))
     {
-        trlmessage("(pctecorr) Error putting CTEDATE0 keyword in header");
+        trlerror("(pctecorr) failed to update CTEDATE0 keyword in header");
         return status;
     }
 
     if ((status = PutKeyDbl(group->globalhdr, "PCTETRSH", pars->thresh,"CTE over subtraction threshold")))
     {
-        trlmessage("(pctecorr) Error putting PCTETRSH keyword in header");
+        trlerror("(pctecorr) failed to update PCTETRSH keyword in header");
         return status;
     }
 
 
     if ((status = PutKeyDbl(group->globalhdr, "CTEDATE1", pars->cte_date1, "Date of CTE model pinning")))
     {
-        trlmessage("(pctecorr) Error putting CTEDATE1 keyword in header");
+        trlerror("(pctecorr) failed to update CTEDATE1 keyword in header");
         return status;
     }
 
     if ((status = PutKeyDbl(group->globalhdr, "PCTEFRAC", pars->scale_frac, "CTE scaling factor")))
     {
-        trlmessage("(pctecorr) Error writing PCTEFRAC to image header");
+        trlerror("(pctecorr) failed to update PCTEFRAC to image header");
         return status;
     }
 
     if ((status = PutKeyInt(group->globalhdr,"PCTETLEN",pars->cte_len,"max length of CTE trail")))
     {
-        trlmessage("(pctecorr) Error updating PCTETLEN in header");
+        trlerror("(pctecorr) failed to update PCTETLEN in header");
         return status;
     }
 
     if ((status = PutKeyDbl(group->globalhdr, "PCTERNOI", pars->rn_amp,"read noise amp clip limit")))
     {
-        trlmessage("(pctecorr) Error updating PCTERNOI in header");
+        trlerror("(pctecorr) failed to update PCTERNOI in header");
         return status;
     }
 
     if ((status = PutKeyInt(group->globalhdr, "PCTENFOR",pars->n_forward,"Number of iter in forward model")))
     {
-        trlmessage("(pctecorr) Error updating PCTENFOR in header");
+        trlerror("(pctecorr) failed to update PCTENFOR in header");
         return status;
     }
 
     if ((status = PutKeyInt(group->globalhdr, "PCTENPAR",pars->n_par,"Number of iter in parallel transfer")))
     {
-        trlmessage("(pctecorr) Error updating PCTENPAR in header");
+        trlerror("(pctecorr) failed to update PCTENPAR in header");
         return status;
     }
 
     if ((status = PutKeyInt(group->globalhdr,"FIXROCR",pars->fix_rocr,"fix readout cosmic rays")))
     {
-        trlmessage("(pctecorr) Error updating FIXROCR keyword in header");
+        trlerror("(pctecorr) failed to update FIXROCR keyword in header");
         return status;
     }
 
@@ -714,7 +710,7 @@ int getCTEParsFromImageHeader(SingleGroup *group, CTEParamsFast *pars) {
         pars->noise_mit = noise_mit;
     else if (tempStatus != KEYWORD_MISSING)
     {
-        trlmessage("(pctecorr) Error reading PCTENSMD keyword from header");
+        trlerror("(pctecorr) Error reading PCTENSMD keyword from header");
         return (status = tempStatus);
     }
     else if (tempStatus == KEYWORD_MISSING)
@@ -729,7 +725,7 @@ int getCTEParsFromImageHeader(SingleGroup *group, CTEParamsFast *pars) {
     }
     else if (tempStatus != KEYWORD_MISSING)
     {
-        trlmessage("(pctecorr) Error reading PCTETLEN keyword from header");
+        trlerror("(pctecorr) Error reading PCTETLEN keyword from header");
         return (status = tempStatus);
     }
     else if (tempStatus == KEYWORD_MISSING)
@@ -744,7 +740,7 @@ int getCTEParsFromImageHeader(SingleGroup *group, CTEParamsFast *pars) {
     }
     else if (tempStatus != KEYWORD_MISSING)
     {
-        trlmessage("(pctecorr) Error reading PCTERNOI keyword from header");
+        trlerror("(pctecorr) Error reading PCTERNOI keyword from header");
         return (status = tempStatus);
     }
     else if (tempStatus == KEYWORD_MISSING)
@@ -759,7 +755,7 @@ int getCTEParsFromImageHeader(SingleGroup *group, CTEParamsFast *pars) {
     }
     else if (tempStatus != KEYWORD_MISSING)
     {
-        trlmessage("(pctecorr) Error reading PCTENFOR keyword from header");
+        trlerror("(pctecorr) Error reading PCTENFOR keyword from header");
         return (status = tempStatus);
     }
     else if (tempStatus == KEYWORD_MISSING)
@@ -774,7 +770,7 @@ int getCTEParsFromImageHeader(SingleGroup *group, CTEParamsFast *pars) {
     }
     else if (tempStatus != KEYWORD_MISSING)
     {
-        trlmessage("(pctecorr) Error reading PCTENPAR keyword from header");
+        trlerror("(pctecorr) Error reading PCTENPAR keyword from header");
         return (status = tempStatus);
     }
     else if (tempStatus == KEYWORD_MISSING)
@@ -797,7 +793,7 @@ int getCTEParsFromImageHeader(SingleGroup *group, CTEParamsFast *pars) {
     }
     else if (tempStatus != KEYWORD_MISSING)
     {
-        trlmessage("(pctecorr) Error reading FIXROCR keyword from header");
+        trlerror("(pctecorr) Error reading FIXROCR keyword from header");
         return (status = tempStatus);
     }
     else if (tempStatus == KEYWORD_MISSING)

--- a/pkg/acs/calacs/acscte/docte.c
+++ b/pkg/acs/calacs/acscte/docte.c
@@ -212,11 +212,11 @@ int DoCTE (ACSInfo *acs_info) {
         {
             sprintf(MsgText, "(pctecorr) Reading CTE parameters from PCTETAB file: '%s'...", cteTabFilename);
             trlmessage(MsgText);
-            /*if ((status = PutKeyStr(x[0].globalhdr, "PCTETAB", cteTabFilename, "CTE Correction Table")))
+            if ((status = PutKeyStr(x[0].globalhdr, "PCTETAB", cteTabFilename, "CTE Correction Table")))
             {
-                trlmessage("(pctecorr) Error updating PCTETAB keyword in image header");
+                trlerror("(pctecorr) failed to update PCTETAB keyword in image header");
                 return status;
-            }*/
+            }
             //Get parameters from PCTETAB reference file
             addPtr(&ptrReg, &ctePars, &freeCTEParamsFast);
             unsigned nScaleTableColumns = N_COLUMNS_FOR_RAZ_CDAB_ALIGNED_IMAGE;


### PR DESCRIPTION
This also corrects some trlmessages() being used as errors to trlerror

resolves #123

Signed-off-by: James Noss <jnoss@stsci.edu>