### PR TITLE
CALACS: Clarifies error/warning messages for SPT files.

### DIFF
--- a/pkg/acs/calacs/calacs/acsdth.c
+++ b/pkg/acs/calacs/calacs/acsdth.c
@@ -35,11 +35,11 @@ static int putEmptyDQ(char *, int, DQHdrData *, int);
  Warren J. Hack, 1998 Oct 14:
  Initial version.
  Warren J. Hack, 1999 Nov 11:
- Adds creation of SPT file for output product.
+ Adds creation of _spt.fits file for output product.
  Warren J. Hack, 2000 Jun 23:
  Modified trailer file creation to include ALL input files.
- Also modified SPT file creation to include all extensions
- from input SPT files.
+ Also modified _spt.fits file creation to include all extensions
+ from input _spt.fits files.
  Warren J. Hack, 2002 Feb 6:
  Moved trailer file initialization outside this so that a
  trailer file can be created/appended for all ASN tables regardless
@@ -47,6 +47,9 @@ static int putEmptyDQ(char *, int, DQHdrData *, int);
  This initialization is now handled by CalAcsRun in 'calacs.c'.
  Warren J. Hack, 2002 April 18:
  Eliminated creation of dummy '_dth.fits' product.
+ Michele D. De La Pena, 2017 September 26:
+ Updated the message regarding the creation of a drizzle-combined data product
+ and some cleanup.
 
  int AcsDth (char *input, char *output, int dthcorr, int printtime, int verbose) {
  */
@@ -80,12 +83,6 @@ int AcsDth (char *in_list, char *output, int dthcorr, int printtime, int verbose
 
   /* ----------------------- Start Code --------------------------------*/
 
-	/* Determine the names of the trailer files based on the input
-   and output file names, then initialize the trailer file buffer
-   with those names.
-   */
-
-  /*	InitDthTrl (in_list, output); */
 	root[0] = '\0';
 	sprintf(mtype,"PROD-DTH");
 
@@ -100,23 +97,18 @@ int AcsDth (char *in_list, char *output, int dthcorr, int printtime, int verbose
 	if (printtime)
     TimeStamp ("ACSDTH started", "");
 
-  sprintf(MsgText,"The task PyDrizzle needs to be run in order to generate");
+  sprintf(MsgText,"The DrizzlePac software package should be used to generate a drizzle-combined");
   trlmessage(MsgText);
-  sprintf(MsgText,"a geometrically corrected, drizzle-combined product.");
-  trlmessage(MsgText);
-  sprintf(MsgText,"PyDrizzle requires PyRAF. See pyraf.stsci.edu for more details.");
+  sprintf(MsgText,"data product.  Please see drizzlepac.stsci.edu for details.\n");
   trlmessage(MsgText);
 
-  /* create new SPT file for output product */
+  /* create new _spt.fits file for output product */
   if (mkNewSpt (in_list, mtype, output)) {
     return(status);
   }
 
   c_imtclose(tpin);
 	PrEnd ("ACSDTH");
-
-	/* Write out temp trailer file to final file */
-	WriteTrlFile ();
 
 	return (status);
 }
@@ -218,7 +210,7 @@ void InitDthTrl (char *inlist, char *output) {
 			trlmessage (MsgText);
 		}
 
-		/* Now, convert trailer filename extensions from '.fits' to '.trl' */
+		/* Now, convert trailer filename extensions from '.fits' to '.tra' */
 		if (MkNewExtn (out_name, TRL_EXTN) ) {
 			sprintf(MsgText, "Error creating input trailer filename %s", out_name);
 			trlerror (MsgText);

--- a/pkg/acs/calacs/calacs/calacs.c
+++ b/pkg/acs/calacs/calacs/calacs.c
@@ -53,6 +53,9 @@
  Moved FLSHCORR from ACSCCD to ACS2D.
  PLL, 2013 Aug 9:
  Separated PCTECORR from ACSCCD. Fixed indentation nightmare.
+ MDD, 2017 Sept 05:
+ Clarify WARNING and ERROR messages associated with _spt files in
+ the ACSDTH step.
 */
 
 void updateAsnTable (AsnInfo *, int, int);
@@ -203,55 +206,57 @@ int CalAcsRun (char *input, int printtime, int save_tmp, int verbose, int debug,
         trlmessage("Finished MAMA processing...");
     }
 
-
-    /* Add DTH processing here... */
-    /* For each DTH product... */
+    /* CALACS no longer generates a drizzled product. Drizzle-combined data is generated   
+       by post-CALACS processing. Instead, the "ACSDTH" pipeline step can create both combined 
+       _spt.fits and .tra files. In order to have a combined output _spt.fits file generated, some 
+       _spt.fits files must exist for the filenames listed in the association table.
+    */
+ 
+    /* Loop over each entry in the association table to create a combined _spt.fits and a 
+       combined .tra file.  The terminology of "dth" is leftover from the original CALACS 
+       implementation.
+    */
     if (asn.process == FULL){
-        if (asn.verbose) {
-            trlmessage ("CALACS: Building DTH products");
-        }
         acsdth_input = NULL;
         for (prod = 0; prod < asn.numprod; prod++) {
-            /* Create empty DTH product, header only */
-            /* This uses only one sub-product for the header template,
-               but later versions should use a function similar to
-               BuildSumInput to create list of subproducts as inputs...
-            */
+
+            /* Create the list of input files */
             acsdth_input = BuildDthInput (&asn, prod);
 
             /* We always want to create a final concatenated trailer file for
-               the entire association whether there is a product or not. So, we
-               set up the trailer file based on the association file name itself.
+               the entire association.  Set up the trailer file based on the 
+               association file name itself.
             */
 
-            /* If desired, we could optionally use the full _drz.tra filename
-               as the trailer filename, based on the output dither product name.
-            if (strcmp(asn.product[prod].prodname,"") != 0) {
-                InitDthTrl (acsdth_input, asn.product[prod].prodname);
-            } else { */
-
+            trlmessage ("CALACS: Building combined .tra product");
             InitDthTrl(acsdth_input, asn.rootname);
 
-            /* End brace for optional dither product name assignment...
-            } */
+            /* Write out temp trailer file to final file */
+            WriteTrlFile ();
 
-            /* Check if we have a PROD-DTH specified...*/
+            /* Check if we have a PROD-DTH specified in the association table.  Even
+               though CALACS will not produce the drizzled product, the MEMTYPE of the 
+               rootname of the association dataset can be PROD-DTH.
+            */
             if (strcmp(asn.product[prod].prodname, "") != 0) {
 
                 if ((asn.dthcorr == PERFORM || asn.dthcorr == DUMMY)) {
+                    trlmessage ("CALACS: Building combined _spt.fits product");
                     if (AcsDth (acsdth_input, asn.product[prod].prodname, asn.dthcorr, printtime, asn.verbose) )
                         return (status);
 
-                    /* Pass posid of 0 to indicate a PRODUCT is to be updated */
                     updateAsnTable(&asn, prod, NOPOSID);
                 }
             } else {
-                trlwarn ("No DTH product name specified. No product created.");
-                /*status = ACS_OK; */
+                trlwarn ("No combined product specified in the association table - no _spt.fits file to be generated.");
             }
         }
-        free (acsdth_input);
+
+        if (acsdth_input != NULL) {
+            free (acsdth_input);
+        }
     }
+
     if (asn.verbose) {
         trlmessage ("CALACS: Finished processing product ");
     }

--- a/pkg/acs/calacs/lib/mkspt.c
+++ b/pkg/acs/calacs/lib/mkspt.c
@@ -1,6 +1,6 @@
-# include <ctype.h>
 # include <stdio.h>
 # include <string.h>
+# include <ctype.h>
 #include "hstcal.h"
 # include "xtables.h"
 
@@ -9,18 +9,19 @@
 # include "acs.h"
 # include "hstcalerr.h"
 
-/* mkNewSpt -- Create a new SPT file for the output file.
+/* mkNewSpt -- Create a new _spt.fits file for the output file.
 
   Description:
   ------------
-    New file will be based on primary header of first input file
+    New file will be based on primary header of first found input file
     given and will not have any extensions.
 
   Date          Author      Description
   ----          ------      -----------
   11-10-1999    W.J. Hack   Initial version
                             based on InitRejTrl and n_mkSPT from CALNICB
-
+  11-18-2017    M.D. De La Pena  Clarified message when input *_spt.fits files not found.  
+                            Generalized creation of output association _spt.fits file.
 */
 
 int mkNewSpt (char *in_list, char *mtype, char *output) {
@@ -29,25 +30,26 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
     arguments:
     char    *in_list            i: input filename/list to copy SPT data
     char    *mtype              i: type of exposure in association
-    char    *output             o: rootname of output SPT file
+    char    *output             o: rootname of output _spt.fits file
 */
 
     extern int  status;
-    IRAFPointer tpin;
+    IRAFPointer tpin = NULL;
     int         n;
-	Hdr         header;		                /* SPT header */
-	FILE        *fp;		                /* file pointer */
-	IODescPtr   im;		           /* descriptor for input image */
+	Hdr         header;          /* _spt.fits header */
+	FILE        *fp = NULL;      /* file pointer */
+	IODescPtr   im = NULL;       /* descriptor for output image */
+	IODescPtr   imUpdate = NULL; /* new descriptor if output image has to be updated */
 
     char        in_name[CHAR_FNAME_LENGTH+1];       /* filename of input data */
-    char        in_spt[CHAR_FNAME_LENGTH+1];        /* filename of SPT source data */
-    char        out_spt[CHAR_FNAME_LENGTH+1];       /* output SPT filename */
-    char        rootname[CHAR_FNAME_LENGTH+1];       /* output SPT rootname */
-    char        obsnum[4];                  /* Observation number string */
+    char        in_spt[CHAR_FNAME_LENGTH+1];        /* filename of _spt.fits source data */
+    char        out_spt[CHAR_FNAME_LENGTH+1];       /* output _spt.fits filename */
+    char        rootname[CHAR_FNAME_LENGTH+1];      /* output _spt.fits rootname */
+    char        obsnum[4];                          /* Observation number string */
     ShortHdrData  stmp;
     int         nimgs, i;
     int         nx;
-	int 		extnum,nextn;
+	int 		extnum, nextn;
 
 
     char        *isuffix[] = {"_blv_tmp","_crj_tmp","_flt","_crj","_dth","_sfl"};
@@ -62,123 +64,160 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
     int         LoadHdr (char *, Hdr *);
     int         PutKeyStr(Hdr *, char *, char *, char *);
     int         PutKeyInt (Hdr *, char *, int, char *);
-    int 	GetKeyInt (Hdr *, char *, int, int, int *);
+    int			GetKeyInt (Hdr *, char *, int, int, int *);
+
+    Bool        doCreateOutputSPT  = False;
+    Bool        isOutputSPTCreated = False;
+    int         numSPT = 0;
 
 /* ----------------------------- Begin ------------------------------*/
-
+   
     out_spt[0] = '\0';
     /*
-        Create output SPT filename from output data filename.
+        Create output _spt.fits filename from output data filename.
     */
     if(MkOutName (output, isuffix, osuffix, nsuffix, out_spt, CHAR_FNAME_LENGTH)){
-        sprintf (MsgText, "Couldn't create output SPT filename for %s", output);
+        sprintf (MsgText, "Couldn't create output _spt.fits filename for %s", output);
         trlerror (MsgText);
         WhichError (status);
         return (status);
     }
 
-    /* See if an output SPT file already exists */
+    // FUTURE WORK: What if there are no input files so CALACS would not make an output file anyway?
+    /* In this case it is not necessary to see if an output _spt.fits file already exists */
     if (FileExists (out_spt)) {
+        sprintf (MsgText, "Output _spt.fits filename for %s exists - cannot overwrite file.", out_spt);
+        trlerror (MsgText);
         return (status);
     }
 
     /*
-        Now, let's get the data to be copied into this new SPT file.
+        Now, let's get the data to be copied into this new _spt.fits file.
     */
     /* open the input file template */
     tpin = c_imtopen (in_list);
     nimgs = c_imtlen(tpin);
 
     /* Loop over all images in input list, and append them to output
-        SPT file.
+        _spt.fits file.
+        nimgs  = Total number of _spt.fits filenames in input list
+        numSPT = Total number of actual existing input _spt.fits files
+        extnum = Total number of SPT extensions in all existing _spt.fits files to be written to output
     */
-	extnum = 0;
+	extnum = 0;  
     for (i = 0; i < nimgs; i++) {
         /* Get first name from input (list?) */
         in_name[0] = '\0';
         c_imtgetim (tpin, in_name, CHAR_FNAME_LENGTH);
 
         in_spt[0] = '\0';
-        /* Create input SPT filename to look for */
+        /* Create input _spt.fits filename */
         if (MkOutName (in_name, isuffix, osuffix, nsuffix, in_spt, CHAR_FNAME_LENGTH)) {
-            sprintf (MsgText, "Couldn't create input SPT filename for %s", in_name);
+            sprintf (MsgText, "Couldn't create input _spt.fits filename for %s", in_name);
             trlerror (MsgText);
             WhichError (status);
             return (status);
         }
-	    /* Check for existence of source/input SPT file */
+
+        /* Check for existence of source/input _spt.fits file */
+        /* If there are no input _spt.fits files, then no combined/ASN _spt.fits file will be created */
 	    if ((fp = fopen (in_spt, "rb")) == NULL) {
-	        sprintf (MsgText, "Can't find input file \"%s\"", in_spt);
+	        sprintf (MsgText, "Cannot find file \"%s\" - processing can proceed.  The\noutput association _spt.fits is comprised of any found individual _spt.fits files.\n", in_spt);
 	        trlwarn  (MsgText);
             status = ACS_OK;        /* don't abort */
 	        continue;				/* try the rest of the images in list */
 	    } else
 	        (void)fcloseWithStatus(&fp);
 
-        /* Create Primary header of new output SPT file from first input
+        /* Keep a count of the number of existing input _spt.fits files.  Only create the output
+           _spt.fits once an input _spt.fits is found.
+        */
+        numSPT++;
+        if (!isOutputSPTCreated)
+            doCreateOutputSPT = True;
+
+        /* Create Primary header of new output _spt.fits file from first found input
             image...
         */
-	    /* Read the primary header of the input SPT file */
+	    /* Read the primary header of the input _spt.fits file */
         nextn = 0;
-		if (LoadHdr (in_spt, &header) )
-            	    return (status);
-		if (GetKeyInt (&header, "NEXTEND", USE_DEFAULT, 1, &nextn)){
-			nextn = 1;
-		}
-        if (i == 0) {
-            /* Create ROOTNAME for output SPT file */
+        if (LoadHdr (in_spt, &header)) {
+            freeHdr (&header);
+            return (status);
+        }
+
+        /* If any of the input _spt.fits files actually contain multiple extensions, then
+           the total number of output extensions is the total number of extensions in 
+           each of the existing input _spt.fits files in the most general case.
+        */
+		(void) GetKeyInt (&header, "NEXTEND", USE_DEFAULT, 1, &nextn);
+
+        if (doCreateOutputSPT) {
+            doCreateOutputSPT  = False;
+            isOutputSPTCreated = True;
+            /* Create ROOTNAME for output _spt.fits file */
             rootname[0] = '\0';
             if (MkName (out_spt, "_spt", "", " ", rootname, CHAR_FNAME_LENGTH)) {
-                sprintf (MsgText, "Couldn't create output SPT ROOTNAME for %s", out_spt);
+                sprintf (MsgText, "Couldn't create output _spt.fits ROOTNAME for %s", out_spt);
                 trlerror (MsgText);
+                freeHdr (&header);
                 WhichError (status);
                 return (status);
             } else {
-		        sprintf(MsgText, "Created output SPT rootname %s...\n",out_spt);
+                sprintf(MsgText, "Created output _spt.fits rootname %s...\n",out_spt);
                 trlmessage (MsgText);
 		    }
 
-	        /* Update the FILENAME header keyword */
-	        if (PutKeyStr (&header, "FILENAME", out_spt, ""))
-	            return (status = 1);
+            /* Update the FILENAME header keyword */
+            if ((status = PutKeyStr (&header, "FILENAME", out_spt, ""))) {
+                freeHdr (&header);
+                return (status);
+             }
 
-	        /* Update the ASN_MTYP header keyword */
-	        if (PutKeyStr(&header, "ASN_MTYP", mtype, "Role of the Exposure in the Association"))
-	            return (status = 1);
+            /* Update the ASN_MTYP header keyword */
+            if ((status = PutKeyStr(&header, "ASN_MTYP", mtype, "Role of the Exposure in the Association"))) {
+                freeHdr (&header);
+                return (status);
+            }
 
-	        /* NOW, update the ROOTNAME header keyword */
-	        for (n = 0; n < strlen(rootname)-1; n++)
-	             rootname[n] = toupper(rootname[n]);
-	        if (PutKeyStr (&header, "ROOTNAME", rootname, ""))
-	            return (status = 1);
+            /* NOW, update the ROOTNAME header keyword */
+            for (n = 0; n < strlen(rootname)-1; n++)
+                rootname[n] = toupper(rootname[n]);
+            if ((status = PutKeyStr (&header, "ROOTNAME", rootname, ""))) {
+                freeHdr (&header);
+                return (status);
+            }
 
             /* Update the OBSERVTN header keyword */
             strncpy (obsnum, &rootname[6], 3); obsnum[3] = '\0';
-            if (putKeyS (&header, "OBSERVTN", obsnum, ""))
-                return (status = 1);
+            if ((status = putKeyS (&header, "OBSERVTN", obsnum, ""))) {
+                freeHdr (&header);
+                return (status);
+            }
 
-	        /* Update the NEXTEND header keyword to reflect number of input
-                images.
+            /* Update the NEXTEND header keyword to reflect number of input
+               images.  This will be updated as necessary at the end of this routine.
             */
-	        if (PutKeyInt (&header, "NEXTEND", nimgs, ""))
-	            return (status = 1);
+            if ((status = PutKeyInt (&header, "NEXTEND", nimgs, ""))) {
+                freeHdr (&header);
+                return (status);
+            }
 
-            sprintf(MsgText,"Updated output SPT file to reflect %d extensions...\n",nimgs);
-            trlmessage(MsgText);
-
-	        /* Write the new SPT file */
+            /* Write the new _spt.fits file */
             /* Open the image; this also writes the header */
             im = openOutputImage (out_spt, "", 0, &header, 0, 0, FITSBYTE);
-            if (hstio_err()) {
+            if (!im || hstio_err()) {
                 trlopenerr (out_spt);
+                freeHdr (&header);
                 return (status = OPEN_FAILED);
             }
+
             /* Close the image */
             closeImage (im);
+            im = NULL;
         }
 
-        /* Uncomment this section to copy input SPT files into output
-            when HSTIO is fixed to work with 1-D data... */
+        /* Write the 1-D data */
 		for (nx = 0; nx < nextn; nx++){
 			extnum = extnum + 1;
         	initShortHdrData(&stmp);
@@ -187,11 +226,45 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
         	freeShortHdrData(&stmp);
         }
 
-	    /* Close the header here... */
+        /* Close the header here... */
         freeHdr (&header);
+    }
+
+    /* If necessary, re-open the primary header to update the NEXTEND keyword */
+    if ((extnum != numSPT) || (numSPT != nimgs)) {
+
+        imUpdate = openUpdateImage (out_spt, "", 0, &header);
+        if (!imUpdate || hstio_err()) {
+            trlopenerr (out_spt);
+            freeHdr (&header);
+            return (status = OPEN_FAILED);
+        }
+
+        if ((status = PutKeyInt (&header, "NEXTEND", extnum, ""))) {
+            closeImage (imUpdate);
+            imUpdate = NULL;
+            freeHdr (&header);
+            return (status);
+        }
+
+        /* Write the updated header and clean up */
+        if ((status = putHeader(imUpdate))) {
+            closeImage (imUpdate);
+            imUpdate = NULL;
+            freeHdr (&header);
+            return (status);
+        }
+
+        closeImage (imUpdate);
+        imUpdate = NULL;
+        freeHdr (&header);
+
+        sprintf(MsgText,"Updated output _spt.fits file to reflect %d extensions...\n",extnum);
+        trlmessage(MsgText);
     }
 
     c_imtclose (tpin);
 	/* Successful return */
 	return (status);
 }
+


### PR DESCRIPTION
Improves error message for existing output association SPT file and warning messages
for individual input SPT files.  Also, now writes all existing input SPT arrays into
output association SPT file.

This fix potentially changes the output association SPT file. CALACS now writes all
existing input SPT arrays (extensions) into the output association SPT file.  Formerly,
if the first input SPT file named in the association table did not exist, no output
association SPT file would be written at all.  Also, if an input SPT file contained
multiple SPT arrays, only one of the arrays would be written to the output association
SPT file.

Resolves #199
Signed-off-by: Michele De La Pena <mdelapena@stsci.edu>