### PR TITLE
Uninitialized variable yields undefined behavior for logging pctehistory keywords

### DIFF
--- a/pkg/acs/calacs/lib/acshist.c
+++ b/pkg/acs/calacs/lib/acshist.c
@@ -68,6 +68,9 @@ int pcteHistory (ACSInfo *acs, Hdr *phdr) {
 	if (OmitStep (acs->pctecorr))		/* nothing to do */
     return (status);
 
+    if (UpdateSwitch ("PCTECORR", acs->pctecorr, phdr, &logit))
+        return (status);
+
 	/* Write history records for the PCTE table. */
 	if (logit)
 	{
@@ -87,9 +90,6 @@ int pcteHistory (ACSInfo *acs, Hdr *phdr) {
 	            TabHistory (&acs->pcte, phdr))
 	        return (status);
 	}
-
-    if (UpdateSwitch ("PCTECORR", acs->pctecorr, phdr, &logit))
-        return (status);
 
 	return (status);
 }


### PR DESCRIPTION
Fixes #295

Regression introduced by #271

Signed-off-by: James Noss <jnoss@stsci.edu>