### PR TITLE
Resolve fclose() related bugs #226 & #252

### DIFF
--- a/hstio/hstio.c
+++ b/hstio/hstio.c
@@ -115,6 +115,26 @@
 # include "hstio.h"
 # include "hstcalerr.h"
 
+int fcloseNull(FILE * stream)
+{
+    if (!stream)
+        return 0;
+    return fclose(stream);
+}
+int fcloseWithStatus(FILE ** stream)
+{
+    int ret = HSTCAL_OK;
+    if (fcloseNull(*stream))
+        ret = IO_ERROR;
+
+    // Whether or not the operation succeeds, the stream is no longer
+    // associated with a file, and the buffer allocated by std::setbuf or
+    // std::setvbuf, if any, is also disassociated and deallocated if
+    // automatic allocation was used.
+    *stream = NULL;
+    return ret;
+}
+
 /*
 ** String defined to allow determination of the HSTIO library version
 ** from the library file (*.a) or the executable using the library.
@@ -1380,7 +1400,7 @@ int ckNewFile(char *fname) {
         if (x == NULL)
             return 0; /* file does not exist */
         /* file exists */
-        fclose(x);
+        fcloseWithStatus(&x);
         value = getenv("imclobber");
         if (value == NULL)
             return 1; /* file exists and was not removed */

--- a/include/hstio.h
+++ b/include/hstio.h
@@ -6,6 +6,7 @@ extern "C" {
 # endif
 
 # include <stdlib.h>
+# include <stdio.h>
 
 # define HSTIO_VERSION "HSTIO Version 2.6 (11-Mar-2010)"
 
@@ -468,6 +469,10 @@ void clear_hstioerr(void);
 */
 int  openSingleGroupLine  (char *filename, int extver, SingleGroupLine *);
 void closeSingleGroupLine (SingleGroupLine *);
+
+int fcloseNull(FILE * stream); // returns 0 if stream=NULL, returns fclose otherwise
+int fcloseWithStatus(FILE ** stream); // calls fcloseNull & returns IO_ERROR upon error,
+                                      // 0 otherwise. Sets *stream=NULL always.
 
 int ckNewFile(char *fname);
 int openFitsFile(char *filename, unsigned int option);

--- a/lib/trlbuf.c
+++ b/lib/trlbuf.c
@@ -203,7 +203,12 @@ char *output        i: full filename of output (final) trailer file
                 /* If so, append the input to output */
                 CatTrlFile(ip, tp);
                 /* Done with this input file... */
-                fclose(ip);
+                int tmpStat = HSTCAL_OK;
+                if ((tmpStat = fcloseWithStatus(&ip)))
+                {
+                    freeOnExit(&ptrReg); // ip isn't registered
+                    return (status=tmpStat);
+                }
             }
 
         }    /* End loop over all input files */
@@ -238,8 +243,7 @@ char *output        i: full filename of output (final) trailer file
                 free (trlbuf.preface);
                 trlbuf.preface = NULL;
             }
-            fclose (trlbuf.fp);
-            trlbuf.fp = NULL;
+            status = fcloseWithStatus(&trlbuf.fp);
             freeOnExit(&ptrReg);
             return(status);
         }
@@ -361,8 +365,7 @@ static int AppendTrlFile(void)
         strcat (oprefix, buf);
     }
     /* Now we know what needs to be kept, let's close the file... */
-    fclose (trlbuf.fp);
-    trlbuf.fp = NULL;
+    (void)fcloseWithStatus(&trlbuf.fp);
 
     /* ...reopen it with 'w+' instead of 'a+'... */
     if ( (trlbuf.fp = fopen(trlbuf.trlfile,"w+")) == NULL) {
@@ -393,8 +396,7 @@ int WriteTrlFile (void)
     /* Now that we have copied the information to the final
         trailer file, we can close it and the temp file...
     */
-    fclose (trlbuf.fp);
-    trlbuf.fp = NULL;
+    status = fcloseWithStatus(&trlbuf.fp);
 
     return (status);
 }
@@ -610,8 +612,7 @@ void CloseTrlBuf (void)
         /* Now that we have copied the information to the final
             trailer file, we can close it and the temp file...
         */
