### PR TITLE
Update SINKCORR keyword and HISTORY when done

### DIFF
--- a/pkg/acs/calacs/acsccd/doccd.c
+++ b/pkg/acs/calacs/acsccd/doccd.c
@@ -69,6 +69,7 @@ int DoCCD (ACSInfo *acs_info) {
     int doNoise (ACSInfo *, SingleGroup *, int *);
     int noiseHistory (Hdr *);
     int SinkDetect (ACSInfo *, SingleGroup *);
+    int sinkHistory(ACSInfo *, Hdr *);
     int GetACSGrp (ACSInfo *, Hdr *);
     int OmitStep (int);
     int PutKeyFlt (Hdr *, char *, float, char *);
@@ -438,6 +439,10 @@ int DoCCD (ACSInfo *acs_info) {
         if (acs_info->printtime)
             TimeStamp("SINKCORR complete", acs_info->rootname);
     }
+
+    if (!OmitStep(acs[0].sinkcorr))
+        if (sinkHistory(&acs[0], x[0].globalhdr))
+            return (status);
     /************************************************************************/
 
     /* Write this imset to the output file.  The


### PR DESCRIPTION
Fix #172 

Follow-up of #64

Update -- Output with this fix will have the following in its primary header when SINKCORR is applied successfully:

```
SINKCORR= 'COMPLETE'           /                  
SNKCFILE= 'xxxxxxxx_snk.fits'     
...
HISTORY SINKCORR complete ...                                                   
HISTORY   reference image xxxxxxxx_snk.fits                                        
HISTORY     INFLIGHT 27/07/2016 22/08/2016                                      
HISTORY     Sink pixel reference file ---------------------------- 
```