### PR TITLE
Don't write to trailer file after trlbuf has been freed and file closed

### DIFF
--- a/pkg/acs/calacs/acs2d/main2d.c
+++ b/pkg/acs/calacs/acs2d/main2d.c
@@ -207,8 +207,8 @@ int main (int argc, char **argv) {
         status = 1;
 
     if (status) {
-        CloseTrlBuf ();
         FreeNames (inlist, outlist, input, output);
+        CloseTrlBuf ();
         exit (ERROR_RETURN);
     }
 

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -238,9 +238,9 @@ int main (int argc, char **argv) {
     /* Close lists of file names, and free name buffers. */
     c_imtclose (i_imt);
     c_imtclose (o_imt);
-    CloseTrlBuf();
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
+    CloseTrlBuf();
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -333,9 +333,9 @@ int main (int argc, char **argv) {
     /* Close lists of file names, and free name buffers. */
     c_imtclose (i_imt);
     c_imtclose (o_imt);
-    CloseTrlBuf();
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
+    CloseTrlBuf();
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/acs/calacs/acsrej/mainrej.c
+++ b/pkg/acs/calacs/acsrej/mainrej.c
@@ -54,14 +54,14 @@ int main (int argc, char **argv) {
         asnerror (MsgText);
     }
 
-    CloseTrlBuf ();
-
     if (status) {
         WhichError (status);
         FreeNames(input);
+        CloseTrlBuf ();
         exit (ERROR_RETURN);
     } else {
         FreeNames(input);
+        CloseTrlBuf ();
         exit (0);
     }
 }

--- a/pkg/acs/calacs/acssum/mainsum.c
+++ b/pkg/acs/calacs/acssum/mainsum.c
@@ -105,10 +105,10 @@ int main (int argc, char **argv) {
 	if (output[0] == '\0') {
 	    if (MkName (input, "_asn", "_sfl", "", output, CHAR_LINE_LENGTH))
         {
-            CloseTrlBuf ();
             free (input);
             free (output);
             WhichError (status);
+            CloseTrlBuf ();
             exit (ERROR_RETURN);
         }
 	}

--- a/pkg/acs/calacs/lib/trlbuf.c
+++ b/pkg/acs/calacs/lib/trlbuf.c
@@ -676,8 +676,17 @@ void CloseTrlBuf (void) {
 
     cleanup: ;
 
-        free (trlbuf.buffer);
-        free (trlbuf.preface);
+        if (trlbuf.buffer)
+        {
+            free (trlbuf.buffer);
+            trlbuf.buffer = NULL;
+        }
+
+        if (trlbuf.preface)
+        {
+            free (trlbuf.preface);
+            trlbuf.preface = NULL;
+        }
 
         if (trlbuf.fp != NULL) {
             fclose (trlbuf.fp);

--- a/pkg/wfc3/calwf3/lib/trlbuf.c
+++ b/pkg/wfc3/calwf3/lib/trlbuf.c
@@ -628,8 +628,17 @@ void CloseTrlBuf (void) {
 
     cleanup: ;
 
-        free (trlbuf.buffer);
-        free (trlbuf.preface);
+        if (trlbuf.buffer)
+        {
+            free (trlbuf.buffer);
+            trlbuf.buffer = NULL;
+        }
+
+        if (trlbuf.preface)
+        {
+            free (trlbuf.preface);
+            trlbuf.preface = NULL;
+        }
 
         if (trlbuf.fp != NULL) {
             fclose (trlbuf.fp);

--- a/pkg/wfc3/calwf3/wf32d/main2d.c
+++ b/pkg/wfc3/calwf3/wf32d/main2d.c
@@ -188,8 +188,8 @@ int main (int argc, char **argv) {
 	    status = 1;
 		
 	if (status) {
-	    CloseTrlBuf ();
 	    FreeNames (inlist, outlist, input, output);
+        CloseTrlBuf ();
 	    exit (ERROR_RETURN);
 	}
 

--- a/pkg/wfc3/calwf3/wf3ccd/mainccd.c
+++ b/pkg/wfc3/calwf3/wf3ccd/mainccd.c
@@ -226,9 +226,9 @@ int main (int argc, char **argv) {
 	/* Close lists of file names, and free name buffers. */
 	c_imtclose (i_imt);
 	c_imtclose (o_imt);
-	CloseTrlBuf();
 	FreeRefFile (&refnames);
 	FreeNames (inlist, outlist, input, output);
+    CloseTrlBuf();
 
 	if (status)
 	    exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3cte/maincte.c
+++ b/pkg/wfc3/calwf3/wf3cte/maincte.c
@@ -230,9 +230,9 @@ int main (int argc, char **argv) {
     /* Close lists of file names, and free name buffers. */
     c_imtclose (i_imt);
     c_imtclose (o_imt);
-    CloseTrlBuf();
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
+    CloseTrlBuf();
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3ir/mainir.c
+++ b/pkg/wfc3/calwf3/wf3ir/mainir.c
@@ -216,9 +216,9 @@ int main (int argc, char **argv) {
 	/* Close lists of file names, and free name buffers. */
 	c_imtclose (i_imt);
 	c_imtclose (o_imt);
-	CloseTrlBuf();
 	FreeRefFile (&refnames);
 	FreeNames (inlist, outlist, input, output);
+    CloseTrlBuf();
 
 	if (status)
 	    exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3rej/mainrej.c
+++ b/pkg/wfc3/calwf3/wf3rej/mainrej.c
@@ -55,12 +55,13 @@ int main (int argc, char **argv) {
         asnerror (MsgText);
     }
 
-    CloseTrlBuf ();
 
     if (status) {
         WhichError (status);
+        CloseTrlBuf ();
         exit (ERROR_RETURN);
     } else{
+        CloseTrlBuf ();
         exit (status);
     }
 }

--- a/pkg/wfc3/calwf3/wf3sum/mainsum.c
+++ b/pkg/wfc3/calwf3/wf3sum/mainsum.c
@@ -112,10 +112,10 @@ int main (int argc, char **argv) {
 
 	if (output[0] == '\0') {
 	    if (MkName (input, "_asn", "_sfl", "", output, CHAR_LINE_LENGTH)) {
-		CloseTrlBuf ();
 		free (input);
 		free (output);
 		WhichError (status);
+        CloseTrlBuf ();
 		exit (ERROR_RETURN);
 	    }
 	}


### PR DESCRIPTION
fixes #196

This also makes trlbuf.buffer and trlbuf.preface NULL after freed.

Signed-off-by: James Noss <jnoss@stsci.edu>