### PR TITLE
CloseTrlBuf(void) -> CloseTrlBuf(struct TrlBuf * ptr)

### DIFF
--- a/include/trlbuf.h
+++ b/include/trlbuf.h
@@ -27,7 +27,7 @@ void SetTrlOverwriteMode (int owrite);
 void SetTrlQuietMode (int quiet);
 void InitTrlPreface (void);
 void ResetTrlPreface (void);
-void CloseTrlBuf (void);
+void CloseTrlBuf (struct TrlBuf * ptr);
 void trlmessage (const char *message);
 void trlwarn (const char *message);
 void trlerror (const char *message);

--- a/lib/trlbuf.c
+++ b/lib/trlbuf.c
@@ -586,28 +586,31 @@ static void WriteTrlBuf (const char *message)
         AddTrlBuf (message);
     }
 }
-void CloseTrlBuf (void)
+void CloseTrlBuf (struct TrlBuf * buf)
 {
     /* Free memory allocated for this list, after writing out any final
         messages to the last used trailer file...
         It will then close any open trailer files as well.
     */
 
+    if (!buf)
+        return;
+
     extern int status;
     FILE *ofp;
 
     /* Do we have any messages which need to be written out? */
-    if (trlbuf.buffer[0] != '\0') {
+    if (buf->buffer[0] != '\0') {
         /* We do, so open last known trailer file and
             append these messages to that file...
         */
 
-        if ( (ofp = fopen(trlbuf.trlfile,"a+")) == NULL) {
-            trlopenerr(trlbuf.trlfile);
+        if ( (ofp = fopen(buf->trlfile,"a+")) == NULL) {
+            trlopenerr(buf->trlfile);
             status = INVALID_TEMP_FILE;
             goto cleanup;
         }
-        fprintf (ofp,"%s",trlbuf.buffer);
+        fprintf (ofp,"%s",buf->buffer);
 
         /* Now that we have copied the information to the final
             trailer file, we can close it and the temp file...
@@ -617,18 +620,18 @@ void CloseTrlBuf (void)
 
     cleanup: ;
 
-        if (trlbuf.buffer)
+        if (buf->buffer)
         {
-            free (trlbuf.buffer);
-            trlbuf.buffer = NULL;
+            free (buf->buffer);
+            buf->buffer = NULL;
         }
-        if (trlbuf.preface)
+        if (buf->preface)
         {
-            free (trlbuf.preface);
-            trlbuf.preface = NULL;
+            free (buf->preface);
+            buf->preface = NULL;
         }
 
-        status = fcloseWithStatus(&trlbuf.fp);
+        status = fcloseWithStatus(&buf->fp);
 
 }
 void trlmessage (const char *message) {

--- a/pkg/acs/calacs/acs2d/main2d.c
+++ b/pkg/acs/calacs/acs2d/main2d.c
@@ -224,7 +224,7 @@ int main (int argc, char **argv) {
 
     if (status) {
         FreeNames (inlist, outlist, input, output);
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
         exit (ERROR_RETURN);
     }
 
@@ -291,7 +291,7 @@ int main (int argc, char **argv) {
     c_imtclose (o_imt);
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
-    CloseTrlBuf ();
+    CloseTrlBuf(&trlbuf);
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -211,7 +211,7 @@ int main (int argc, char **argv) {
         status = 1;
     if (status) {
         FreeNames (inlist, outlist, input, output);
-        CloseTrlBuf();
+        CloseTrlBuf(&trlbuf);
         exit (ERROR_RETURN);
     }
 
@@ -256,7 +256,7 @@ int main (int argc, char **argv) {
     c_imtclose (o_imt);
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
-    CloseTrlBuf();
+    CloseTrlBuf(&trlbuf);
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -287,7 +287,7 @@ int main (int argc, char **argv) {
         status = 1;
     if (status) {
         FreeNames (inlist, outlist, input, output);
-        CloseTrlBuf();
+        CloseTrlBuf(&trlbuf);
         exit (ERROR_RETURN);
     }
 
@@ -346,7 +346,7 @@ int main (int argc, char **argv) {
     c_imtclose (o_imt);
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
-    CloseTrlBuf();
+    CloseTrlBuf(&trlbuf);
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/acs/calacs/acsrej/mainrej.c
+++ b/pkg/acs/calacs/acsrej/mainrej.c
@@ -59,11 +59,11 @@ int main (int argc, char **argv) {
     if (status) {
         WhichError (status);
         FreeNames(input);
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
         exit (ERROR_RETURN);
     } else {
         FreeNames(input);
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
         exit (0);
     }
 }

--- a/pkg/acs/calacs/acssum/mainsum.c
+++ b/pkg/acs/calacs/acssum/mainsum.c
@@ -126,7 +126,7 @@ int main (int argc, char **argv) {
             free (input);
             free (output);
             WhichError (status);
-            CloseTrlBuf ();
+            CloseTrlBuf(&trlbuf);
             exit (ERROR_RETURN);
         }
 	}
@@ -141,7 +141,7 @@ int main (int argc, char **argv) {
 	free (output);
     free (mtype);
 
-	CloseTrlBuf ();
+	CloseTrlBuf(&trlbuf);
 
 	if (status)
 	    exit (ERROR_RETURN);

--- a/pkg/acs/calacs/calacs/acsmain.c
+++ b/pkg/acs/calacs/calacs/acsmain.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
 		    trlerror (MsgText);
             /* Added 19 Mar 1999 - provides interpretation of error for user */
             WhichError (status);
-		    CloseTrlBuf ();
+		    CloseTrlBuf(&trlbuf);
 	        exit (ERROR_RETURN);
         }
 	}
@@ -252,7 +252,7 @@ int main(int argc, char **argv) {
 	sprintf (MsgText, "CALACS completion for %s", input);
 	trlmessage (MsgText);
 
-	CloseTrlBuf ();
+	CloseTrlBuf(&trlbuf);
 
 	/* Exit the program */
 	exit(0);

--- a/pkg/wfc3/calwf3/calwf3/wf3main.c
+++ b/pkg/wfc3/calwf3/calwf3/wf3main.c
@@ -137,7 +137,7 @@ int main (int argc, char **argv) {
 			trlerror (MsgText);
 			/* Provide interpretation of error for user */
 			WhichError (status);
-			CloseTrlBuf ();
+			CloseTrlBuf(&trlbuf);
 			exit (ERROR_RETURN);
 		}
 	}
@@ -146,7 +146,7 @@ int main (int argc, char **argv) {
 	sprintf (MsgText, "CALWF3 completion for %s", input);
 	trlmessage (MsgText);
 
-	CloseTrlBuf ();
+	CloseTrlBuf(&trlbuf);
 
 	/* Exit the program */
 	exit (0);

--- a/pkg/wfc3/calwf3/wf32d/main2d.c
+++ b/pkg/wfc3/calwf3/wf32d/main2d.c
@@ -205,7 +205,7 @@ int main (int argc, char **argv) {
 		
 	if (status) {
 	    FreeNames (inlist, outlist, input, output);
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
 	    exit (ERROR_RETURN);
 	}
 
@@ -239,7 +239,7 @@ int main (int argc, char **argv) {
 	c_imtclose (o_imt);
 	FreeRefFile (&refnames);
 	FreeNames (inlist, outlist, input, output);
-	CloseTrlBuf ();
+	CloseTrlBuf(&trlbuf);
 	
 	if (status)
 	    exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3ccd/mainccd.c
+++ b/pkg/wfc3/calwf3/wf3ccd/mainccd.c
@@ -209,7 +209,7 @@ int main (int argc, char **argv) {
 	    status = 1;
 	if (status) {
 	    FreeNames (inlist, outlist, input, output);
-	    CloseTrlBuf();
+	    CloseTrlBuf(&trlbuf);
 	    exit (ERROR_RETURN);
 	}
 
@@ -244,7 +244,7 @@ int main (int argc, char **argv) {
 	c_imtclose (o_imt);
 	FreeRefFile (&refnames);
 	FreeNames (inlist, outlist, input, output);
-    CloseTrlBuf();
+    CloseTrlBuf(&trlbuf);
 
 	if (status)
 	    exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3cte/maincte.c
+++ b/pkg/wfc3/calwf3/wf3cte/maincte.c
@@ -183,7 +183,7 @@ int main (int argc, char **argv) {
         status = 1;
     if (status) {
         FreeNames (inlist, outlist, input, output);
-        CloseTrlBuf();
+        CloseTrlBuf(&trlbuf);
         exit (ERROR_RETURN);
     }
 
@@ -248,7 +248,7 @@ int main (int argc, char **argv) {
     c_imtclose (o_imt);
     FreeRefFile (&refnames);
     FreeNames (inlist, outlist, input, output);
-    CloseTrlBuf();
+    CloseTrlBuf(&trlbuf);
 
     if (status)
         exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3ir/mainir.c
+++ b/pkg/wfc3/calwf3/wf3ir/mainir.c
@@ -198,7 +198,7 @@ int main (int argc, char **argv) {
 	    status = 1;
 	if (status) {
 	    FreeNames (inlist, outlist, input, output);
-	    CloseTrlBuf();
+	    CloseTrlBuf(&trlbuf);
 	    exit (ERROR_RETURN);
 	}
 
@@ -234,7 +234,7 @@ int main (int argc, char **argv) {
 	c_imtclose (o_imt);
 	FreeRefFile (&refnames);
 	FreeNames (inlist, outlist, input, output);
-    CloseTrlBuf();
+    CloseTrlBuf(&trlbuf);
 
 	if (status)
 	    exit (ERROR_RETURN);

--- a/pkg/wfc3/calwf3/wf3rej/mainrej.c
+++ b/pkg/wfc3/calwf3/wf3rej/mainrej.c
@@ -60,10 +60,10 @@ int main (int argc, char **argv) {
 
     if (status) {
         WhichError (status);
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
         exit (ERROR_RETURN);
     } else{
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
         exit (status);
     }
 }

--- a/pkg/wfc3/calwf3/wf3sum/mainsum.c
+++ b/pkg/wfc3/calwf3/wf3sum/mainsum.c
@@ -132,7 +132,7 @@ int main (int argc, char **argv) {
 		free (input);
 		free (output);
 		WhichError (status);
-        CloseTrlBuf ();
+        CloseTrlBuf(&trlbuf);
 		exit (ERROR_RETURN);
 	    }
 	}
@@ -147,7 +147,7 @@ int main (int argc, char **argv) {
 	free (output);
 	free (mtype);
 
-	CloseTrlBuf ();
+	CloseTrlBuf(&trlbuf);
 
 	if (status)
 	    exit (ERROR_RETURN);


### PR DESCRIPTION
Resolves #247

This faciltates TrlBuf objects being tracked by PtrRegister.

Signed-off-by: James Noss <jnoss@stsci.edu>