### PR TITLE
Add --help cmd option to print syntax

### DIFF
--- a/pkg/acs/calacs/acs2d/main2d.c
+++ b/pkg/acs/calacs/acs2d/main2d.c
@@ -23,7 +23,11 @@ int status = 0;			/* zero is OK */
 static void FreeNames (char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf("syntax:  acs2d [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+    printf("syntax:  acs2d [--help] [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* Standard string buffer for use in messages */
@@ -149,6 +153,11 @@ int main (int argc, char **argv) {
             if (!(strcmp(argv[i],"--gitinfo")))
             {
                 printGitInfo();
+                exit(0);
+            }
+            if (!(strcmp(argv[i],"--help")))
+            {
+                printHelp();
                 exit(0);
             }
             for (j = 1;  argv[i][j] != '\0';  j++) {

--- a/pkg/acs/calacs/acs2d/main2d.c
+++ b/pkg/acs/calacs/acs2d/main2d.c
@@ -21,10 +21,14 @@ int status = 0;			/* zero is OK */
 #include "trlbuf.h"
 
 static void FreeNames (char *, char *, char *, char *);
-struct TrlBuf trlbuf = { 0 };
+static void printSyntax(void)
+{
+    printf("syntax:  acs2d [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+}
 
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
+struct TrlBuf trlbuf = { 0 };
 
 /* This is the main module for acs2d.  It gets the input and output
    file names, calibration switches, and flags, and then calls acs2d.
@@ -156,6 +160,7 @@ int main (int argc, char **argv) {
                     quiet = YES;
                 } else {
                     printf ("Unrecognized option %s\n", argv[i]);
+                    printSyntax();
                     FreeNames (inlist, outlist, input, output);
                     exit (1);
                 }
@@ -169,7 +174,7 @@ int main (int argc, char **argv) {
         }
     }
     if (inlist[0] == '\0' || too_many) {
-        printf ("syntax:  acs2d [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+        printSyntax();
         /*
         printf ("  command-line switches:\n");
         printf ("       -dqi -glin -lflg -dark\n");

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -27,7 +27,11 @@ struct TrlBuf trlbuf = { 0 };
 static void FreeNames (char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf ("syntax:  acsccd [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+    printf ("syntax:  acsccd [--help] [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* This is the main module for ACSCCD.  It gets the input and output
@@ -142,6 +146,11 @@ int main (int argc, char **argv) {
             if (!(strcmp(argv[i],"--gitinfo")))
             {
                 printGitInfo();
+                exit(0);
+            }
+            if (!(strcmp(argv[i],"--help")))
+            {
+                printHelp();
                 exit(0);
             }
             for (j = 1;  argv[i][j] != '\0';  j++) {

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -22,9 +22,13 @@ int status = 0;			/* zero is OK */
 
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
+struct TrlBuf trlbuf = { 0 };
 
 static void FreeNames (char *, char *, char *, char *);
-struct TrlBuf trlbuf = { 0 };
+static void printSyntax(void)
+{
+    printf ("syntax:  acsccd [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+}
 
 /* This is the main module for ACSCCD.  It gets the input and output
  file names, calibration switches, and flags, and then calls ACSccd.
@@ -149,6 +153,7 @@ int main (int argc, char **argv) {
                     quiet = YES;
                 } else {
                     printf (MsgText, "Unrecognized option %s\n", argv[i]);
+                    printSyntax();
                     FreeNames (inlist, outlist, input, output);
                     exit (1);
                 }
@@ -162,7 +167,7 @@ int main (int argc, char **argv) {
         }
     }
     if (inlist[0] == '\0' || too_many) {
-        printf ("syntax:  acsccd [-t] [-v] [-q] [--version] [--gitinfo] input output\n");
+        printSyntax();
         /*
         printf ("  command-line switches:\n");
         printf ("       -dqi -atod -blev -bias\n");

--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -40,7 +40,11 @@ char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
 static void printSyntax()
 {
-    printf ("syntax:  acscte.e [-t] [-v] [-q] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input [output]\n");
+    printf ("syntax:  acscte.e [--help] [-t] [-v] [-q] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input [output]\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 int main (int argc, char **argv) {
@@ -127,6 +131,11 @@ int main (int argc, char **argv) {
             if (!(strcmp(argv[i],"--gitinfo")))
             {
                 printGitInfo();
+                exit(0);
+            }
+            if (!(strcmp(argv[i],"--help")))
+            {
+                printHelp();
                 exit(0);
             }
             if (strncmp(argv[i], "--ctegen", 8) == 0)

--- a/pkg/acs/calacs/acssum/mainsum.c
+++ b/pkg/acs/calacs/acssum/mainsum.c
@@ -32,7 +32,11 @@ char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
 static void printSyntax(void)
 {
-    printf ("syntax:  acssum [-t] [-v] [-q] [--version] [--gitinfo] input [output]\n");
+    printf ("syntax:  acssum [--help] [-t] [-v] [-q] [--version] [--gitinfo] input [output]\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 int main (int argc, char **argv) {
@@ -72,6 +76,11 @@ int main (int argc, char **argv) {
             if (!(strcmp(argv[i],"--gitinfo")))
             {
                 printGitInfo();
+                exit(0);
+            }
+            if (!(strcmp(argv[i],"--help")))
+            {
+                printHelp();
                 exit(0);
             }
 			for (j = 1;  argv[i][j] != '\0';  j++) {

--- a/pkg/acs/calacs/acssum/mainsum.c
+++ b/pkg/acs/calacs/acssum/mainsum.c
@@ -30,6 +30,11 @@ struct TrlBuf trlbuf = { 0 };
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
+static void printSyntax(void)
+{
+    printf ("syntax:  acssum [-t] [-v] [-q] [--version] [--gitinfo] input [output]\n");
+}
+
 int main (int argc, char **argv) {
 
 	char *input, *output;	/* file names */
@@ -78,6 +83,7 @@ int main (int argc, char **argv) {
 				quiet = YES;
 				} else {
 					printf (MsgText, "Unrecognized option %s\n", argv[i]);
+					printSyntax();
 					free (input);
 					free (output);
 					exit (1);
@@ -92,7 +98,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (input[0] == '\0' || too_many) {
-	    printf ("syntax:  acssum [-t] [-v] [-q] [--version] [--gitinfo] input [output]\n");
+        printSyntax();
 		free (input);
 		free (output);
 		exit (ERROR_RETURN);

--- a/pkg/acs/calacs/calacs/acsmain.c
+++ b/pkg/acs/calacs/calacs/acsmain.c
@@ -24,7 +24,11 @@ char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
 static void printSyntax(void)
 {
-    printf("syntax:  calacs.e [-t] [-s] [-v] [-q] [-r] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input \n");
+    printf("syntax:  calacs.e [--help] [-t] [-s] [-v] [-q] [-r] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input \n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 int main(int argc, char **argv) {
@@ -76,6 +80,11 @@ int main(int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
         if (strncmp(argv[i], "--ctegen", 8) == 0)

--- a/pkg/acs/calacs/calacs/acsmain.c
+++ b/pkg/acs/calacs/calacs/acsmain.c
@@ -22,9 +22,9 @@ struct TrlBuf trlbuf = { 0 };
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
-static void printSyntax()
+static void printSyntax(void)
 {
-    printf ("syntax:  calacs.e [-t] [-s] [-v] [-q] [-r] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input \n");
+    printf("syntax:  calacs.e [-t] [-s] [-v] [-q] [-r] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input \n");
 }
 
 int main(int argc, char **argv) {

--- a/pkg/stis/calstis/cs0/cs0.c
+++ b/pkg/stis/calstis/cs0/cs0.c
@@ -13,7 +13,10 @@
 # include "hstcalversion.h"
 
 static void FreeNames (char *, char *, char *, char *, char *, char *);
-
+static void printSyntax(void)
+{
+    printf("syntax:  cs0.e [-t] [-s] [-v] [--version] [--gitinfo] input [outroot] [-w wavecal]\n");
+}
 /* This is the main module for calstis0.  It gets the input and output
    file names, calibration switches, and flags, and then calls CalStis0.
 
@@ -116,6 +119,7 @@ int main (int argc, char **argv) {
 			wavecal_next = 1;
 		    } else {
 			printf ("Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			FreeNames (rawlist, wavlist, outlist,
 				rawfile, wavfile, outroot);
 			exit (ERROR_RETURN);
@@ -142,8 +146,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (rawlist[0] == '\0' || too_many || wavecal_next) {
-	    printf (
-	"syntax:  cs0.e [-t] [-s] [-v] [--version] [--gitinfo] input [outroot] [-w wavecal]\n");
+	    printSyntax();
 	    FreeNames (rawlist, wavlist, outlist, rawfile, wavfile, outroot);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/stis/calstis/cs0/cs0.c
+++ b/pkg/stis/calstis/cs0/cs0.c
@@ -15,8 +15,13 @@
 static void FreeNames (char *, char *, char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf("syntax:  cs0.e [-t] [-s] [-v] [--version] [--gitinfo] input [outroot] [-w wavecal]\n");
+    printf("syntax:  cs0.e [--help] [-t] [-s] [-v] [--version] [--gitinfo] input [outroot] [-w wavecal]\n");
 }
+static void printHelp(void)
+{
+    printSyntax();
+}
+
 /* This is the main module for calstis0.  It gets the input and output
    file names, calibration switches, and flags, and then calls CalStis0.
 
@@ -101,6 +106,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 		if (strcmp (argv[i], "-r") == 0) {

--- a/pkg/stis/calstis/cs1/cs1.c
+++ b/pkg/stis/calstis/cs1/cs1.c
@@ -17,11 +17,15 @@ static int CompareNumbers (int, int, char *);
 static void FreeNames (char *, char *, char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf ("syntax:  cs1.e [-t] [-v] [--version] [--gitinfo] input output [outblev]\n");
+    printf ("syntax:  cs1.e [--help] [-t] [-v] [--version] [--gitinfo] input output [outblev]\n");
     printf ("  command-line switches:\n");
     printf ("       -dqi  -atod -blev\n");
     printf ("       -dopp -lors -glin -lflg\n");
     printf ("       -bias -dark -flat -shad -phot -stat\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* This is the main module for calstis1.  It gets the input and output
@@ -134,6 +138,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 	    if (strcmp (argv[i], "-r") == 0) {

--- a/pkg/stis/calstis/cs1/cs1.c
+++ b/pkg/stis/calstis/cs1/cs1.c
@@ -15,6 +15,14 @@
 
 static int CompareNumbers (int, int, char *);
 static void FreeNames (char *, char *, char *, char *, char *, char *);
+static void printSyntax(void)
+{
+    printf ("syntax:  cs1.e [-t] [-v] [--version] [--gitinfo] input output [outblev]\n");
+    printf ("  command-line switches:\n");
+    printf ("       -dqi  -atod -blev\n");
+    printf ("       -dopp -lors -glin -lflg\n");
+    printf ("       -bias -dark -flat -shad -phot -stat\n");
+}
 
 /* This is the main module for calstis1.  It gets the input and output
    file names, calibration switches, and flags, and then calls CalStis1.
@@ -183,6 +191,7 @@ int main (int argc, char **argv) {
 			verbose = 1;
 		    } else {
 			printf ("ERROR:  Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			exit (1);
 		    }
 		}
@@ -215,11 +224,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (inlist[0] == '\0' || too_many) {
-	    printf ("syntax:  cs1.e [-t] [-v] [--version] [--gitinfo] input output [outblev]\n");
-	    printf ("  command-line switches:\n");
-	    printf ("       -dqi  -atod -blev\n");
-	    printf ("       -dopp -lors -glin -lflg\n");
-	    printf ("       -bias -dark -flat -shad -phot -stat\n");
+	    printSyntax();
 	    FreeNames (inlist, outlist, blevlist, input, output, outblev);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/stis/calstis/cs11/cs11.c
+++ b/pkg/stis/calstis/cs11/cs11.c
@@ -16,7 +16,11 @@ static int CompareNumbers (int, char *, int, char *);
 static void FreeNames (char *, char *, char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf("syntax:  cs11.e [-t] [-v] [--version] [--gitinfo] wavecal science output\n");
+    printf("syntax:  cs11.e [--help] [-t] [-v] [--version] [--gitinfo] wavecal science output\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* This is the main module for calstis11.  It gets the file names,
@@ -85,6 +89,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 	    if (strcmp (argv[i], "-r") == 0) {

--- a/pkg/stis/calstis/cs11/cs11.c
+++ b/pkg/stis/calstis/cs11/cs11.c
@@ -14,6 +14,10 @@
 
 static int CompareNumbers (int, char *, int, char *);
 static void FreeNames (char *, char *, char *, char *, char *, char *);
+static void printSyntax(void)
+{
+    printf("syntax:  cs11.e [-t] [-v] [--version] [--gitinfo] wavecal science output\n");
+}
 
 /* This is the main module for calstis11.  It gets the file names,
    calibration switches, and flags, and then calls CalStis11.
@@ -95,6 +99,7 @@ int main (int argc, char **argv) {
 			verbose = 1;
 		    } else {
 			printf ("ERROR:  Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			exit (1);
 		    }
 		}
@@ -109,8 +114,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (scilist[0] == '\0' || too_many) {
-	    printf (
-	"ERROR:  syntax:  cs11.e [-t] [-v] [--version] [--gitinfo] wavecal science output\n");
+	    printSyntax();
 	    FreeNames (wavlist, scilist, outlist, inwav, insci, output);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/stis/calstis/cs12/cs12.c
+++ b/pkg/stis/calstis/cs12/cs12.c
@@ -18,6 +18,10 @@ static int WavOption (char *, int *);
 
 static int CompareNumbers (int, int);
 static void FreeNames (char *, char *, char *, char *, char *);
+static void printSyntax(void)
+{
+    printf ("syntax:  cs12.e [-t] [-v] [--version] [--gitinfo] wavecal science\n");
+}
 
 /* This is the main module for calstis12.  It gets the input file names
    and command-line flags, and then calls CalStis12.
@@ -102,6 +106,7 @@ int main (int argc, char **argv) {
 			verbose = 1;
 		    } else {
 			printf ("ERROR:  Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			exit (1);
 		    }
 		}
@@ -116,7 +121,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (scilist[0] == '\0' || too_many) {
-	    printf ("ERROR:  syntax:  cs12.e [-t] [-v] [--version] [--gitinfo] wavecal science\n");
+	    printSyntax();
 	    exit (ERROR_RETURN);
 	}
 	if (which_wavecal[0] != '\0') {

--- a/pkg/stis/calstis/cs12/cs12.c
+++ b/pkg/stis/calstis/cs12/cs12.c
@@ -20,7 +20,11 @@ static int CompareNumbers (int, int);
 static void FreeNames (char *, char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf ("syntax:  cs12.e [-t] [-v] [--version] [--gitinfo] wavecal science\n");
+    printf ("syntax:  cs12.e [--help] [-t] [-v] [--version] [--gitinfo] wavecal science\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* This is the main module for calstis12.  It gets the input file names
@@ -92,6 +96,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 	    if (strcmp (argv[i], "-r") == 0) {

--- a/pkg/stis/calstis/cs4/cs4.c
+++ b/pkg/stis/calstis/cs4/cs4.c
@@ -14,6 +14,10 @@
 
 static int CompareNumbers (int, int);
 static void FreeNames (char *, char *, char *, char *);
+static void printSyntax(void)
+{
+    printf("syntax:  cs4.e [-t] [-v] [--version] [--gitinfo] input [-angle slit_angle] [-d debugfile]\n");
+}
 
 /* This is the main module for calstis4.  It gets the input file name
    and command-line flags, and then calls CalStis4.
@@ -118,8 +122,8 @@ int main (int argc, char **argv) {
 			    /* next argument must be debug file name */
 			    dbg_next = 1;
 			} else {
-			    printf ("ERROR:  Unrecognized option %s\n",
-				argv[i]);
+			    printf ("ERROR:  Unrecognized option %s\n", argv[i]);
+			    printSyntax();
 			    exit (1);
 			}
 		    }
@@ -131,8 +135,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (inlist[0] == '\0' || too_many || dbg_next) {
-	    printf (
-	"syntax:  cs4.e [-t] [-v] [--version] [--gitinfo] input [-angle slit_angle] [-d debugfile]\n");
+	    printSyntax();
 	    FreeNames (inlist, input, dbglist, dbgfile);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/stis/calstis/cs4/cs4.c
+++ b/pkg/stis/calstis/cs4/cs4.c
@@ -16,7 +16,11 @@ static int CompareNumbers (int, int);
 static void FreeNames (char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf("syntax:  cs4.e [-t] [-v] [--version] [--gitinfo] input [-angle slit_angle] [-d debugfile]\n");
+    printf("syntax:  cs4.e [--help] [-t] [-v] [--version] [--gitinfo] input [-angle slit_angle] [-d debugfile]\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* This is the main module for calstis4.  It gets the input file name
@@ -103,6 +107,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 		if (strcmp (argv[i], "-r") == 0) {

--- a/pkg/stis/calstis/cs8/cs8.c
+++ b/pkg/stis/calstis/cs8/cs8.c
@@ -11,6 +11,11 @@
 # include "hstcalerr.h"
 # include "hstcalversion.h"
 
+static void printSyntax(void)
+{
+    printf("syntax:  cs8.e [-t] [-v] [--version] [--gitinfo] input output\n");
+}
+
 /* This is the main module for calstis8.  It gets the input and output
    file names, calibration switches, and flags, and then calls CalStis8.
 
@@ -65,6 +70,7 @@ int main (int argc, char **argv) {
 			verbose = 1;
 		    } else {
 			printf ("ERROR:  Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			exit (1);
 		    }
 		}
@@ -77,7 +83,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (input[0] == '\0' || too_many) {
-	    printf ("ERROR:  syntax:  cs8.e [-t] [-v] [--version] [--gitinfo] input output\n");
+	    printSyntax();
 	    exit (ERROR_RETURN);
 	}
 	if (output[0] == '\0') {

--- a/pkg/stis/calstis/cs8/cs8.c
+++ b/pkg/stis/calstis/cs8/cs8.c
@@ -13,7 +13,11 @@
 
 static void printSyntax(void)
 {
-    printf("syntax:  cs8.e [-t] [-v] [--version] [--gitinfo] input output\n");
+    printf("syntax:  cs8.e [--help] [-t] [-v] [--version] [--gitinfo] input output\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* This is the main module for calstis8.  It gets the input and output
@@ -57,6 +61,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 		if (strcmp (argv[i], "-r") == 0) {

--- a/pkg/wfc3/calwf3/calwf3/wf3main.c
+++ b/pkg/wfc3/calwf3/calwf3/wf3main.c
@@ -23,7 +23,11 @@ char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
 static void printSyntax(void)
 {
-    printf("syntax:  calwf3.e [-t] [-s] [-v] [-q] [-r] [-1] [--version] [--gitinfo] input \n");
+    printf("syntax:  calwf3.e [--help] [-t] [-s] [-v] [-q] [-r] [-1] [--version] [--gitinfo] input \n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 int main (int argc, char **argv) {
@@ -67,6 +71,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 		if (argv[i][0] == '-') {

--- a/pkg/wfc3/calwf3/calwf3/wf3main.c
+++ b/pkg/wfc3/calwf3/calwf3/wf3main.c
@@ -21,6 +21,11 @@ struct TrlBuf trlbuf = { 0 };
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
+static void printSyntax(void)
+{
+    printf("syntax:  calwf3.e [-t] [-s] [-v] [-q] [-r] [-1] [--version] [--gitinfo] input \n");
+}
+
 int main (int argc, char **argv) {
 
 	/* Local variables */
@@ -83,6 +88,7 @@ int main (int argc, char **argv) {
                     onecpu = YES;
                 } else {
 					printf ("Unrecognized option %s\n", argv[i]);
+					printSyntax();
 					exit (ERROR_RETURN);
 				}
 			}
@@ -94,7 +100,7 @@ int main (int argc, char **argv) {
 	}
 
 	if (input[0] == '\0' || too_many) {
-		printf ("syntax:  calwf3.e [-t] [-s] [-v] [-q] [-r] [-1] [--version] [--gitinfo] input \n");
+	    printSyntax();
 		exit (ERROR_RETURN);
 	}
 

--- a/pkg/wfc3/calwf3/wf32d/main2d.c
+++ b/pkg/wfc3/calwf3/wf32d/main2d.c
@@ -21,10 +21,17 @@ int status = 0;			/* zero is OK */
 # include "trlbuf.h"
 
 static void FreeNames (char *, char *, char *, char *);
-struct TrlBuf trlbuf = { 0 };
+static void printSyntax(void)
+{
+    printf ("syntax:  wf32d [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("  command-line switches:\n");
+    printf ("       -dqi  -atod\n");
+    printf ("       -dark -flat -shad -phot -stat\n");
+}
 
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
+struct TrlBuf trlbuf = { 0 };
 
 /* This is the main module for wf32d.  It gets the input and output
    file names, calibration switches, and flags, and then calls wf32d.
@@ -142,6 +149,7 @@ int main (int argc, char **argv) {
               exit(0);
 		    } else {
 			printf ("Unrecognized option %s\n", argv[i]);
+			printSyntax();
 	    		FreeNames (inlist, outlist, input, output);
 			exit (1);
 		    }
@@ -155,10 +163,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (inlist[0] == '\0' || too_many) {
-	    printf ("syntax:  wf32d [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
-	    printf ("  command-line switches:\n");
-	    printf ("       -dqi  -atod\n");
-	    printf ("       -dark -flat -shad -phot -stat\n");
+	    printSyntax();
 	    FreeNames (inlist, outlist, input, output);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/wfc3/calwf3/wf32d/main2d.c
+++ b/pkg/wfc3/calwf3/wf32d/main2d.c
@@ -23,10 +23,14 @@ int status = 0;			/* zero is OK */
 static void FreeNames (char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf ("syntax:  wf32d [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("syntax:  wf32d [--help] [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
     printf ("  command-line switches:\n");
     printf ("       -dqi  -atod\n");
     printf ("       -dark -flat -shad -phot -stat\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* Standard string buffer for use in messages */
@@ -119,6 +123,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 	    if (strcmp (argv[i], "-dqi") == 0) {	/* turn on */

--- a/pkg/wfc3/calwf3/wf3ccd/mainccd.c
+++ b/pkg/wfc3/calwf3/wf3ccd/mainccd.c
@@ -22,10 +22,16 @@ int status = 0;			/* zero is OK */
 
 static void FreeNames (char *, char *, char *, char *);
 int MkOutName (char *, char **, char **, int, char *, int);
-struct TrlBuf trlbuf = { 0 };
+static void printSyntax(void)
+{
+    printf ("syntax:  wf3ccd [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("  command-line switches:\n");
+    printf ("       -dqi  -atod -blev -bias\n");
+}
 
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
+struct TrlBuf trlbuf = { 0 };
 
 /* This is the main module for WF3CCD.  It gets the input and output
    file names, calibration switches, and flags, and then calls WF3ccd.
@@ -145,6 +151,7 @@ int main (int argc, char **argv) {
                 exit(0);
 		    } else {
 			printf (MsgText, "Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			FreeNames (inlist, outlist, input, output);
 			exit (1);
 		    }
@@ -159,9 +166,7 @@ int main (int argc, char **argv) {
 	}
 
 	if (inlist[0] == '\0' || too_many) {
-	    printf ("syntax:  wf3ccd [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
-	    printf ("  command-line switches:\n");
-	    printf ("       -dqi  -atod -blev -bias\n");
+	    printSyntax();
 	    FreeNames (inlist, outlist, input, output);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/wfc3/calwf3/wf3ccd/mainccd.c
+++ b/pkg/wfc3/calwf3/wf3ccd/mainccd.c
@@ -24,9 +24,13 @@ static void FreeNames (char *, char *, char *, char *);
 int MkOutName (char *, char **, char **, int, char *, int);
 static void printSyntax(void)
 {
-    printf ("syntax:  wf3ccd [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("syntax:  wf3ccd [--help] [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
     printf ("  command-line switches:\n");
     printf ("       -dqi  -atod -blev -bias\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* Standard string buffer for use in messages */
@@ -121,6 +125,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 	    if (strcmp (argv[i], "-dqi") == 0) {	/* turn on */

--- a/pkg/wfc3/calwf3/wf3cte/maincte.c
+++ b/pkg/wfc3/calwf3/wf3cte/maincte.c
@@ -41,6 +41,10 @@ int CompareNumbers (int, int, char *);
 int LoadHdr (char *, Hdr *);
 int GetSwitch (Hdr *, char *, int *);
 void initCCDSwitches (CCD_Switch *);
+static void printSyntax(void)
+{
+    printf ("syntax:  WF3cte [-v] [-1] [--version] [--gitinfo] input output\n");
+}
 
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
@@ -134,6 +138,7 @@ int main (int argc, char **argv) {
 					exit(0);
                 } else {
                     printf (MsgText, "Unrecognized option %s\n", argv[i]);
+                    printSyntax();
                     FreeNames (inlist, outlist, input, output);
                     exit (ERROR_RETURN);
                 }
@@ -147,7 +152,7 @@ int main (int argc, char **argv) {
         }
     }
     if (inlist[0] == '\0' || too_many) {
-        printf ("syntax:  WF3cte [-v] [-1] [--version] [--gitinfo] input output\n");
+        printSyntax();
         FreeNames (inlist, outlist, input, output);
         exit (ERROR_RETURN);
     }

--- a/pkg/wfc3/calwf3/wf3cte/maincte.c
+++ b/pkg/wfc3/calwf3/wf3cte/maincte.c
@@ -43,7 +43,11 @@ int GetSwitch (Hdr *, char *, int *);
 void initCCDSwitches (CCD_Switch *);
 static void printSyntax(void)
 {
-    printf ("syntax:  WF3cte [-v] [-1] [--version] [--gitinfo] input output\n");
+    printf ("syntax:  WF3cte [--help] [-v] [-1] [--version] [--gitinfo] input output\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* Standard string buffer for use in messages */
@@ -124,6 +128,11 @@ int main (int argc, char **argv) {
             if (!(strcmp(argv[i],"--gitinfo")))
             {
                 printGitInfo();
+                exit(0);
+            }
+            if (!(strcmp(argv[i],"--help")))
+            {
+                printHelp();
                 exit(0);
             }
             for (j = 1;  argv[i][j] != '\0';  j++) {

--- a/pkg/wfc3/calwf3/wf3ir/mainir.c
+++ b/pkg/wfc3/calwf3/wf3ir/mainir.c
@@ -23,9 +23,13 @@ int status = 0;			/* zero is OK */
 static void FreeNames (char *, char *, char *, char *);
 static void printSyntax(void)
 {
-    printf ("syntax:  wf3ir [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("syntax:  wf3ir [--help] [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
     printf ("  command-line switches:\n");
     printf ("       -bseq -pede\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* Standard string buffer for use in messages */
@@ -121,6 +125,11 @@ int main (int argc, char **argv) {
         if (!(strcmp(argv[i],"--gitinfo")))
         {
             printGitInfo();
+            exit(0);
+        }
+        if (!(strcmp(argv[i],"--help")))
+        {
+            printHelp();
             exit(0);
         }
 	    if (argv[i][0] == '-') {

--- a/pkg/wfc3/calwf3/wf3ir/mainir.c
+++ b/pkg/wfc3/calwf3/wf3ir/mainir.c
@@ -21,10 +21,16 @@ int status = 0;			/* zero is OK */
 # include "trlbuf.h"
 
 static void FreeNames (char *, char *, char *, char *);
-struct TrlBuf trlbuf = { 0 };
+static void printSyntax(void)
+{
+    printf ("syntax:  wf3ir [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("  command-line switches:\n");
+    printf ("       -bseq -pede\n");
+}
 
 /* Standard string buffer for use in messages */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
+struct TrlBuf trlbuf = { 0 };
 
 /* This is the main module for WF3IR.  It gets the input and output
    file names, calibration switches, and flags, and then calls WF3ir.
@@ -130,6 +136,7 @@ int main (int argc, char **argv) {
                 exit(0);
 		    } else {
 			printf (MsgText, "Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			FreeNames (inlist, outlist, input, output);
 			exit (1);
 		    }
@@ -144,9 +151,7 @@ int main (int argc, char **argv) {
 	}
     
 	if (inlist[0] == '\0' || too_many) {
-	    printf ("syntax:  wf3ir [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
-	    printf ("  command-line switches:\n");
-	    printf ("       -bseq -pede\n");
+	    printSyntax();
 	    FreeNames (inlist, outlist, input, output);
 	    exit (ERROR_RETURN);
 	}

--- a/pkg/wfc3/calwf3/wf3sum/mainsum.c
+++ b/pkg/wfc3/calwf3/wf3sum/mainsum.c
@@ -22,7 +22,11 @@ struct TrlBuf trlbuf = { 0 };
 
 static void printSyntax(void)
 {
-    printf ("syntax:  wf3sum [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+    printf ("syntax:  wf3sum [--help] [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+}
+static void printHelp(void)
+{
+    printSyntax();
 }
 
 /* 
@@ -76,6 +80,11 @@ int main (int argc, char **argv) {
             if (!(strcmp(argv[i],"--gitinfo")))
             {
                 printGitInfo();
+                exit(0);
+            }
+            if (!(strcmp(argv[i],"--help")))
+            {
+                printHelp();
                 exit(0);
             }
 		for (j = 1;  argv[i][j] != '\0';  j++) {

--- a/pkg/wfc3/calwf3/wf3sum/mainsum.c
+++ b/pkg/wfc3/calwf3/wf3sum/mainsum.c
@@ -20,6 +20,11 @@ int status = 0;			/* zero is OK */
 char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 struct TrlBuf trlbuf = { 0 };
 
+static void printSyntax(void)
+{
+    printf ("syntax:  wf3sum [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+}
+
 /* 
     This function will only return either 0 (WF3_OK) if everything
     processed normally or ERROR_RETURN (2) if there was some error.
@@ -85,6 +90,7 @@ int main (int argc, char **argv) {
                 exit(0);
 		    } else {
 			printf (MsgText, "Unrecognized option %s\n", argv[i]);
+			printSyntax();
 			free (input);
 			free (output);
 			exit (1);
@@ -99,7 +105,7 @@ int main (int argc, char **argv) {
 	    }
 	}
 	if (input[0] == '\0' || too_many) {
-	    printf ("syntax:  wf3sum [-t] [-v] [-q] [-r] [--version] [--gitinfo] input output\n");
+	    printSyntax();
 	    free (input);
 	    free (output);
 	    exit (ERROR_RETURN);


### PR DESCRIPTION
Add --help cmd option to print syntax
    
Resolves #238
    
Doesn't cover:
wf3rej.e
acsrej.e
cs2.e
cs6.e
    
Signed-off-by: James Noss <jnoss@stsci.edu>

AND

"unrecognized option" errors should also print syntax
    
Resolves #171
    
Doesn't cover:
wf3rej.e
acsrej.e
cs2.e
cs6.e
    
Signed-off-by: James Noss <jnoss@stsci.edu>