### PR TITLE
ACS CTE: Add forward modeling functionality

### DIFF
--- a/ctegen2/ctegen2.h
+++ b/ctegen2/ctegen2.h
@@ -79,6 +79,7 @@ typedef struct {
 
 int inverseCTEBlurWithRowMajorIput(const SingleGroup * rsz, SingleGroup * rsc, const SingleGroup * trapPixelMap, CTEParamsFast * cte);
 int inverseCTEBlur(const SingleGroup * rsz, SingleGroup * rsc, SingleGroup * trapPixelMap, CTEParamsFast * cte);
+int forwardModel(const SingleGroup * input, SingleGroup * output, SingleGroup * trapPixelMap, CTEParamsFast * ctePars);
 
 int simulatePixelReadout_v1_1(double * const pixelColumn, const float * const traps, const CTEParamsFast * const cte,
         const FloatTwoDArray * const rprof, const FloatTwoDArray * const cprof, const unsigned nRows);

--- a/pkg/acs/calacs/acscte/forward_model/main.c
+++ b/pkg/acs/calacs/acscte/forward_model/main.c
@@ -1,0 +1,23 @@
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+extern int doMainCTE (int argc, char **argv);
+
+int main (int argc, char **argv)
+{
+    // alloc a new argv + 1 for the above new option
+    char ** newArgv = malloc((argc + 1)*sizeof(char*));
+    assert(newArgv);
+
+    // Copy the old pointers to the new one
+    memcpy(newArgv, argv, argc*sizeof(char*));
+
+    // Add the new opt and inc argc
+    newArgv[argc++] = "--forwardModelOnly";
+
+    const int status = doMainCTE(argc, newArgv);
+    free(newArgv);
+    return status;
+}

--- a/pkg/acs/calacs/acscte/forward_model/wscript
+++ b/pkg/acs/calacs/acscte/forward_model/wscript
@@ -1,0 +1,25 @@
+# vim: set syntax=python:
+
+def build(bld):
+    t = bld.program(
+        source = ['../acscte.c',
+                  '../docte.c',
+                  '../dopcte.c',
+                  '../dopcte-gen2.c',
+                  '../getcteflag.c',
+                  '../getctesw.c',
+                  '../pcte_fixycte.c',
+                  '../pcte_funcs.c',
+                  '../maincte.c',
+                  'main.c'
+                  ],
+        target = 'acscteforwardmodel.e',
+        includes = ['.',
+                    '../../../../../ctegen2',
+                    '../../../../../include'],
+        use = ['hstcallib', 'calacs', 'imphttab', 'ctegen2'] + bld.env.LOCAL_LIBS,
+        lib = bld.env.EXTERNAL_LIBS,
+        libpath = bld.env.LIBPATH,
+        rpath=bld.env.LIBPATH_CFITSIO,
+        install_path = '${PREFIX}/bin'
+        )

--- a/pkg/acs/calacs/acscte/main.c
+++ b/pkg/acs/calacs/acscte/main.c
@@ -1,0 +1,9 @@
+/* ACSCTE -- CTE loss correction */
+
+extern int doMainCTE (int argc, char **argv);
+
+int main (int argc, char **argv)
+{
+    return doMainCTE(argc, argv);
+}
+

--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -4,6 +4,7 @@
 # include <stdlib.h>		/* calloc */
 # include <time.h>
 # include <string.h>
+#include <stdbool.h>
 
 int status = 0;			/* zero is OK */
 
@@ -38,19 +39,21 @@ char MsgText[MSG_BUFF_LENGTH]; // Global char auto initialized to '\0'
 
  */
 
+int doMainCTE (int argc, char **argv);
+
 static void printSyntax()
 {
-    printf ("syntax:  acscte.e [--help] [-t] [-v] [-q] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] input [output]\n");
+    printf ("syntax:  acscte.e [--help] [-t] [-v] [-q] [--version] [--gitinfo] [-1|--nthreads <N>] [--ctegen <1|2>] [--pctetab <path>] [--forwardModelOnly] input [output]\n");
 }
 static void printHelp(void)
 {
     printSyntax();
 }
 
-int main (int argc, char **argv) {
+int doMainCTE (int argc, char **argv) {
 
     char *inlist;		/* input blv_tmp file name */
-    char *outlist;		/* output blc_tmp file name */
+    char *outlist;		/* output file name */
     /*int switch_on = 0;*/	/* was any switch specified? */
     int printtime = NO;	/* print time after each step? */
     int verbose = NO;	/* print additional info? */
@@ -58,6 +61,7 @@ int main (int argc, char **argv) {
     int quiet = NO;	/* print additional info? */
     unsigned cteAlgorithmGen = 0; //Use gen1cte algorithm rather than gen2 (default)
     unsigned nThreads = 0;
+    bool forwardModelOnly = false;
     char pcteTabNameFromCmd[CHAR_LINE_LENGTH];
     *pcteTabNameFromCmd = '\0';
     int too_many = 0;	/* too many command-line arguments? */
@@ -71,8 +75,8 @@ int main (int argc, char **argv) {
     int n;
 
     /* Input and output suffixes. */
-    char isuffix[] = "_blv_tmp";
-    char osuffix[] = "_blc_tmp";
+    char isuffix[CHAR_FNAME_LENGTH] = "_blv_tmp";
+    char osuffix[CHAR_FNAME_LENGTH] = "_blc_tmp"; // "_ctefmod" for forwardModelOnly==true - gets assigned later.
 
     /* A structure to pass the calibration switches to ACSCTE */
     CalSwitch ccd_sw;
@@ -84,7 +88,9 @@ int main (int argc, char **argv) {
     void FreeRefFile (RefFileInfo *);
     void initSwitch (CalSwitch *);
 
-    int ACScte (char *, char *, CalSwitch *, RefFileInfo *, int, int, int, const unsigned cteAlgorithmGen, const char * pcteTabNameFromCmd);
+    int ACScte (char *, char *, CalSwitch *, RefFileInfo *, int, int, int,
+            const unsigned cteAlgorithmGen, const char * pcteTabNameFromCmd,
+            const bool forwardModelOnly);
     int DefSwitch (char *);
     int MkName (char *, char *, char *, char *, char *, int);
     void WhichError (int);
@@ -196,6 +202,12 @@ int main (int argc, char **argv) {
                 strcpy(pcteTabNameFromCmd, argv[i]);
                 continue;
             }
+            else if (strncmp(argv[i], "--forwardModelOnly", 18) == 0)
+            {
+                printf("WARNING: running CTE forward model only");
+                forwardModelOnly = true;
+                continue;
+            }
             else
             {
                 if (argv[i][1] == '-')
@@ -241,6 +253,13 @@ int main (int argc, char **argv) {
 
     /* Copy command-line value for QUIET to structure */
     SetTrlQuietMode(quiet);
+
+    if (forwardModelOnly && cteAlgorithmGen == 1)
+    {
+        trlerror("--forwardModelOnly NOT compatible with 1st generation CTE algorithm");
+        freeOnExit(&ptrReg);
+        exit (INVALID_VALUE);
+    }
 
     if (cteAlgorithmGen)
     {
@@ -334,7 +353,12 @@ int main (int argc, char **argv) {
             continue;
         }
         if (pctecorr == PERFORM)
-            strcpy(osuffix, "_blc_tmp");
+        {
+            if (forwardModelOnly)
+                strcpy(osuffix, "_ctefmod");
+            else
+                strcpy(osuffix, "_blc_tmp");
+        }
         else {
             WhichError (status);
             sprintf (MsgText, "Skipping %s because PCTECORR is not set to PERFORM", input);
@@ -351,7 +375,7 @@ int main (int argc, char **argv) {
 
         /* Calibrate the current input file. */
         if ((status = ACScte (input, output, &ccd_sw, &refnames, printtime, verbose,
-                    nThreads, cteAlgorithmGen, pcteTabNameFromCmd))) {
+                    nThreads, cteAlgorithmGen, pcteTabNameFromCmd, forwardModelOnly))) {
             sprintf (MsgText, "Error processing %s.", input);
             trlerror (MsgText);
             WhichError (status);

--- a/pkg/acs/calacs/acscte/wscript
+++ b/pkg/acs/calacs/acscte/wscript
@@ -10,7 +10,8 @@ def build(bld):
                   'getctesw.c',
                   'pcte_fixycte.c',
                   'pcte_funcs.c',
-                  'maincte.c'
+                  'maincte.c',
+                  'main.c'
                   ],
         target = 'acscte.e',
         includes = ['.',

--- a/pkg/acs/calacs/calacs/calacs.c
+++ b/pkg/acs/calacs/calacs/calacs.c
@@ -1,6 +1,7 @@
 # include <stdio.h>
 # include <stdlib.h>    /* calloc */
 # include <string.h>
+# include <stdbool.h>
 
 #include "hstcal.h"
 # include "xtables.h"   /* for IRAFPointer definition */
@@ -446,7 +447,7 @@ int ProcessACSCCD (AsnInfo *asn, ACSInfo *acshdr, int *save_tmp, int printtime, 
     void FreeRefFile (RefFileInfo *);
     int ACSRefInit (ACSInfo *, CalSwitch *, RefFileInfo *);
     int ACSccd (char *, char *, CalSwitch *, RefFileInfo *, int, int);
-    int ACScte (char *, char *, CalSwitch *, RefFileInfo *, int, int, int, const unsigned cteAlgorithmGen, const char *);
+    int ACScte (char *, char *, CalSwitch *, RefFileInfo *, int, int, int, const unsigned cteAlgorithmGen, const char * pcteTabNameFromCmd, const bool forwardModelOnly);
     int ACS2d (char *, char *,CalSwitch *, RefFileInfo *, int, int);
     int GetAsnMember (AsnInfo *, int, int, int, ACSInfo *);
     int GetSingle (AsnInfo *, ACSInfo *);
@@ -609,9 +610,10 @@ int ProcessACSCCD (AsnInfo *asn, ACSInfo *acshdr, int *save_tmp, int printtime, 
 
                 /* Do PCTECORR now. */
                 if (acshdr->sci_basic_cte == PERFORM) {
+                    // ``forwardModelOnly = false`` because it is not part of the pipeline processing.
                     if (ACScte(acshdr->blv_tmp, acshdr->blc_tmp,
                                &acscte_sci_sw, &sciref, printtime,
-                               asn->verbose, nThreads, cteAlgorithmGen, pcteTabNameFromCmd)) { //this is the line
+                               asn->verbose, nThreads, cteAlgorithmGen, pcteTabNameFromCmd, false)) {
                         return (status);
                     }
                 }

--- a/pkg/acs/calacs/wscript
+++ b/pkg/acs/calacs/wscript
@@ -7,6 +7,7 @@ SUBDIRS = [
     'acssum',
     'acsccd',
     'acscte',
+    'acscte/forward_model',
     'acs2d'
     ]
 
@@ -20,6 +21,7 @@ def build(bld):
             'acsccd.e',
             'acsrej.e',
             'acscte.e',
+            'acscteforwardmodel.e',
             'acs2d.e',
             'acssum.e'],
         always=True)


### PR DESCRIPTION
The cmd line option ``--forwardModelOnly``
piggy-backs upon the normal CTE code and usage (gen2 only) however,
instead of correcting the CTE trails it actually simulates (adds) them.

All CTE flags and ref files must be defined in the exact same
manner needed to run the actual CTE correction.

``PCTECORR`` must be set to ``PERFORM``.

Signed-off-by: James Noss <jnoss@stsci.edu>