### PR TITLE
Modify the dark correction to work directly on the 2D image rather than line-by-line

### DIFF
--- a/pkg/acs/calacs/lib/multk2d.c
+++ b/pkg/acs/calacs/lib/multk2d.c
@@ -1,7 +1,12 @@
 # include "hstio.h"
+# include "hstcal.h"
 
 /* The science data and the error array values are multiplied by k;
    the data quality array is not modified.
+
+   M.D. De La Pena: 05 June 2018
+   Created AvgSciVal from AvgSciValLine (multk1d.c) and put the new routine 
+   here to complement the multk2d routine.
 */
 
 int multk2d (SingleGroup *a, float k) {
@@ -13,25 +18,57 @@ float k          i: multiply a by this constant
 
 	extern int status;
 
-	int i, j;
-    int dimx, dimy;
-
 	if (k == 1.)
 	    return (status);
 
 	/* science data */
-    dimx = a->sci.data.nx;
-    dimy = a->sci.data.ny;
+    int dimx = a->sci.data.nx;
+    int dimy = a->sci.data.ny;
     
-	for (j = 0;  j < dimy;  j++)
-	    for (i = 0;  i < dimx;  i++)
-		Pix (a->sci.data, i, j) = k * Pix (a->sci.data, i, j);
+    {unsigned int i, j;
+    for (j = 0;  j < dimy;  j++) {
+        for (i = 0;  i < dimx;  i++) {
 
-	/* error array */
-	for (j = 0;  j < dimy;  j++)
-	    for (i = 0;  i < dimx;  i++)
-		Pix (a->err.data, i, j) = k * Pix (a->err.data, i, j);
+            /* science array */
+            Pix (a->sci.data, i, j) = k * Pix (a->sci.data, i, j);
+
+            /* error array */
+            Pix (a->err.data, i, j) = k * Pix (a->err.data, i, j);
+        }
+    }}
 
 	return (status);
 }
 
+/* Compute the average of all the good pixels in the image, as
+   well as a weight value.
+*/ 
+void AvgSciVal (SingleGroup *y, short sdqflags, double *mean, double *weight) {
+
+    double sum  = 0.0;
+    int numgood = 0;     /* number of good pixels */
+    short flagval;       /* data quality flag value */
+
+    int dimx = y->sci.data.nx;
+    int dimy = y->sci.data.ny;
+
+    {unsigned int i, j;
+    for (j = 0; j < dimy; j++) {
+        for (i = 0;  i < dimx;  i++) {
+            flagval = DQPix (y->dq.data, i, j);
+
+            /* no serious flag bit set */
+            if ( ! (sdqflags & flagval) ) {
+               sum += Pix (y->sci.data, i, j);
+               numgood++;
+            }
+        }
+    }}
+
+    *mean   = 0.0;
+    *weight = 0.0;
+    if (numgood > 0) {
+        *mean   = sum / (double) numgood;
+        *weight = (double) numgood / (double)(dimx * dimy);
+    } 
+}

--- a/pkg/acs/calacs/lib/sub1d.c
+++ b/pkg/acs/calacs/lib/sub1d.c
@@ -51,3 +51,4 @@ SingleGroupLine *b   i: second input data
 
 	return (status);
 }
+

