### PR TITLE
Temporarily set PCTECORR to OMIT during non-CTE ACSrej so as not to use CTE dark

### DIFF
--- a/pkg/acs/calacs/calacs/wscript
+++ b/pkg/acs/calacs/calacs/wscript
@@ -5,6 +5,10 @@ def build(bld):
         name = 'calacs.e',
         source = 'acsmain.c',
         target = 'calacs.e',
+        includes = ['./',
+                    '../include/',
+                    '../../../../include/'
+                    ],
         use = ['hstcallib', 'calacs', 'imphttab'] + bld.env.LOCAL_LIBS,
         lib = bld.env.EXTERNAL_LIBS,
         libpath = bld.env.LIBPATH,


### PR DESCRIPTION

Fixes #217

Signed-off-by: James Noss <jnoss@stsci.edu>