### PR TITLE
ACS CTE: Use amp dependent RN from CCDTAB and not general RN from PCTETAB

### DIFF
--- a/ctegen2/ctehelpers.c
+++ b/ctegen2/ctehelpers.c
@@ -204,7 +204,7 @@ int loadPCTETAB (char *filename, CTEParamsFast *pars) {
        CTEDATE1 - reference date of CTE model pinning, in fractional years
 
        PCTETLEN - max length of CTE trail
-       PCTERNCL - readnoise amplitude and clipping level
+       PCTERNOI - readnoise amplitude and clipping level
        PCTESMIT - number of iterations used in CTE forward modeling
        PCTESHFT - number of iterations used in the parallel transfer
        PCTENSMD - readnoise mitigation algorithm

--- a/pkg/acs/calacs/acscte/docte.c
+++ b/pkg/acs/calacs/acscte/docte.c
@@ -251,8 +251,8 @@ int DoCTE (ACSInfo *acs_info) {
                 return (status);
             }
 
-            sprintf(MsgText, "(pctecorr) Read noise level PCTERNCL: %f", ctePars.rn_amp);
-            trlmessage(MsgText);
+            sprintf(MsgText, "(pctecorr) IGNORING read noise level PCTERNOI from PCTETAB: %f. Using amp dependent values from CCDTAB instead", ctePars.rn_amp);
+            trlwarn(MsgText);
             sprintf(MsgText, "(pctecorr) Readout simulation forward modeling iterations PCTENFOR: %i",
                     ctePars.n_forward);
             trlmessage(MsgText);

--- a/pkg/acs/calacs/acscte/dopcte-gen2.c
+++ b/pkg/acs/calacs/acscte/dopcte-gen2.c
@@ -88,6 +88,10 @@ int doPCTEGen2 (ACSInfo *acs, CTEParamsFast * ctePars, SingleGroup * chipImage)
         sprintf(MsgText, "(pctecorr) Performing CTE correction for amp %c", ccdamp[nthAmp]);
         trlmessage(MsgText);
 
+        ctePars->rn_amp = acs->readnoise[nthAmp];
+        sprintf(MsgText, "(pctecorr) Read noise level from CCDTAB: %f.", ctePars->rn_amp);
+        trlmessage(MsgText);
+
         /* get the amp letter and number where A:0, B:1, etc. */
         amploc = strchr(AMPSORDER, ccdamp[nthAmp]);
         ampID = *amploc - AMPSORDER[0];


### PR DESCRIPTION

Resolves #213

Signed-off-by: James Noss <jnoss@stsci.edu>