### PR TITLE
ACS CTE: Use amp dependent read-noise

### DIFF
--- a/ctegen2/ctegen2.h
+++ b/ctegen2/ctegen2.h
@@ -101,7 +101,7 @@ void initCTEParamsFast(CTEParamsFast * pars, const unsigned _nTraps, const unsig
 int allocateCTEParamsFast(CTEParamsFast * pars);
 void freeCTEParamsFast(CTEParamsFast * pars);
 
-int populateHeaderWithCTEKeywordValues(SingleGroup *group, CTEParamsFast *pars);
+int populateImageFileWithCTEKeywordValues(SingleGroup *group, CTEParamsFast *pars);
 int getCTEParsFromImageHeader(SingleGroup * input, CTEParamsFast * params);
 int loadPCTETAB(char *filename, CTEParamsFast * params);
 void ctewarn (char *message);

--- a/ctegen2/ctehelpers.c
+++ b/ctegen2/ctehelpers.c
@@ -189,7 +189,7 @@ int loadPCTETAB (char *filename, CTEParamsFast *pars) {
        CTEDATE1 - reference date of CTE model pinning, in fractional years
 
        PCTETLEN - max length of CTE trail
-       PCTERNCL - readnoise amplitude and clipping level
+       PCTERNOI - readnoise amplitude and clipping level
        PCTESMIT - number of iterations used in CTE forward modeling
        PCTESHFT - number of iterations used in the parallel transfer
        PCTENSMD - readnoise mitigation algorithm
@@ -605,74 +605,76 @@ No.    Name         Type      Cards   Dimensions   Format
 
  */
 
-int populateHeaderWithCTEKeywordValues(SingleGroup *group, CTEParamsFast *pars)
+int populateImageFileWithCTEKeywordValues(SingleGroup *group, CTEParamsFast *pars)
 {
     extern int status;
 
-    if ((status = PutKeyStr(group->globalhdr,"CTE_NAME", pars->cte_name, "CTE algorithm name")))
+    if ((status = updateKeyOrAddAsHistKeyStr(group->globalhdr,"CTE_NAME", pars->cte_name, "CTE algorithm name")))
     {
-        trlerror("(pctecorr) failed to update CTE_NAME keyword in image header");
+        trlerror("(pctecorr) failed to update (or add as history) CTE_NAME keyword in image header");
         return status;
     }
 
-    if ((status = PutKeyStr(group->globalhdr,"CTE_VER", pars->cte_ver, "CTE algorithm version")))
+    if ((status = updateKeyOrAddAsHistKeyStr(group->globalhdr,"CTE_VER", pars->cte_ver, "CTE algorithm version")))
     {
-        trlerror("(pctecorr) failed to update CTE_VER keyword in image header");
+        trlerror("(pctecorr) failed to update (or add as history) CTE_VER keyword in image header");
         return status;
     }
 
-    if ((status = PutKeyDbl(group->globalhdr, "CTEDATE0", pars->cte_date0,"Date of instrument installation")))
+    if ((status = updateKeyOrAddAsHistKeyDouble(group->globalhdr, "CTEDATE0", pars->cte_date0,"Date of instrument installation")))
     {
-        trlerror("(pctecorr) failed to update CTEDATE0 keyword in header");
+        trlerror("(pctecorr) failed to update (or add as history) CTEDATE0 keyword in header");
         return status;
     }
 
-    if ((status = PutKeyDbl(group->globalhdr, "PCTETRSH", pars->thresh,"CTE over subtraction threshold")))
+    if ((status = updateKeyOrAddAsHistKeyDouble(group->globalhdr, "PCTETRSH", pars->thresh,"CTE over subtraction threshold")))
     {
-        trlerror("(pctecorr) failed to update PCTETRSH keyword in header");
+        trlerror("(pctecorr) failed to update (or add as history) PCTETRSH keyword in header");
         return status;
     }
 
 
-    if ((status = PutKeyDbl(group->globalhdr, "CTEDATE1", pars->cte_date1, "Date of CTE model pinning")))
+    if ((status = updateKeyOrAddAsHistKeyDouble(group->globalhdr, "CTEDATE1", pars->cte_date1, "Date of CTE model pinning")))
     {
-        trlerror("(pctecorr) failed to update CTEDATE1 keyword in header");
+        trlerror("(pctecorr) failed to update (or add as history) CTEDATE1 keyword in header");
         return status;
     }
 
-    if ((status = PutKeyDbl(group->globalhdr, "PCTEFRAC", pars->scale_frac, "CTE scaling factor")))
+    if ((status = updateKeyOrAddAsHistKeyDouble(group->globalhdr, "PCTEFRAC", pars->scale_frac, "CTE scaling factor")))
     {
-        trlerror("(pctecorr) failed to update PCTEFRAC to image header");
+        trlerror("(pctecorr) failed to update (or add as history) PCTEFRAC to image header");
         return status;
     }
 
-    if ((status = PutKeyInt(group->globalhdr,"PCTETLEN",pars->cte_len,"max length of CTE trail")))
+    if ((status = updateKeyOrAddAsHistKeyInt(group->globalhdr,"PCTETLEN",pars->cte_len,"max length of CTE trail")))
     {
-        trlerror("(pctecorr) failed to update PCTETLEN in header");
+        trlerror("(pctecorr) failed to update (or add as history) PCTETLEN in header");
         return status;
     }
 
-    if ((status = PutKeyDbl(group->globalhdr, "PCTERNOI", pars->rn_amp,"read noise amp clip limit")))
+    // The ACS CTE correction doesn't use this amp independent value, it uses the amp dependent values read from the CCDTAB.
+    // The values used are written the the resultant image file as history keywords (pcteHistory()).
+    /*if ((status = updateKeyOrAddAsHistKeyDouble(group->globalhdr, "PCTERNOI", pars->rn_amp,"read noise amp clip limit")))
     {
-        trlerror("(pctecorr) failed to update PCTERNOI in header");
+        trlerror("(pctecorr) failed to update (or add as history) PCTERNOI in header");
+        return status;
+    }*/
+
+    if ((status = updateKeyOrAddAsHistKeyInt(group->globalhdr, "PCTENFOR",pars->n_forward,"Number of iter in forward model")))
+    {
+        trlerror("(pctecorr) failed to update (or add as history) PCTENFOR in header");
         return status;
     }
 
-    if ((status = PutKeyInt(group->globalhdr, "PCTENFOR",pars->n_forward,"Number of iter in forward model")))
+    if ((status = updateKeyOrAddAsHistKeyInt(group->globalhdr, "PCTENPAR",pars->n_par,"Number of iter in parallel transfer")))
     {
-        trlerror("(pctecorr) failed to update PCTENFOR in header");
+        trlerror("(pctecorr) failed to update (or add as history) PCTENPAR in header");
         return status;
     }
 
-    if ((status = PutKeyInt(group->globalhdr, "PCTENPAR",pars->n_par,"Number of iter in parallel transfer")))
+    if ((status = updateKeyOrAddAsHistKeyInt(group->globalhdr,"FIXROCR",pars->fix_rocr,"fix readout cosmic rays")))
     {
-        trlerror("(pctecorr) failed to update PCTENPAR in header");
-        return status;
-    }
-
-    if ((status = PutKeyInt(group->globalhdr,"FIXROCR",pars->fix_rocr,"fix readout cosmic rays")))
-    {
-        trlerror("(pctecorr) failed to update FIXROCR keyword in header");
+        trlerror("(pctecorr) failed to update (or add as history) FIXROCR keyword in header");
         return status;
     }
 

--- a/include/hstio.h
+++ b/include/hstio.h
@@ -123,6 +123,10 @@ extern "C" {
 
 # define SZ_PATHNAME 511
 
+#define intFormat "%12d"
+#define floatFormat "%#14.7E"
+#define doubleFormat "%#20.12E"
+
 # if !defined(BOOL_)
 # define BOOL_
 enum Bool_ { False = 0, True = 1 };
@@ -563,11 +567,25 @@ int getKeyI (Hdr *, char *keyword, int *value);
 int getKeyF (Hdr *, char *keyword, float *value);
 int getKeyD (Hdr *, char *keyword, double *value);
 int getKeyS (Hdr *, char *keyword, char *value);
+/*\group(put)*/
 int putKeyB (Hdr *, char *keyword, Bool value, char *comment);
 int putKeyI (Hdr *, char *keyword, int value, char *comment);
 int putKeyF (Hdr *, char *keyword, float value, char *comment);
 int putKeyD (Hdr *, char *keyword, double value, char *comment);
 int putKeyS (Hdr *, char *keyword, char *value, char *comment);
+/*\group(update)*/
+// The following updateKeyX() will only set values for existing keywords
+int updateKeyB (Hdr *, char *keyword, Bool value, char *comment);
+int updateKeyI (Hdr *, char *keyword, int value, char *comment);
+int updateKeyF (Hdr *, char *keyword, float value, char *comment);
+int updateKeyD (Hdr *, char *keyword, double value, char *comment);
+int updateKeyS (Hdr *, char *keyword, char *value, char *comment);
+// Updates existing keyword OR add as history keyword
+int updateKeyOrAddAsHistKeyBool (Hdr *hd, char *keyword, Bool value, char *comment);
+int updateKeyOrAddAsHistKeyInt (Hdr *hd, char *keyword, int value, char *comment);
+int updateKeyOrAddAsHistKeyFloat (Hdr *hd, char *keyword, float value, char *comment);
+int updateKeyOrAddAsHistKeyDouble (Hdr *hd, char *keyword, double value, char *comment);
+int updateKeyOrAddAsHistKeyStr (Hdr *hd, char *keyword, char *value, char *comment);
 /* End high-level keyword access routines */
 
 char *getKwName(FitsKw);

--- a/pkg/acs/calacs/acscte/docte.c
+++ b/pkg/acs/calacs/acscte/docte.c
@@ -246,14 +246,14 @@ int DoCTE (ACSInfo *acs_info) {
 
             ctePars.scale_frac = (acs->expstart - ctePars.cte_date0) / (ctePars.cte_date1 - ctePars.cte_date0);
 
-            if ((status = populateHeaderWithCTEKeywordValues(&x[0], &ctePars)))
+            if ((status = populateImageFileWithCTEKeywordValues(&x[0], &ctePars)))
             {
                 freeOnExit(&ptrReg);
                 return (status);
             }
 
-            sprintf(MsgText, "(pctecorr) Read noise level PCTERNCL: %f", ctePars.rn_amp);
-            trlmessage(MsgText);
+            sprintf(MsgText, "(pctecorr) IGNORING read noise level PCTERNOI from PCTETAB: %f. Using amp dependent values from CCDTAB instead", ctePars.rn_amp);
+            trlwarn(MsgText);
             sprintf(MsgText, "(pctecorr) Readout simulation forward modeling iterations PCTENFOR: %i",
                     ctePars.n_forward);
             trlmessage(MsgText);

--- a/pkg/acs/calacs/acscte/dopcte-gen2.c
+++ b/pkg/acs/calacs/acscte/dopcte-gen2.c
@@ -93,6 +93,10 @@ int doPCTEGen2 (ACSInfo *acs, CTEParamsFast * ctePars, SingleGroup * chipImage)
         amploc = strchr(AMPSORDER, ccdamp[nthAmp]);
         ampID = *amploc - AMPSORDER[0];
 
+        ctePars->rn_amp = acs->readnoise[ampID];
+        sprintf(MsgText, "(pctecorr) Read noise level from CCDTAB: %f.", ctePars->rn_amp);
+        trlmessage(MsgText);
+
         /* get amp array size */
         if (get_amp_array_size_acs_cte(acs, chipImage, ampID, amploc, ccdamp,
                                &amp_xsize, &amp_ysize, &amp_xbeg,

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -11,6 +11,6 @@
 
 /* name and version number of generation 2 CTE correction algorithm */
 #define ACS_GEN2_CTE_NAME "PixelCTE 2017"
-#define ACS_GEN2_CTE_VER "1.2"
+#define ACS_GEN2_CTE_VER "2.0"
 
 #endif /* INCL_ACSVERSION_H */

--- a/pkg/acs/calacs/lib/acshist.c
+++ b/pkg/acs/calacs/lib/acshist.c
@@ -68,14 +68,28 @@ int pcteHistory (ACSInfo *acs, Hdr *phdr) {
 	if (OmitStep (acs->pctecorr))		/* nothing to do */
     return (status);
 
-	if (UpdateSwitch ("PCTECORR", acs->pctecorr, phdr, &logit))
-    return (status);
-
 	/* Write history records for the PCTE table. */
-	if (logit) {
-    if (TabHistory (&acs->pcte, phdr))
-      return (status);
+	if (logit)
+	{
+        // Add amp dependent readnoise (PCTERNOI) values used for PCTECORR
+        // read from CCDTAB.
+        char strBuffer[MSG_BUFF_LENGTH];
+        *strBuffer = '\0';
+        {unsigned i;
+        for (i = 0; i < strlen(AMPSORDER); ++i)
+        {
+            sprintf(strBuffer, "PCTERNOI " floatFormat " Amp '%c' read noise clip limit (from CCDTAB).", acs->readnoise[i], AMPSORDER[i]);
+            if ((status = addHistoryKw(phdr, strBuffer)))
+                return status;
+        }}
+
+	    if (addHistoryKw (phdr, "CTE parameters table: ") ||
+	            TabHistory (&acs->pcte, phdr))
+	        return (status);
 	}
+
+    if (UpdateSwitch ("PCTECORR", acs->pctecorr, phdr, &logit))
+        return (status);
 
 	return (status);
 }


### PR DESCRIPTION
ACS CTE: Use amp dependent RN from CCDTAB and not general RN from PCTETAB
    
Resolves #213

AND

Add updateKeyX() and updateKeyOrAddAsHistKeyX() functions
    
Resolves #270

Signed-off-by: James Noss <jnoss@stsci.edu>