### PR TITLE
Fix unguarded IFs introduced in #275

### DIFF
--- a/pkg/acs/calacs/lib/reffiles.c
+++ b/pkg/acs/calacs/lib/reffiles.c
@@ -128,7 +128,7 @@ RefFileInfo *ref   io: the list of reference info
     if (!ref)
         return;
 
-	RefFileInfo *current, *next;
+    RefFileInfo *current, *next;
 
 	current = ref->next;		/* don't free the first record */
 	while (current) {

--- a/pkg/stis/calstis/cs12/cs12.c
+++ b/pkg/stis/calstis/cs12/cs12.c
@@ -147,9 +147,11 @@ int main (int argc, char **argv) {
 	    exit (ERROR_RETURN);
 	}
 	if (which_wavecal[0] != '\0') {
-	    if ((status = WavOption (which_wavecal, &w_option)))
-	        freeOnExit(&ptrReg);
-		exit (status);
+        if ((status = WavOption (which_wavecal, &w_option)))
+        {
+            freeOnExit(&ptrReg);
+            exit (status);
+        }
 	} else {
 	    w_option = STIS_LINEAR;
 	}

--- a/pkg/stis/calstis/cs6/cs6.c
+++ b/pkg/stis/calstis/cs6/cs6.c
@@ -180,12 +180,16 @@ int main (int argc, char **argv) {
 
 	    if (MkOutName (finput, isuffix, osuffix, nsuffix,
                 foutput, STIS_FNAME))
+	    {
 	        freeOnExit(&ptrReg);
 	        exit (ERROR_RETURN);
+	    }
 	    if (MkOutName (finput, isuffix, owsuffix, nsuffix,
                 foutw, STIS_FNAME))
+	    {
 	        freeOnExit(&ptrReg);
 	        exit (ERROR_RETURN);
+	    }
 
 	    /* Extract 1-D STIS data. */
 
@@ -203,8 +207,10 @@ int main (int argc, char **argv) {
 	        WhichError (status);
 	    }
 	    if (status)
+	    {
 	        freeOnExit(&ptrReg);
 	        exit (ERROR_RETURN);
+	    }
 	}
 	freeOnExit(&ptrReg);
 	exit (0);

--- a/pkg/stis/calstis/lib/reffiles.c
+++ b/pkg/stis/calstis/lib/reffiles.c
@@ -126,7 +126,7 @@ RefFileInfo *ref   io: the list of reference info
     if (!ref)
         return;
 
-	RefFileInfo *current, *next;
+    RefFileInfo *current, *next;
 
 	current = ref->next;		/* don't free the first record */
 	while (current) {

--- a/pkg/wfc3/calwf3/lib/reffiles.c
+++ b/pkg/wfc3/calwf3/lib/reffiles.c
@@ -133,7 +133,7 @@ RefFileInfo *ref   io: the list of reference info
     if (!ref)
         return;
 
-	RefFileInfo *current, *next;
+    RefFileInfo *current, *next;
 
 	current = ref->next;		/* don't free the first record */
 	while (current) {


### PR DESCRIPTION
Fixes #280

This also addresses the "-Wmisleading-indentation" compiler warnings generated
from the following files, also from #275

pkg/stis/calstis/lib/reffiles.c
pkg/stis/calstis/cs12/cs12.c
pkg/acs/calacs/lib/reffiles.c
pkg/wfc3/calwf3/lib/reffiles.c

Signed-off-by: James Noss <jnoss@stsci.edu>