### PR TITLE
ACS "unrecognised option" error should also print syntax

### DIFF
--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -30,6 +30,11 @@ static void FreeNames (char *, char *, char *, char *);
 
  */
 
+static void printSyntax()
+{
+    printf ("syntax:  acscte.e [-t] [-v] [-q] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input [output]\n");
+}
+
 int main (int argc, char **argv) {
 
     char *inlist;		/* input blv_tmp file name */
@@ -155,6 +160,7 @@ int main (int argc, char **argv) {
                 if (argv[i][1] == '-')
                 {
                     printf ("Unrecognized option %s\n", argv[i]);
+                    printSyntax();
                     exit (ERROR_RETURN);
                 }
                 for (j = 1;  argv[i][j] != '\0';  j++) {
@@ -168,6 +174,7 @@ int main (int argc, char **argv) {
                         onecpu = YES;
                     } else {
                         printf ("Unrecognized option %s\n", argv[i]);
+                        printSyntax();
                         break;
                     }
                 }
@@ -181,7 +188,7 @@ int main (int argc, char **argv) {
         }
     }
     if (inlist[0] == '\0' || too_many) {
-        printf ("syntax:  acscte [-t] [-v] [-q] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input output\n");
+        printSyntax();
         FreeNames (inlist, outlist, input, output);
         exit (ERROR_RETURN);
     }

--- a/pkg/acs/calacs/calacs/acsmain.c
+++ b/pkg/acs/calacs/calacs/acsmain.c
@@ -15,6 +15,11 @@
 
 int	status;		/* value of zero indicates OK */
 
+static void printSyntax()
+{
+    printf ("syntax:  calacs.e [-t] [-s] [-v] [-q] [-r] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input \n");
+}
+
 int main(int argc, char **argv) {
 
 	/* Local variables */
@@ -111,6 +116,7 @@ int main(int argc, char **argv) {
             if (argv[i][1] == '-')
             {
                 printf ("Unrecognized option %s\n", argv[i]);
+                printSyntax();
                 exit (ERROR_RETURN);
             }
             for (j = 1;  argv[i][j] != '\0';  j++)
@@ -132,6 +138,7 @@ int main(int argc, char **argv) {
                     onecpu = YES;
                 } else {
                     printf ("Unrecognized option %s\n", argv[i]);
+                    printSyntax();
                     exit (ERROR_RETURN);
                 }
             }
@@ -144,7 +151,7 @@ int main(int argc, char **argv) {
 
     if (input[0] == '\0' || too_many) {
         printf ("CALACS Version %s\n",ACS_CAL_VER_NUM);
-        printf ("syntax:  calacs.e [-t] [-s] [-v] [-q] [-r] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input \n");
+        printSyntax();
         exit (ERROR_RETURN);
     }
 


### PR DESCRIPTION
resolves #169

Note: This also corrects the acscte syntax listing 'output' as optional
i.e. [output].

Signed-off-by: James Noss <jnoss@stsci.edu>