### PR TITLE
Remove extraneous Mac builds to lessen burden to Travis queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,18 +31,6 @@ matrix:
 
   - os: osx
     env:
-      - PYTHON_VERSION=2.7
-      - CFLAGS="-m64"
-      - LDFLAGS="-m64 -Wl,-rpath $EXE_PREFIX/envs/test/lib"
-
-  - os: osx
-    env:
-      - PYTHON_VERSION=3.5
-      - CFLAGS="-m64"
-      - LDFLAGS="-m64 -Wl,-rpath $EXE_PREFIX/envs/test/lib"
-
-  - os: osx
-    env:
       - CFLAGS="-m64"
       - LDFLAGS="-m64 -Wl,-rpath $EXE_PREFIX/envs/test/lib"
 
@@ -50,21 +38,6 @@ matrix:
     compiler: clang
     env:
       - PYTHON_VERSION=2.7
-      - CC="clang"
-      - CFLAGS="-arch x86_64"
-      - LDFLAGS="-arch x86_64"
-
-  - os: osx
-    compiler: clang
-    env:
-      - PYTHON_VERSION=3.5
-      - CC="clang"
-      - CFLAGS="-arch x86_64"
-      - LDFLAGS="-arch x86_64"
-
-  - os: osx
-    compiler: clang
-    env:
       - CC="clang"
       - CFLAGS="-arch x86_64"
       - LDFLAGS="-arch x86_64"


### PR DESCRIPTION
Mac builds on Travis CI are very susceptible to long queue compared to Linux builds. Given that HSTCAL does not depend on Python (outside of `waf`, which is a third-party package), there is really no need to test Mac builds across different Python versions. Here, I removed some duplicate builds to lessen the Travis queue time for testing this package.