### PR TITLE
Modifications to address IT199

### DIFF
--- a/pkg/acs/calacs/calacs/acsdth.c
+++ b/pkg/acs/calacs/calacs/acsdth.c
@@ -100,11 +100,9 @@ int AcsDth (char *in_list, char *output, int dthcorr, int printtime, int verbose
 	if (printtime)
     TimeStamp ("ACSDTH started", "");
 
-  sprintf(MsgText,"The task PyDrizzle needs to be run in order to generate");
+  sprintf(MsgText,"\nThe DrizzlePac software package should be used to generate a drizzle-combined");
   trlmessage(MsgText);
-  sprintf(MsgText,"a geometrically corrected, drizzle-combined product.");
-  trlmessage(MsgText);
-  sprintf(MsgText,"PyDrizzle requires PyRAF. See pyraf.stsci.edu for more details.");
+  sprintf(MsgText,"data product.  Please see drizzlepac.stsci.edu for details.\n");
   trlmessage(MsgText);
 
   /* create new SPT file for output product */

--- a/pkg/acs/calacs/lib/mkspt.c
+++ b/pkg/acs/calacs/lib/mkspt.c
@@ -9,7 +9,7 @@
 # include "acs.h"
 # include "hstcalerr.h"
 
-/* mkNewSpt -- Create a new SPT file for the output file.
+/* mkNewSpt -- Create a new *_spt.fits file for the output file.
 
   Description:
   ------------
@@ -27,27 +27,27 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
 
 /*
     arguments:
-    char    *in_list            i: input filename/list to copy SPT data
+    char    *in_list            i: input filename/list to copy *_spt.fits data
     char    *mtype              i: type of exposure in association
-    char    *output             o: rootname of output SPT file
+    char    *output             o: rootname of output *_spt.fits file
 */
 
     extern int  status;
-    IRAFPointer tpin;
+    IRAFPointer tpin = NULL;
     int         n;
-	Hdr         header;		                /* SPT header */
-	FILE        *fp;		                /* file pointer */
-	IODescPtr   im;		           /* descriptor for input image */
+	Hdr         header;		                /* *_spt.fits header */
+	FILE        *fp = NULL;		                /* file pointer */
+	IODescPtr   im  = NULL;		           /* descriptor for input image */
 
     char        in_name[CHAR_FNAME_LENGTH+1];       /* filename of input data */
-    char        in_spt[CHAR_FNAME_LENGTH+1];        /* filename of SPT source data */
-    char        out_spt[CHAR_FNAME_LENGTH+1];       /* output SPT filename */
-    char        rootname[CHAR_FNAME_LENGTH+1];       /* output SPT rootname */
+    char        in_spt[CHAR_FNAME_LENGTH+1];        /* filename of *_spt.fits source data */
+    char        out_spt[CHAR_FNAME_LENGTH+1];       /* output *_spt.fits filename */
+    char        rootname[CHAR_FNAME_LENGTH+1];       /* output *_spt.fits rootname */
     char        obsnum[4];                  /* Observation number string */
     ShortHdrData  stmp;
     int         nimgs, i;
     int         nx;
-	int 		extnum,nextn;
+	int 		extnum, nextn;
 
 
     char        *isuffix[] = {"_blv_tmp","_crj_tmp","_flt","_crj","_dth","_sfl"};
@@ -68,29 +68,32 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
 
     out_spt[0] = '\0';
     /*
-        Create output SPT filename from output data filename.
+        Create output *_spt.fits filename from output data filename.
     */
     if(MkOutName (output, isuffix, osuffix, nsuffix, out_spt, CHAR_FNAME_LENGTH)){
-        sprintf (MsgText, "Couldn't create output SPT filename for %s", output);
+        sprintf (MsgText, "Couldn't create output *_spt.fits filename for %s", output);
         trlerror (MsgText);
         WhichError (status);
         return (status);
     }
 
-    /* See if an output SPT file already exists */
+    /* See if an output *_spt.fits file already exists */
+    /* Low-level code issues a warning if the file already exists, and it cannot be deleted. */
     if (FileExists (out_spt)) {
+        sprintf (MsgText, "Solution is to delete %s file or to set environment variable 'imclobber' to 'yes'.", out_spt);
+        trlerror (MsgText);
         return (status);
     }
 
     /*
-        Now, let's get the data to be copied into this new SPT file.
+        Now, let's get the data to be copied into this new *_spt.fits file.
     */
     /* open the input file template */
     tpin = c_imtopen (in_list);
     nimgs = c_imtlen(tpin);
 
     /* Loop over all images in input list, and append them to output
-        SPT file.
+        *_spt.fits file.
     */
 	extnum = 0;
     for (i = 0; i < nimgs; i++) {
@@ -99,87 +102,109 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
         c_imtgetim (tpin, in_name, CHAR_FNAME_LENGTH);
 
         in_spt[0] = '\0';
-        /* Create input SPT filename to look for */
+        /* Create input *_spt.fits filename */
         if (MkOutName (in_name, isuffix, osuffix, nsuffix, in_spt, CHAR_FNAME_LENGTH)) {
-            sprintf (MsgText, "Couldn't create input SPT filename for %s", in_name);
+            sprintf (MsgText, "Couldn't create input *_spt.fits filename for %s", in_name);
             trlerror (MsgText);
             WhichError (status);
             return (status);
         }
-	    /* Check for existence of source/input SPT file */
+	    /* Check for existence of source/input *_spt.fits file */
+        /* If the input *_spt.fits file corresponding to the first *_raw.fits file in the list is missing, this */
+        /* routine will fail as the header from the first *_spt.fits is used for the header of the output *_spt.fits file. */
+        /* This routine needs to be re-worked to use the header from any found input *_spt.fits file. */
 	    if ((fp = fopen (in_spt, "rb")) == NULL) {
-	        sprintf (MsgText, "Can't find input file \"%s\"", in_spt);
-	        trlwarn  (MsgText);
+			if (i == 0) {
+	            sprintf (MsgText, "Cannot find the first input file \"%s\" which is needed to create the output file header.\n", in_spt);
+	            trlerror (MsgText);
+            } else {
+	            sprintf (MsgText, "Cannot find input file \"%s\", but processing can proceed.  Output\nassociation *_spt.fits is comprised of any found individual *_spt.fits files.\n", in_spt);
+	            trlwarn (MsgText);
+            }
             status = ACS_OK;        /* don't abort */
 	        continue;				/* try the rest of the images in list */
 	    } else
 	        (void)fcloseWithStatus(&fp);
 
-        /* Create Primary header of new output SPT file from first input
+        /* Create Primary header of new output *_spt.fits file from first input
             image...
         */
-	    /* Read the primary header of the input SPT file */
+	    /* Read the primary header of the input *_spt.fits file */
         nextn = 0;
-		if (LoadHdr (in_spt, &header) )
-            	    return (status);
-		if (GetKeyInt (&header, "NEXTEND", USE_DEFAULT, 1, &nextn)){
-			nextn = 1;
+		if (LoadHdr (in_spt, &header)) {
+			freeHdr (&header);
+			return (status);
 		}
+
+		GetKeyInt (&header, "NEXTEND", USE_DEFAULT, 1, &nextn);
+
         if (i == 0) {
-            /* Create ROOTNAME for output SPT file */
+            /* Create ROOTNAME for output *_spt.fits file */
             rootname[0] = '\0';
             if (MkName (out_spt, "_spt", "", " ", rootname, CHAR_FNAME_LENGTH)) {
-                sprintf (MsgText, "Couldn't create output SPT ROOTNAME for %s", out_spt);
+                sprintf (MsgText, "Couldn't create output *_spt.fits ROOTNAME for %s", out_spt);
                 trlerror (MsgText);
                 WhichError (status);
+                freeHdr (&header);
                 return (status);
             } else {
-		        sprintf(MsgText, "Created output SPT rootname %s...\n",out_spt);
+		        sprintf(MsgText, "Created output *_spt.fits rootname %s...\n",out_spt);
                 trlmessage (MsgText);
 		    }
 
 	        /* Update the FILENAME header keyword */
-	        if (PutKeyStr (&header, "FILENAME", out_spt, ""))
-	            return (status = 1);
+	        if ((status = PutKeyStr (&header, "FILENAME", out_spt, ""))) {
+				freeHdr (&header);
+	            return (status);
+			}
 
 	        /* Update the ASN_MTYP header keyword */
-	        if (PutKeyStr(&header, "ASN_MTYP", mtype, "Role of the Exposure in the Association"))
-	            return (status = 1);
+	        if ((status = PutKeyStr(&header, "ASN_MTYP", mtype, "Role of the Exposure in the Association"))) {
+				freeHdr (&header);
+	            return (status);
+			}
 
 	        /* NOW, update the ROOTNAME header keyword */
 	        for (n = 0; n < strlen(rootname)-1; n++)
 	             rootname[n] = toupper(rootname[n]);
-	        if (PutKeyStr (&header, "ROOTNAME", rootname, ""))
-	            return (status = 1);
+	        if ((status = PutKeyStr (&header, "ROOTNAME", rootname, ""))) {
+				freeHdr (&header);
+	            return (status);
+			}
 
             /* Update the OBSERVTN header keyword */
             strncpy (obsnum, &rootname[6], 3); obsnum[3] = '\0';
-            if (putKeyS (&header, "OBSERVTN", obsnum, ""))
-                return (status = 1);
+            if ((status = putKeyS (&header, "OBSERVTN", obsnum, ""))) {
+                freeHdr (&header);
+                return (status);
+			}
 
 	        /* Update the NEXTEND header keyword to reflect number of input
                 images.
             */
-	        if (PutKeyInt (&header, "NEXTEND", nimgs, ""))
-	            return (status = 1);
+	        if ((status = PutKeyInt (&header, "NEXTEND", nimgs, ""))) {
+				freeHdr (&header);
+	            return (status);
+			}
 
-            sprintf(MsgText,"Updated output SPT file to reflect %d extensions...\n",nimgs);
+            sprintf(MsgText,"Updated output *_spt.fits file to reflect %d extensions...\n",nimgs);
             trlmessage(MsgText);
 
-	        /* Write the new SPT file */
+	        /* Write the new *_spt.fits file */
             /* Open the image; this also writes the header */
             im = openOutputImage (out_spt, "", 0, &header, 0, 0, FITSBYTE);
             if (hstio_err()) {
                 trlopenerr (out_spt);
+                freeHdr (&header);
                 return (status = OPEN_FAILED);
             }
             /* Close the image */
             closeImage (im);
+            im = NULL;
         }
 
-        /* Uncomment this section to copy input SPT files into output
-            when HSTIO is fixed to work with 1-D data... */
-		for (nx = 0; nx < nextn; nx++){
+        /* Copy input *_spt.fits files into output file */
+        for (nx = 0; nx < nextn; nx++){
 			extnum = extnum + 1;
         	initShortHdrData(&stmp);
         	getShortHD(in_spt, "UDL", (nx+1), &stmp);
@@ -192,6 +217,7 @@ int mkNewSpt (char *in_list, char *mtype, char *output) {
     }
 
     c_imtclose (tpin);
+    tpin = NULL;
 	/* Successful return */
 	return (status);
 }


### PR DESCRIPTION
- Improved messages
  - Fixed obsolete reference for the Drizzle software.
  - Improved the error message when the *_spt.fits file already exists for the association, 
    and the "imclobber" environment variable is not set to "yes | YES". CALACS will stop 
    with an error message providing the solution.

ERROR:    Solution is to delete jcqtb4020_spt.fits file or to set environment variable 'imclobber' to 'yes'.

  - Improved the warning message when looking for individual input *_spt.fits files.  
    If the input missing *_spt.fits file is the file corresponding to the first *_raw.fits
    file in the list, this will cause calacs to error out (bad design).  Now an error message
    is issued at this stage.

ERROR:    Cannot find the first input file "jcqtb4a5q_spt.fits" which is needed to create the output file header.

    If the input missing *_spt.fits file is any file other than the one corresponding to the 
    first *_raw.fits, only a warning is issued.

Warning    Cannot find input file "jcqtb4bnq_spt.fits", but processing can proceed.  Output
association *_spt.fits is comprised of any found individual *_spt.fits files.

- Set pointers to NULL, used the return status from low-level functions versus setting
  (status = 1) explicitly, and freed the header structure after errors.

Resolves #199
Signed-off-by: Michele De La Pena mdelapena@stsci.edu