### PR TITLE
Bump ACS version to 9.2.0

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,4 +1,4 @@
- 28-Apr-2017:  CALACS 9.1.0 New CTE algorithm implemented
+ 01-Jun-2017:  CALACS 9.2.0 New CTE algorithm implemented.
  21-Feb-2017:  CALACS 9.1.0 New SINKCORR step added in ACSCCD for WFC.
  22-Nov-2016:  CALACS 9.0.0 BLEVCORR now uses new OSCNTAB that correctly
                             process all subarrays.

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,7 +1,8 @@
-### 28-Apr-2017 - JAN -- Version 9.1.0
-	New CTE algorithm implemented. Use of either new (gen2) & old (gen1) 
-	dynamically detected from CTE_NAME in PCTETAB.
-	New cmd line options added: --ntherads <n>, --ctegen <1|2>, --pctetab <filename>
+### 01-Jun-2017 - JAN -- Version 9.2.0
+    New CTE algorithm implemented. Use of either new (gen2) & old (gen1) 
+    dynamically detected from CTE_NAME in PCTETAB, however --ctegen 1 is explicitly
+    required to override the gen2 default.
+    New cmd line options added: --ntherads <n>, --ctegen <1|2>, --pctetab <filename>
 
 ### 21-Feb-2017 - PLL -- Version 9.1.0
     New SINKCORR step is added to ACSCCD for WFC.

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,34 @@
+Update for version 9.2.0 - 01-Jun-2017 (JAN) : git diff f0c177019cb4c159c801e0228be058269701f577  6472dcef5b86b1c240b35933e5bc7284c53dbafd --name-only
+    ctegen2/ctegen2.c
+    ctegen2/ctegen2.h
+    ctegen2/ctehelpers.c
+    ctegen2/wscript
+    hstio/hstio.c
+    include/hstio.h
+    pkg/acs/calacs/Dates
+    pkg/acs/calacs/History
+    pkg/acs/calacs/Updates
+    pkg/acs/calacs/acscte/acscte.c
+    pkg/acs/calacs/acscte/docte.c
+    pkg/acs/calacs/acscte/dopcte-gen2.c
+    pkg/acs/calacs/acscte/dopcte.c
+    pkg/acs/calacs/acscte/getcteflag.c
+    pkg/acs/calacs/acscte/maincte.c
+    pkg/acs/calacs/acscte/pcte.h
+    pkg/acs/calacs/acscte/pcte_fixycte.c
+    pkg/acs/calacs/acscte/pcte_funcs.c
+    pkg/acs/calacs/acscte/wscript
+    pkg/acs/calacs/calacs/acsmain.c
+    pkg/acs/calacs/calacs/calacs.c
+    pkg/acs/calacs/calacs/calacs.h
+    pkg/acs/calacs/include/acs.h
+    pkg/acs/calacs/include/acsinfo.h
+    pkg/acs/calacs/include/acsversion.h
+    pkg/acs/calacs/lib/acsinfo.c
+    pkg/acs/calacs/lib/ucalver.c
+    pkg/acs/calacs/lib/wscript
+    wscript
+
 Update for version 9.1.0 - 21-Feb-17 (PLL)
     acsccd/doccd.c
     acsccd/dosink.c

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -1,6 +1,6 @@
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "9.1.0 (21-Feb-2017)"
-#define ACS_CAL_VER_NUM "9.1.0"
+#define ACS_CAL_VER "9.2.0 (01-Jun-2017)"
+#define ACS_CAL_VER_NUM "9.2.0"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
This updates the following files:

pkg/acs/calacs/Dates
pkg/acs/calacs/History
pkg/acs/calacs/Updates
pkg/acs/calacs/include/acsversion.h

resolves #146

Signed-off-by: James Noss <jnoss@stsci.edu>