--- a/pkg/acs/calacs/lib/sub2d.c
+++ b/pkg/acs/calacs/lib/sub2d.c
@@ -1,0 +1,57 @@
+# include <math.h>
+# include "hstio.h"
+# include "hstcalerr.h"	/* SIZE_MISMATCH */
+
+/* Subtract the second SingleGroup from the first, leaving the
+   result in the first.  
+
+   (*a) -= (*b)
+
+   The science data arrays are subtracted; the error arrays are combined;
+   the data quality arrays are combined.
+
+   M.D. De La Pena: 05 June 2018
+   Created this file/routine from sub1d.c.
+   the data quality arrays are combined.  For all extensions, the entire 2D
+   arrays are used.
+*/
+int sub2d (SingleGroup *a, SingleGroup *b) {
+
+/* arguments:
+SingleGroup *a   io: input data, output difference
+SingleGroup *b   i: second input data
+*/
+
+    extern int status;
+
+    float da, db;           /* errors for a and b */
+    short dqa, dqb, dqab;   /* data quality for a, b, combined */
+
+    if ((a->sci.data.nx != b->sci.data.nx) || (a->sci.data.ny != b->sci.data.ny))
+        return (status = SIZE_MISMATCH);
+
+    /* science, error, and DQ data */
+    int dimx = a->sci.data.nx;
+    int dimy = a->sci.data.ny;
+
+    {unsigned int i, j;
+    for (j = 0; j < dimy; j++) {
+        for (i = 0;  i < dimx;  i++) {
+            /* science array */
+            Pix(a->sci.data, i, j) -= Pix(b->sci.data, i, j);
+
+            /* error array */
+            da = Pix (a->err.data, i, j);
+            db = Pix (b->err.data, i, j);
+            Pix (a->err.data, i, j) = sqrt (da * da + db * db);
+
+            /* data quality */
+            dqa = DQPix (a->dq.data, i, j);
+            dqb = DQPix (b->dq.data, i, j);
+            dqab = dqa | dqb;
+            DQSetPix (a->dq.data, i, j, dqab);
+       }
+    }}
+
+    return (status);
+}

--- a/pkg/acs/calacs/lib/trim2d.c
+++ b/pkg/acs/calacs/lib/trim2d.c
@@ -1,0 +1,108 @@
+# include <stdlib.h>		/* calloc */
+# include <string.h>		/* strncmp */
+# include <math.h>		/* sqrt */
+#include "hstcal.h"
+# include "hstio.h"
+# include "hstcalerr.h"	/* SIZE_MISMATCH */
+# include "acs.h"
+
+/* This routine is a mild modification of the trim1d routine from trim.c. This trim2d routine 
+   takes an input data image, extracts a specified subset, and assigns the values to 
+   an output data array.  The calling routine must allocate the output SingleGroup (setting 
+   its size) and free it when done.
+   M.D. De La Pena: 05 June 2018
+
+   This function does not treat any expansion or reduction in Y!
+*/
+
+int trim2d (SingleGroup *a, int xstart, int ystart, int binx, int biny, int update, SingleGroup *b) {
+
+/* arguments:
+const SingleGroup *a  i: input data
+int xstart        i: starting location of subarray (zero indexed,
+                          input pixel coordinates)
+int ystart        i: starting location of subarray (zero indexed,
+                          input pixel coordinates)
+int binx          i: number of X input pixels for one output pixel
+int biny          i: number of Y input pixels for one output pixel
+int update        i: == 1 means have already updated the header info
+                     == 0 means we need to update the header info
+SingleGroup *b    o: output data
+*/
+
+    extern int status;
+
+    double block[2];	/* number of input pixels for one output */
+    double offset[2];	/* offset of binned image */
+
+    /* Initialize internal variables... */
+    int nx = b->sci.data.tot_nx;
+    int ny = b->sci.data.tot_ny;
+    block[0] = binx;
+    block[1] = biny;
+    offset[0] = xstart;
+    offset[1] = ystart;
+
+    int BinCoords (Hdr *, double *, double *, Hdr *, Hdr *, Hdr *);
+
+    /* Check the subset of the input corresponding to the output */
+    if ( (xstart < 0 || xstart + nx*binx > a->sci.data.tot_nx) ||
+         (ystart < 0 || ystart + ny*biny > a->sci.data.tot_ny) ) {
+         trlerror ("(trim2d)  subset is out of bounds:");
+         sprintf (MsgText,"         input is %d x %d pixels, output is %d x %d pixels",
+         a->sci.data.tot_nx, a->sci.data.tot_ny, b->sci.data.tot_nx, b->sci.data.tot_ny);
+         trlmessage (MsgText);
+         sprintf (MsgText, "        startx = (%d), starty = (%d), binx = %d, biny = %d.", 
+         xstart+1, ystart+1, binx, biny);
+         trlmessage (MsgText);
+         return (status = SIZE_MISMATCH);
+    }
+
+    /* i,j = pixel indices in input array, m,n = pixel idices in output array */
+    {unsigned int i, j, m, n;
+    for (n = 0, j = ystart; n < ny; n++, j++) {
+        for (m = 0, i = xstart;  m < nx;  m++, i++) {
+            /* Extract the science array */
+            Pix(b->sci.data, m, n) = Pix(a->sci.data, i, j);
+
+            /* Extract the error array */
+            Pix(b->err.data, m, n) = Pix(a->err.data, i, j);
+
+            /* Extract the data quality array */
+            DQSetPix (b->dq.data, m, n, DQPix(a->dq.data, i, j));
+        }
+    }}
+
+    /* Copy header info only if requested... */
+    int retStatus = 0;
+    if (update == YES) {
+       /* Copy the headers. */
+       status = copyHdr (b->globalhdr, a->globalhdr);
+       if (status || hstio_err()) {
+          retStatus = (hstio_err() != HSTOK) ? hstio_err() : status;
+          return (retStatus);
+       }
+       status = copyHdr (&b->sci.hdr, &a->sci.hdr);
+       if (status || hstio_err()) {
+           retStatus = (hstio_err() != HSTOK) ? hstio_err() : status;
+           return (retStatus);
+       }
+       status = copyHdr (&b->err.hdr, &a->err.hdr);
+       if (status || hstio_err()) {
+           retStatus = (hstio_err() != HSTOK) ? hstio_err() : status;
+           return (retStatus);
+        }
+       status = copyHdr (&b->dq.hdr, &a->dq.hdr);
+       if (status || hstio_err()) {
+           retStatus = (hstio_err() != HSTOK) ? hstio_err() : status;
+           return (retStatus);
+        }
+
+       /* Update the coordinate parameters that depend on the binning. */
+       if (BinCoords (&a->sci.hdr, block, offset,
+                &b->sci.hdr, &b->err.hdr, &b->dq.hdr))
+          return (status);
+    }
+
+    return (status);
+}

