### PR TITLE
All BIAS files are processed by CALACS to use only read noise for ERR…

### DIFF
--- a/pkg/acs/calacs/acsrej/acsrej_init.c
+++ b/pkg/acs/calacs/acsrej/acsrej_init.c
@@ -52,7 +52,7 @@ int acsrej_init (IODescPtr ipsci[], IODescPtr ipdq[], clpar *par, int nimgs, int
     float       exp2n, expn;
     int         non_zero;
     Hdr         dqhdr;
-    int         newbias;
+    int         readnoise_only;
 
     void        ipiksrt (float [], int, int[]);
     void        get_nsegn (int, int, int, int, float *, float*, float *, float *);
@@ -65,7 +65,7 @@ int acsrej_init (IODescPtr ipsci[], IODescPtr ipdq[], clpar *par, int nimgs, int
     detector = gain.detector;
     chip = gain.chip;
     dqpat = par->badinpdq;
-    newbias = par->newbias;
+    readnoise_only = par->readnoise_only;
 
     ipts = calloc (nimgs, sizeof(int));
     npts = calloc (dim_x, sizeof(int));
@@ -160,7 +160,7 @@ int acsrej_init (IODescPtr ipsci[], IODescPtr ipdq[], clpar *par, int nimgs, int
                 }
                 raw0 = Pix(sg->sci.data,i,j);
                 exp2n = (expn > 0.) ? expn : 1.;
-                if (newbias == 0) {
+                if (readnoise_only == 0) {
                     Pix(sg->err.data,i,j) = (nse[0]+ raw0/gn[0] + SQ(scale*raw0)) / exp2n;
                 } else {
                     Pix(sg->err.data,i,j) = (nse[0]) / exp2n;
@@ -186,7 +186,7 @@ int acsrej_init (IODescPtr ipsci[], IODescPtr ipdq[], clpar *par, int nimgs, int
 
                 raw0 = Pix(sg->sci.data,i,j);
                 exp2n = (expn > 0.) ? expn : 1.;
-                if (newbias == 0){
+                if (readnoise_only == 0){
                     Pix(sg->err.data,i,j) = (nse[1]+ raw0/gn[1] + SQ(scale*raw0)) / exp2n;
                 } else {
                     Pix(sg->err.data,i,j) = (nse[1]) / exp2n;
@@ -239,7 +239,7 @@ int acsrej_init (IODescPtr ipsci[], IODescPtr ipdq[], clpar *par, int nimgs, int
                         if ((bufdq[i] & dqpat) == OK && (efac[n] > 0.)) {
                             Pix(sg->sci.data,i,j) = val;
                             /*Pix(sg->err.data,i,j) = (nse[0]+ raw0/gn[0] + SQ(scale*raw0)) / exp2[n];*/
-                            if (newbias == 0){
+                            if (readnoise_only == 0){
                                 Pix(sg->err.data,i,j) = (nse[0]+ raw0/gn[0] + SQ(scale*signal0)) / exp2[n];
                             } else {
                                 Pix(sg->err.data,i,j) = (nse[0]) / exp2[n];
@@ -266,7 +266,7 @@ int acsrej_init (IODescPtr ipsci[], IODescPtr ipdq[], clpar *par, int nimgs, int
                     if ( (n == 0) || (val < Pix(sg->sci.data,i,j) && ((bufdq[i] & dqpat) == OK)) ) {
                         Pix(sg->sci.data,i,j) = val;
                         if (efac[n] > 0.) {
-                            if (newbias == 0){
+                            if (readnoise_only == 0){
                                 Pix(sg->err.data,i,j) = (nse[1]+ raw0/gn[1] + SQ(scale*signal0)) / exp2[n];
                             } else {
                                 Pix(sg->err.data,i,j) = (nse[1]) / exp2[n];

--- a/pkg/acs/calacs/acsrej/acsrej_loop.c
+++ b/pkg/acs/calacs/acsrej/acsrej_loop.c
@@ -143,7 +143,7 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr ipdq[],
     short   maskdq;
 
     float   efacn, skyvaln, exp2n;
-    int     newbias;
+    int     readnoise_only;
 
     ShortTwoDArray dq2;         /* local array for storing output blv DQ vals */
 
@@ -196,7 +196,7 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr ipdq[],
     nocr = ~crflag;
     nospill = ~SPILL;
     numpix = dim_x * dim_y;
-    newbias = par->newbias;
+    readnoise_only = par->readnoise_only;
 
     /* Set up mask for detecting CR-affected pixels */
     maskdq = OK | EXCLUDE;
@@ -674,7 +674,7 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr ipdq[],
                                 sumvar[i] += nse[0] + val/gn[0] + SQ(scale*val);
                                 */
 
-                                if (newbias == 0) {
+                                if (readnoise_only == 0) {
                                     sumvar[i] += nse[0] + val/gn[0];
                                 } else {
                                     sumvar[i] += nse[0];
@@ -689,7 +689,7 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr ipdq[],
                                 /* clip the data at zero */
                                 val = (dum > 0.) ? dum : 0.;
 
-                                if (newbias == 0) {
+                                if (readnoise_only == 0) {
                                     sumvar[i] += nse[1] + val/gn[1];
                                 } else {
                                     sumvar[i] += nse[1];

--- a/pkg/acs/calacs/acsrej/rej_command.c
+++ b/pkg/acs/calacs/acsrej/rej_command.c
@@ -47,12 +47,27 @@ int newpar[];       o: array of parameters set by the user
         List all options for user
     */
     if (argc < 3) {
-        syntax_error ("acsrej input output [-t] [-v]");
-        printf("                    [-shadcorr] [-crmask] [-newbias] \n ");
+        syntax_error ("acsrej.e input output [-t] [-v]");
+        printf("                    [-shadcorr] [-crmask] [-readnoise_only] \n");
         printf("                    [-table <filename>] [-scale #]\n");
         printf("                    [-init (med|min)] [-sky (none|mode)]\n");
         printf("                    [-sigmas #] [-radius #] [-thresh #]\n");
-        printf("                    [-pdq #]\n");
+        printf("                    [-pdq #]\n\n");
+		printf("input             comma-delimited string (e.g., filename or filename1,filename2,filename3)\n");
+		printf("output            string\n");
+		printf("-t                print timestamps\n");
+		printf("-v                turn on verbose mode\n");
+		printf("-shadcorr         turn on shutter shading correction (intended for CCD images only)\n");
+		printf("-crmask           flag CR-rejected pixels in the input files\n");
+		printf("-readnoise_only   use read noise and not Poission noise to create ERR array (intended for BIAS images)\n");
+		printf("-table filename   cosmic ray rejection table to use for default parameter values\n");
+		printf("-scale #          multiplicative factor (in percent) applied to noise\n");
+		printf("-init med|min     scheme for computing initial guess image (median or minimum)\n");
+		printf("-sky none|mode    scheme for computing sky levels to be subtracted (none:0.0 or mode:most frequently occurring value)\n");
+		printf("-sigmas #[,#...]  cosmic ray rejection thresholds, no. of thresholds are the no. of iterations\n");
+		printf("-radius #         radius (in pixels) to propagate the cosmic ray\n");
+		printf("-thresh #         cosmic ray rejection propagation threshold\n");
+		printf("-pdq #            data quality flag used for cosmic ray rejection\n\n");
         return(status);
     }
 
@@ -89,8 +104,22 @@ int newpar[];       o: array of parameters set by the user
                 par->shadcorr = 1;
                 ctoken++;
 
+            // This option/variable was previously named "newbias", and it has been renamed
+            // to "readnoise_only" which is more informative.  The variable controls
+            // the type of noise used in the computation of the error (ERR) array.  In particular,
+            // this variable is intended to control the noise used when processing BIAS data.  When
+            // using CALACS, readnoise_only will only be set to "1" (true) for BIAS data.  When using
+            // ACSREJ as a standalone utility, the readnoise_only can be set to "1" for any data.
             } else if (strcmp("newbias", argv[ctoken]+1) == 0) {
-                par->newbias = 1;
+                printf ("\n***************************************************************************************\n");
+				printf ("     As of HSTCAL Version 2.0.0 (CALACS Version 10.0.0 HSTDP 2018_1) the 'newbias'\n ");
+                printf ("    option for ACSREJ has been renamed 'readnoise_only' to clarify functionality.\n ");
+                printf ("    Please update all programs which invoke ACSREJ with this option.\n");
+                printf ("***************************************************************************************\n\n");
+                return (status = INVALID_VALUE);
+
+            } else if (strcmp("readnoise_only", argv[ctoken]+1) == 0) {
+                par->readnoise_only = 1;
                 ctoken++;
 
             } else if (strcmp("crmask", argv[ctoken]+1) == 0) {
@@ -245,7 +274,7 @@ int newpar[];     o: array of parameters set by the user
     par->verbose = 0;
     par->printtime = 0;
     par->shadcorr = 0;
-    par->newbias = 0;
+    par->readnoise_only = 0;
 
     newpar[TOTAL] = 0;
     newpar[SCALENSE] = 0;

--- a/pkg/acs/calacs/calacs/acsinit.c
+++ b/pkg/acs/calacs/calacs/acsinit.c
@@ -83,7 +83,7 @@ void ACSDefaults (ACSInfo *acs) {
     acs->scibin[1] = 0;
     acs->scigain = 0;
     acs->samebin = 0;
-    acs->newbias = 0;
+    acs->readnoise_only = 0;
 
     /* Initialize flags to not perform the step. */
     acs->sci_basic_ccd = OMIT;

--- a/pkg/acs/calacs/calacs/calacs.c
+++ b/pkg/acs/calacs/calacs/calacs.c
@@ -378,7 +378,7 @@ static int ACSRej_0Wrapper(char * inputList,
         Bool updateASNTableFlag)
 {
     if (ACSRej_0 (inputList, crTempName, acshdr->mtype,
-                                  acshdr->newbias, printtime, asn->verbose))
+                                  acshdr->readnoise_only, printtime, asn->verbose))
     {
         if (status == NO_GOOD_DATA)
         {
@@ -1267,7 +1267,7 @@ static int CopyFFile (char *infile, char *outfile) {
    default parameters, copies printtime and verbose into the par structure,
    and calls ACSRej.
 */
-static int ACSRej_0 (char *input, char *output, char *mtype, int newbias, int printtime, int verbose) {
+static int ACSRej_0 (char *input, char *output, char *mtype, int readnoise_only, int printtime, int verbose) {
 
     extern int status;
     clpar par;              /* parameters used */
@@ -1279,7 +1279,7 @@ static int ACSRej_0 (char *input, char *output, char *mtype, int newbias, int pr
     rej_reset (&par, newpar);
     par.printtime = printtime;
     par.verbose = verbose;
-    par.newbias = newbias;
+    par.readnoise_only = readnoise_only;
 
     status = AcsRej (input, output, mtype, &par, newpar);
 

--- a/pkg/acs/calacs/calacs/calacs.h
+++ b/pkg/acs/calacs/calacs/calacs.h
@@ -39,7 +39,7 @@ typedef struct {
     int scibin[2];  /* binning factors */
     int scigain;    /* ccdgain values */
     int samebin;
-    int newbias;
+    int readnoise_only;
 
     /* calibration switches */
     int sci_basic_ccd;  /* do acsccd? (dqicorr or blevcorr) */

--- a/pkg/acs/calacs/calacs/getsciinfo.c
+++ b/pkg/acs/calacs/calacs/getsciinfo.c
@@ -31,14 +31,12 @@ RefFileInfo *sciref  io: list of keyword,filename pairs for science file
 	Hdr phdr;		/* primary header */
 	int nextend;		/* number of FITS extensions in rawfile */
 
-    time_t date,date_limit;
-    char dateobs[ACS_CBUF],targname[CHAR_LINE_LENGTH];
+    char targname[CHAR_LINE_LENGTH];
 
     int GetKeyStr (Hdr *, char *, int, char *, char *, int);
 	int GetKeyInt (Hdr *, char *, int, int, int *);
 	int GetFlags (CalSwitch *, Hdr *);
 	int SciFlags (ACSInfo *, CalSwitch *, Hdr *, RefFileInfo *);
-        int parseObsDateVal (char *dateobs, time_t *date);
 
 	/* Read primary header of rawfile into phdr. */
 	initHdr (&phdr);
@@ -74,19 +72,10 @@ RefFileInfo *sciref  io: list of keyword,filename pairs for science file
     */
 	acs->samebin = 1;	/* default */
 
-    /* Get and parse DATE-OBS into a floating point value*/
-    if (GetKeyStr (&phdr, "DATE-OBS", USE_DEFAULT, "", dateobs, ACS_CBUF))
-        	    return (status);
-    parseObsDateVal(dateobs, &date);
-    /* Parse date used to check whether ACS HRC/WFC data was
-       pre-SM4 or post-SM4 and turn into a float for comparison
-       with exposure's date-obs
-    */
-    parseObsDateVal("2009-01-01", &date_limit);
     if (GetKeyStr (&phdr, "TARGNAME", USE_DEFAULT, "", targname, CHAR_LINE_LENGTH))
         return (status);
-    if (strncmp(targname,"BIAS",4) == 0 && date > date_limit){
-        acs->newbias = 1;
+    if (strncmp(targname,"BIAS",4) == 0){
+        acs->readnoise_only = 1;
     }
 
 	/* Get calibration switches, and check that reference files exist. */

--- a/pkg/acs/calacs/include/acsrej.h
+++ b/pkg/acs/calacs/include/acsrej.h
@@ -37,7 +37,7 @@ typedef struct {
     int     shadcorr;
     int     printtime;
     int     verbose;
-    int     newbias;
+    int     readnoise_only;
 } clpar;
 
 #endif /* INCL_ACSREJ_H */


### PR DESCRIPTION
All BIAS files are now processed by CALACS to use only read noise (vs Poisson) for the computation of the ERR array as the date discriminant (pre- and post-SM4) has been removed. Also, when using ACSREJ standalone, the user now must use the "readnoise_only" flag (formerly "newbias" flag) to obtain the same results as CALACS for BIAS images.  NOTE: Modifying the flag to ACSREJ is expeditious rather than user-friendly.  The "newbias" flag has been removed (not just deprecated) as this functionality is used mostly internally for calibration purposes.  If the "newbias" flag is invoked, ACSREJ will issue an message regarding the change and exit with an error.

When updating ACSREJ for standalone use, improved the syntax or usage message which addresses a portion of #278 for ACSREJ only.

Resolves #277. (EDIT: Added a space for proper cross-linking.)
Addresses some components of #278 for ACSREJ only.
  