-        fclose (ofp);
-        ofp = NULL;
+        status = fcloseWithStatus(&ofp);
     }
 
     cleanup: ;
@@ -627,8 +628,7 @@ void CloseTrlBuf (void)
             trlbuf.preface = NULL;
         }
 
-        fclose (trlbuf.fp);
-        trlbuf.fp = NULL;
+        status = fcloseWithStatus(&trlbuf.fp);
 
 }
 void trlmessage (const char *message) {

--- a/pkg/acs/calacs/calacs/calacs.c
+++ b/pkg/acs/calacs/calacs/calacs.c
@@ -1171,7 +1171,7 @@ static int CopyFFile (char *infile, char *outfile) {
     if ((ifp = fopen (infile, "rb")) == NULL) {
         sprintf (MsgText, "Can't open %s.", infile);
         trlerror (MsgText);
-        fclose (ofp);
+        (void)fcloseWithStatus(&ofp);
         remove (outfile);
         free (buf);
         return (status = OPEN_FAILED);
@@ -1184,8 +1184,8 @@ static int CopyFFile (char *infile, char *outfile) {
             sprintf (MsgText, "Can't read from %s (copying to %s).",
             infile, outfile);
             trlerror (MsgText);
-            fclose (ofp);
-            fclose (ifp);
+            (void)fcloseWithStatus(&ofp);
+            (void)fcloseWithStatus(&ifp);
             free (buf);
             return (status = FILE_NOT_READABLE);
         }
@@ -1196,15 +1196,15 @@ static int CopyFFile (char *infile, char *outfile) {
         if (nout < nin) {
             sprintf (MsgText, "Can't copy %s to %s.", infile, outfile);
             trlerror (MsgText);
-            fclose (ofp);
-            fclose (ifp);
+            (void)fcloseWithStatus(&ofp);
+            (void)fcloseWithStatus(&ifp);
             free (buf);
             return (status = COPY_NOT_POSSIBLE);
         }
     }
 
-    fclose (ofp);
-    fclose (ifp);
+    (void)fcloseWithStatus(&ofp);
+    (void)fcloseWithStatus(&ifp);
     free (buf);
 
     /* Update the FILENAME keyword in the primary header of the output file. */

--- a/pkg/acs/calacs/lib/fileexists.c
+++ b/pkg/acs/calacs/lib/fileexists.c
@@ -74,7 +74,7 @@ int TrlExists (char *trlname) {
 			/* New Trailer File */
 			sprintf (MsgText, "Creating new trailer file `%s'.", trlname);
 			trlmessage (MsgText);
-			fclose (fp);	
+			(void)fcloseWithStatus(&fp);
 			return (exists);
 		}
 		
@@ -85,7 +85,7 @@ int TrlExists (char *trlname) {
 
 		/* This flag is used to set OverwriteMode in TRL files */
 		exists = EXISTS_YES;
-		fclose (fp);
+		(void)fcloseWithStatus(&fp);
 		return (exists);		
 	}
 }

--- a/pkg/acs/calacs/lib/mkspt.c
+++ b/pkg/acs/calacs/lib/mkspt.c
@@ -113,7 +113,7 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
             status = ACS_OK;        /* don't abort */
 	        continue;				/* try the rest of the images in list */
 	    } else
-	        fclose (fp);
+	        (void)fcloseWithStatus(&fp);
 
         /* Create Primary header of new output SPT file from first input
             image...

--- a/pkg/imphttab/test_getphttab.c
+++ b/pkg/imphttab/test_getphttab.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include "hstio.h"
 #include "hstcal.h"
 #include "c_iraf.h"
 #include "imphttab.h"
@@ -84,7 +85,8 @@ int main(int argc, char **argv){
         "MJD extrapolation into the future.",
         1.2544879212041671e-18, 8344.116261683303, 56.820520968140734, fp);
 
-    fclose(fp);
+    if ((status = fcloseWithStatus(&fp)))
+        return status;
     printf("Wrote test results to %s\n", outfile);
 
     return 0;

--- a/pkg/stis/calstis/cs0/calstis0.c
+++ b/pkg/stis/calstis/cs0/calstis0.c
@@ -700,7 +700,7 @@ char *outfile   i: name of output file
 
 	if ((ifp = fopen (infile, "rb")) == NULL) {
 	    printf ("ERROR    Can't open %s.\n", infile);
-	    fclose (ofp);
+	    (void)fcloseWithStatus(&ofp);
 	    remove (outfile);
 	    free (buf);
 	    return (OPEN_FAILED);
@@ -712,8 +712,8 @@ char *outfile   i: name of output file
 	    if (ferror (ifp)) {
 		printf ("ERROR    Can't read from %s (copying to %s).\n",
 				infile, outfile);
-		fclose (ofp);
-		fclose (ifp);
+		(void)fcloseWithStatus(&ofp);
+		(void)fcloseWithStatus(&ifp);
 		free (buf);
 		return (GENERIC_ERROR_CODE);
 	    }
@@ -723,15 +723,15 @@ char *outfile   i: name of output file
 	    nout = fwrite (buf, sizeof(char), nin, ofp);
 	    if (nout < nin) {
 		printf ("ERROR    Can't copy %s to %s.\n", infile, outfile);
-		fclose (ofp);
-		fclose (ifp);
+		(void)fcloseWithStatus(&ofp);
+		(void)fcloseWithStatus(&ifp);
 		free (buf);
 		return (GENERIC_ERROR_CODE);
 	    }
 	}
 
-	fclose (ofp);
-	fclose (ifp);
+	(void)fcloseWithStatus(&ofp);
+	(void)fcloseWithStatus(&ifp);
 	free (buf);
 
 	return (0);

--- a/pkg/stis/calstis/cs1/doblev.c
+++ b/pkg/stis/calstis/cs1/doblev.c
@@ -183,8 +183,14 @@ int *driftcorr    o: true means correction for drift along lines was applied
 		fprintf (ofp, "%6d  %0.6g\n", j+1, biaslevel + averagedrift);
 	}
 
-	if (ofp != NULL)
-	    fclose (ofp);			/* done with output file */
+
+	if ((status = fcloseWithStatus(&ofp))) /* done with output file */
+	{
+	    freeSingleGroup (*x);
+	    if (*x)
+	        free (*x);
+	    return status;
+	}
 
 	/* This is the mean value of all the bias levels subtracted. */
 	*meanblev = sumbias / out->sci.data.ny;
@@ -223,7 +229,7 @@ static FILE *BlevOpen (char *fname, int extver, int *status) {
 
 	    } else {
 
-		fclose (fp);
+	        (void)fcloseWithStatus(&fp);
 		printf ("ERROR    File %s already exists.\n", fname);
 		*status = OPEN_FAILED;
 		fp = NULL;

--- a/pkg/stis/calstis/cs1/doblev.c
+++ b/pkg/stis/calstis/cs1/doblev.c
@@ -184,24 +184,19 @@ int *driftcorr    o: true means correction for drift along lines was applied
 	}
 
 
-	if ((status = fcloseWithStatus(&ofp))) /* done with output file */
-	{
-	    freeSingleGroup (*x);
-	    if (*x)
-	        free (*x);
-	    return status;
-	}
+	status = fcloseWithStatus(&ofp); // Don't return here and give caller opportunity to recover.
 
 	/* This is the mean value of all the bias levels subtracted. */
 	*meanblev = sumbias / out->sci.data.ny;
 
-	/* Free x, and copy out to x. */
+	// Free 'x', and move 'out' to 'x'.
 	freeSingleGroup (*x);
-	free (*x);
+	if (*x)
+	    free (*x);
 	*x = out;
 	*done = 1;			/* overscan was actually removed */
 
-	return (0);
+	return (status);
 }
 
 /* This routine opens an output text file if the name is non-null. */
