### PR TITLE
Memory corruption in PtrRegister::freeReg()

### DIFF
--- a/hstio/hstio.c
+++ b/hstio/hstio.c
@@ -123,27 +123,31 @@ const char *hstio_version = HSTIO_VERSION;
 
 void initPtrRegister(PtrRegister * reg)
 {
-    reg->cursor = 0; //points to last ptr NOT next slot
+    if (!reg)
+        return;
+
+    reg->cursor = -1; //when >= 0 => points to last ptr NOT next slot
     reg->length = PTR_REGISTER_LENGTH_INC;
-    reg->ptrs = calloc(reg->length+1, sizeof(*reg->ptrs));
+    reg->ptrs = malloc(reg->length*sizeof(*reg->ptrs));
     assert(reg->ptrs);
-    reg->freeFunctions = calloc(reg->length+1, sizeof(*reg->freeFunctions));
+    reg->freeFunctions = malloc(reg->length*sizeof(*reg->freeFunctions));
     if (!reg->freeFunctions)
     {
         free(reg->ptrs);
         assert(0);
     }
-    reg->ptrs[0] = reg; //this ptr
-    reg->freeFunctions[0] = &free;
 }
 void addPtr(PtrRegister * reg, void * ptr, void * freeFunc)
 {
     if (!reg || !ptr || !freeFunc)
         return;
 
+    //guard against incorrect use of adding self
+    assert(ptr != reg); //Sorry this is not allowed - reg must be owned by a scope
+
     //check ptr isn't already registered? - go on then.
     {int i;
-    for (i = reg->cursor; i >= 0 ; --i)// i >= 0 prevents adding self again
+    for (i = reg->cursor; i >= 0 ; --i)
     {
         if (reg->ptrs[i] == ptr)
             return;
@@ -152,20 +156,19 @@ void addPtr(PtrRegister * reg, void * ptr, void * freeFunc)
     if (++reg->cursor >= reg->length)
     {
         reg->length += PTR_REGISTER_LENGTH_INC;
-        assert(realloc(&reg->ptrs, reg->length*sizeof(*reg->ptrs)));
-        assert(realloc(reg->freeFunctions, reg->length*sizeof(*reg->freeFunctions)));
+        assert(reg->ptrs = realloc(reg->ptrs, reg->length*sizeof(*reg->ptrs)));
+        assert(reg->freeFunctions = realloc(reg->freeFunctions, reg->length*sizeof(*reg->freeFunctions)));
     }
     reg->ptrs[reg->cursor] = ptr;
     reg->freeFunctions[reg->cursor] = freeFunc;
 }
 void freePtr(PtrRegister * reg, void * ptr)
 {
-    //Can't be used to free itself, use freeReg(), use of i > 0 in below for is reason.
-    if (!reg || !ptr)
+    if (!reg || !ptr || reg->cursor < 0)
         return;
 
     int i;
-    for (i = reg->cursor; i > 0 ; --i)
+    for (i = reg->cursor; i >= 0 ; --i)
     {
         if (reg->ptrs[i] == ptr)
             break;
@@ -191,42 +194,33 @@ void freePtr(PtrRegister * reg, void * ptr)
 }
 void freeAll(PtrRegister * reg)
 {
-    if (!reg || reg->length == 0 || reg->cursor == 0)
+    if (!reg || !reg->length || reg->cursor < 0)
         return;
 
-    {unsigned i;
-    for (i = 1; i <= reg->cursor; ++i)
-    {
-        if (reg->freeFunctions[i] && reg->ptrs[i])
-        {
-            reg->freeFunctions[i](reg->ptrs[i]);
-            reg->ptrs[i] = NULL;
-            reg->freeFunctions[i] = NULL;
-        }
-    }}
-    reg->cursor = 0;
+    while (reg->cursor >= 0)
+        freePtr(reg, reg->ptrs[reg->cursor]);
 }
 void freeReg(PtrRegister * reg)
 {
-    if (!reg || reg->length == 0)
+    if (!reg || !reg->length)
         return;
 
-    if (reg->cursor > 0)
+    if (reg->cursor >= 0)
         freeAll(reg);
 
-    reg->cursor = 0;
+    reg->cursor = -1;
     reg->length = 0;
-    // free 'itself'
-    reg->freeFunctions[0](reg->ptrs);
-    reg->ptrs[0] = NULL;
-    reg->freeFunctions[0](reg->freeFunctions);
-    reg->freeFunctions[0] = NULL;
+    //free registers
+    free(reg->ptrs);
+    reg->ptrs = NULL;
+    free(reg->freeFunctions);
+    reg->freeFunctions = NULL;
 }
 void freeOnExit(PtrRegister * reg)
 {
-    //Free everything registered
+    //free everything registered
     freeAll(reg);
-    //Free itself
+    //free registers
     freeReg(reg);
 }
 

--- a/include/hstio.h
+++ b/include/hstio.h
@@ -135,7 +135,7 @@ extern "C" {
  * ...
  * if (cancel)
  * {
- *     freeOnExit(&ptrReg); // This frees itself, i.e. the register array holding the ptrs
+ *     freeOnExit(&ptrReg); // This frees everything including the register arrays holding the ptrs & freeFunctions
  *     return;
  * }
  * ...
@@ -146,8 +146,8 @@ extern "C" {
 typedef void (*FreeFunction)(void*); // Only trivial functions accepted
 #define PTR_REGISTER_LENGTH_INC 10
 typedef struct {
-    unsigned cursor;
-    unsigned length;
+    int cursor; //when >= 0 => points to last ptr NOT next slot
+    unsigned length; //length of ptrs & freeFunctions
     void ** ptrs;
     FreeFunction * freeFunctions;
 } PtrRegister;
@@ -155,8 +155,8 @@ void initPtrRegister(PtrRegister * reg);
 void addPtr(PtrRegister * reg, void * ptr, void * freeFunc); // ptr list is self expanding
 void freePtr(PtrRegister * reg, void * ptr);
 void freeOnExit(PtrRegister * reg); //only calls freeAll() followed by freeReg()
-void freeAll(PtrRegister * reg); // frees all ptrs registered (excluding itself)
-void freeReg(PtrRegister * reg); // frees itself i.e. the register array holding the ptrs
+void freeAll(PtrRegister * reg); // frees all ptrs registered
+void freeReg(PtrRegister * reg); // frees the register arrays holding the ptrs & freeFunctions
 
 # define SZ_PATHNAME 511
 


### PR DESCRIPTION
This also does some refactoring to remove 'this' pointer
being stored as 0th pointer in register

fixes #133

Signed-off-by: James Noss <jnoss@stsci.edu>