### PR TITLE
Make main CTE loop over columns dynamic rather than static

### DIFF
--- a/ctegen2/ctegen2.c
+++ b/ctegen2/ctegen2.c
@@ -97,7 +97,7 @@ int inverseCTEBlur(const SingleGroup * input, SingleGroup * output, SingleGroup 
             Bool localOK = True;
             {unsigned j;
 #ifdef _OPENMP
-            #pragma omp for schedule(static)
+            #pragma omp for schedule(dynamic)
 #endif
             for (j = 0; j < nColumns; ++j)
             {


### PR DESCRIPTION
This should reduce possible runtimes being held up by contended cores when run as
the default 'greedy' mode.

resolves #152 

Signed-off-by: James Noss <jnoss@stsci.edu>