@@ -232,7 +227,6 @@ static FILE *BlevOpen (char *fname, int extver, int *status) {
 	        (void)fcloseWithStatus(&fp);
 		printf ("ERROR    File %s already exists.\n", fname);
 		*status = OPEN_FAILED;
-		fp = NULL;
 	    }
 
 	} else {

--- a/pkg/stis/calstis/cs4/calstis4.c
+++ b/pkg/stis/calstis/cs4/calstis4.c
@@ -166,8 +166,8 @@ double slit_angle      i: angle of long slit used with echelle; this is
 	printf ("\n");
 	PrEnd (4);
 
-	if (sts.dbg != NULL)
-	    fclose (sts.dbg);
+	if ((status = fcloseWithStatus(&sts.dbg)))
+	    return status;
 
 	if (sts.printtime)
 	    TimeStamp ("CALSTIS-4 completed", sts.rootname);

--- a/pkg/wfc3/calwf3/calwf3/calwf3.c
+++ b/pkg/wfc3/calwf3/calwf3/calwf3.c
@@ -608,7 +608,7 @@ int CopyFFile (char *infile, char *outfile) {
 	if ((ifp = fopen (infile, "rb")) == NULL) {
 		sprintf (MsgText,"Can't open %s", infile);
 		trlerror (MsgText);
-		fclose (ofp);
+		(void)fcloseWithStatus(&ofp);
 		remove (outfile);
 		free (buf);
 		return (status = OPEN_FAILED);
@@ -621,8 +621,8 @@ int CopyFFile (char *infile, char *outfile) {
 			sprintf (MsgText, "Can't read from %s (copying to %s).",
 					infile, outfile);
 			trlerror (MsgText);
-			fclose (ofp);
-			fclose (ifp);
+			(void)fcloseWithStatus(&ofp);
+			(void)fcloseWithStatus(&ifp);
 			free (buf);
 			return (status = FILE_NOT_READABLE);
 		}
@@ -633,15 +633,15 @@ int CopyFFile (char *infile, char *outfile) {
 		if (nout < nin) {
 			sprintf (MsgText, "Can't copy %s to %s.", infile, outfile);
 			trlerror (MsgText);
-			fclose (ofp);
-			fclose (ifp);
+			(void)fcloseWithStatus(&ofp);
+			(void)fcloseWithStatus(&ifp);
 			free (buf);
 			return (status = COPY_NOT_POSSIBLE);
 		}
 	}
 
-	fclose (ofp);
-	fclose (ifp);
+	(void)fcloseWithStatus(&ofp);
+	(void)fcloseWithStatus(&ifp);
 	free (buf);
 
 	/* Update the FILENAME keyword in the primary header of the

--- a/pkg/wfc3/calwf3/lib/fileexists.c
+++ b/pkg/wfc3/calwf3/lib/fileexists.c
@@ -79,7 +79,7 @@ int TrlExists (char *trlname) {
 		/* New Trailer File */
 		sprintf (MsgText, "Creating new trailer file `%s'.", trlname);
 		trlmessage (MsgText);
-		fclose (fp);	
+		(void)fcloseWithStatus(&fp);
 		return (exists);
 	    }
 		
@@ -91,7 +91,7 @@ int TrlExists (char *trlname) {
 
 	    /* This flag is used to set OverwriteMode in TRL files */
 	    exists = EXISTS_YES;
-	    fclose (fp);
+	    (void)fcloseWithStatus(&fp);
 	    return (exists);		
 	}
 }

--- a/pkg/wfc3/calwf3/lib/mkspt.c
+++ b/pkg/wfc3/calwf3/lib/mkspt.c
@@ -123,7 +123,7 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
 		  status = WF3_OK;      /* don't abort */
 		  continue;		/* try the rest of the images in list */
 	     } else
-		  fclose (fp);
+	         (void)fcloseWithStatus(&fp);
 
 	     /* Create Primary header of new output SPT file from first
 	     ** input image. */

--- a/tables/tbl_util.c
+++ b/tables/tbl_util.c
@@ -3,6 +3,7 @@
 # include <stdio.h>
 # include <string.h>
 # include <fitsio.h>
+#include "hstio.h"
 #include "hstcal.h"
 # include "ctables.h"
 
@@ -103,7 +104,7 @@ function value          o: 1 if the file exists, 0 otherwise
             file_exists = 0;
         } else {
             file_exists = 1;
-            fclose (fd);
+            (void)fcloseWithStatus(&fd);
         }
 
         return file_exists;


### PR DESCRIPTION
Set error status on failed fclose
    
Resolves #226
    
Signed-off-by: James Noss <jnoss@stsci.edu>

AND

Guard fclose(std::FILE* stream) against stream == NULL
    
Fixes #252
    
Signed-off-by: James Noss <jnoss@stsci.edu>