### PR TITLE
PtrRegister::freeReg() should NOT call freeAll()

### DIFF
--- a/hstio/hstio.c
+++ b/hstio/hstio.c
@@ -208,11 +208,16 @@ void freeAll(PtrRegister * reg)
 }
 void freeReg(PtrRegister * reg)
 {
+    /* THIS SHOULD NEVER CALL freeALL()
+     * This is designed to be used when allocating multiple persistent memory allocations,
+     * registering each allocation in turn. If one allocation fails freeOnExit() can be
+     * called to free prior successful allocations and if all allocations are successful
+     * this function can be called to free the registers without freeing the actual
+     * pointers just allocated.
+     */
+
     if (!reg || reg->length == 0)
         return;
-
-    if (reg->cursor > 0)
-        freeAll(reg);
 
     reg->cursor = 0;
     reg->length = 0;

--- a/include/hstio.h
+++ b/include/hstio.h
@@ -156,7 +156,7 @@ void addPtr(PtrRegister * reg, void * ptr, void * freeFunc); // ptr list is self
 void freePtr(PtrRegister * reg, void * ptr);
 void freeOnExit(PtrRegister * reg); //only calls freeAll() followed by freeReg()
 void freeAll(PtrRegister * reg); // frees all ptrs registered (excluding itself)
-void freeReg(PtrRegister * reg); // frees itself i.e. the register array holding the ptrs
+void freeReg(PtrRegister * reg); //frees ONLY the registers themselves and NOT the pointers in PtrRegister::ptrs
 
 # define SZ_PATHNAME 511
 


### PR DESCRIPTION
relates to #135

Signed-off-by: James Noss <jnoss@stsci.edu>