--- a/pkg/acs/calacs/lib/wscript
+++ b/pkg/acs/calacs/lib/wscript
@@ -17,8 +17,8 @@ def build(bld):
             median.c   mkname.c   mkoutname.c   mkspt.c   mult1d.c
             multk1d.c   multk2d.c   omitstep.c   parseamps.c   parsedate.c
             prinfo.c   reffiles.c   rowpedigree.c   sameint.c   spline.c
-            streqic.c   sub1d.c   tabhistory.c   tabpedigree.c
-            timestamp.c   trim.c   ucalver.c   ufilename.c
+            streqic.c   sub1d.c   sub2d.c	tabhistory.c   tabpedigree.c
+            timestamp.c   trim.c   trim2d.c		ucalver.c   ufilename.c
             unbinline.c   whicherror.c  toelectrons.c
 
             ../acs2d/acs2d.c   ../acs2d/do2d.c   ../acs2d/dodark.c


### PR DESCRIPTION
Addresses IT #314.

The dark correction algorithm has been modified to work directly on the full 2D data rather than on a line-by-line basis.  This is in preparation for the implementation of a new dark correction algorithm which accommodates a high-dynamic range dark.  The new algorithm is TBD by the ACS team.  At this stage, the known 2D modifications have been done and regression testing with a varied sample of 18 ACS datasets.  Please note there are still some print statements in the code being utilized for testing.  Also, there is an open question as to the exact computation wanted for the mean dark value.  This code only exists on my origin/hackday branch at this time. 