### PR TITLE
Make acs->nimsets = findTotalNumberOfImsets() conditional on forwarModelOnly

### DIFF
--- a/include/str_util.h
+++ b/include/str_util.h
@@ -1,0 +1,9 @@
+#ifndef STR_UTIL_INCL
+#define STR_UTIL_INCL
+
+#include <stdbool.h>
+
+void upperCase(char * str);
+bool isStrInLanguage(const char * str, const char * alphabet);
+
+#endif

--- a/lib/str_util.c
+++ b/lib/str_util.c
@@ -1,0 +1,32 @@
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+#include <fitsio.h>
+
+#include "str_util.h"
+
+void upperCase(char * str)
+{
+    if (!str || *str=='\0')
+        return;
+    fits_uppercase(str);
+}
+
+bool isStrInLanguage(const char * str, const char * alphabet)
+{
+    assert(str); // Not an empty string, use "" or '\0' instead
+    assert(alphabet && *alphabet!='\0'); // alphabet := non-empty finite set
+
+    // For any set A the empty set is a subset of A
+    if (*str=='\0')
+        return true;
+
+    {unsigned i;
+    for (i = 0; i < strlen(str) ; ++i)
+    {
+        if (!strchr(alphabet, str[i]))
+            return false;
+    }}
+    return true;
+}
+

--- a/lib/wscript
+++ b/lib/wscript
@@ -5,7 +5,8 @@ def build(bld):
         source = [
             'hstcal_memory.c',
             'trlbuf.c',
-            'hstcalversion.c'
+            'hstcalversion.c',
+            'str_util.c'
             ],
         target = 'hstcallib',
         includes = ['./',

--- a/pkg/acs/calacs/acs2d/acs2d.c
+++ b/pkg/acs/calacs/acs2d/acs2d.c
@@ -16,6 +16,7 @@
 # include "hstcalerr.h"
 # include "acscorr.h"		/* calibration switch names for calacs */
 # include "trlbuf.h"
+# include "getacskeys.h"
 
 void Init2DTrl (char *, char *);
 
@@ -41,7 +42,6 @@ int ACS2d (char *input, char *output, CalSwitch *acs2d_sw, RefFileInfo *refnames
 	int Do2D (ACSInfo *, int);
 	int FileExists (char *);
 	int Get2dFlags (ACSInfo *, Hdr *);
-	int GetACSKeys (ACSInfo *, Hdr *);
 	int GetLinTab (ACSInfo *);
 	void Sanity2d (ACSInfo *);
 	void TimeStamp (char *, char *);
@@ -107,7 +107,7 @@ int ACS2d (char *input, char *output, CalSwitch *acs2d_sw, RefFileInfo *refnames
 	/* Get keyword values from primary header using same function 
 		used in ACSCCD
 	*/
-	if (GetACSKeys (&acs2d, &phdr)) {
+	if (getAndCheckACSKeys (&acs2d, &phdr)) {
 		freeHdr (&phdr);
 	    return (status);
 	}

--- a/pkg/acs/calacs/acsccd/acsccd.c
+++ b/pkg/acs/calacs/acsccd/acsccd.c
@@ -15,6 +15,7 @@
 # include "hstcalerr.h"
 # include "acscorr.h"		/* calibration switch names */
 # include "trlbuf.h"
+# include "getacskeys.h"
 
 static int BiasKeywords (ACSInfo *);
 void InitCCDTrl (char *, char *);
@@ -47,7 +48,6 @@ int ACSccd (char *input, char *output, CalSwitch *ccd_sw,
     int DoCCD (ACSInfo *);
     int FileExists (char *);
     int GetACSFlags (ACSInfo *, Hdr *);
-    int GetACSKeys (ACSInfo *, Hdr *);
     void TimeStamp (char *, char *);
     void PrBegin (char *);
     void PrEnd (char *);
@@ -121,7 +121,7 @@ int ACSccd (char *input, char *output, CalSwitch *ccd_sw,
         return (status);
 
     /* Get keyword values from primary header. */
-    if (GetACSKeys (&acs, &phdr)) {
+    if (getAndCheckACSKeys (&acs, &phdr)) {
         freeHdr (&phdr);
         return (status);
     }

--- a/pkg/acs/calacs/acsrej/acsrej_check.c
+++ b/pkg/acs/calacs/acsrej/acsrej_check.c
@@ -8,6 +8,7 @@
 # include   "rej.h"
 # include   "hstcalerr.h"
 # include   "acsinfo.h"
+# include   "getacskeys.h"
 
 
 static int getACSnsegn (Hdr *, char *, multiamp *, multiamp *);
@@ -383,7 +384,6 @@ static int getACSampxy (Hdr *hdr, int det, int chip, char *ccdamp, int dimx, int
     char tabname[CHAR_LINE_LENGTH];
 
     void ACSInit (ACSInfo *);
-    int GetACSKeys (ACSInfo *, Hdr *);
     int GetKeyStr (Hdr *, char *, int, char *, char *, int);
     int GetCCDTab (ACSInfo *, int, int);
 
@@ -400,7 +400,7 @@ static int getACSampxy (Hdr *hdr, int det, int chip, char *ccdamp, int dimx, int
         Get keyword values from primary header using same function
         used in ACSCCD.
     */
-    if (GetACSKeys (&acsrej, hdr)) {
+    if (getAndCheckACSKeys (&acsrej, hdr)) {
         freeHdr (hdr);
         return (status);
     }

--- a/pkg/acs/calacs/include/acsinfo.h
+++ b/pkg/acs/calacs/include/acsinfo.h
@@ -48,6 +48,7 @@ typedef struct {
     int ncombine;                   /* number previously summed together */
     int nimsets;                    /* number of "groups" in file */
     int members;                /* # of members associated with this exposure */
+    int nextend;                    // # of extensions in file = ``NEXTEND``
     char mtype[SZ_STRKWVAL+1];      /* Role of exposure in association */
 
     /* Exposure time keywords */

--- a/pkg/acs/calacs/include/getacskeys.h
+++ b/pkg/acs/calacs/include/getacskeys.h
@@ -1,0 +1,10 @@
+#ifndef GETACSKEYS_INCL
+#define GETACSKEYS_INCL
+
+# include "hstio.h"
+# include "acsinfo.h"
+
+int getACSKeys (ACSInfo *acs, Hdr *phdr);
+int getAndCheckACSKeys (ACSInfo *acs, Hdr *phdr);
+
+#endif

--- a/pkg/acs/calacs/lib/getacskeys.c
+++ b/pkg/acs/calacs/lib/getacskeys.c
@@ -1,7 +1,6 @@
 # include <stdio.h>
 # include <stddef.h>
 # include <string.h>
-# include <ctype.h>		/* islower, toupper */
 
 #include "hstcal.h"
 # include "hstio.h"
@@ -9,6 +8,7 @@
 # include "acs.h"
 # include "acsinfo.h"
 # include "hstcalerr.h"
+# include "str_util.h"
 
 /* This routine gets keyword values from the primary header.
  
@@ -24,7 +24,7 @@
  26-Jul-2018 MDD - Convert APERTURE and JWROTYPE values to upper-case. 
  */
 
-int GetACSKeys (ACSInfo *acs, Hdr *phdr) {
+int getACSKeys (ACSInfo *acs, Hdr *phdr) {
   
   /* arguments:
    ACSInfo *acs  	io: calibration switches and info
@@ -33,7 +33,6 @@ int GetACSKeys (ACSInfo *acs, Hdr *phdr) {
   
 	extern int status;
   
-	int nextend;			/* number of FITS extensions */
 	Bool subarray;
   
 	int GetKeyInt (Hdr *, char *, int, int, int *);
@@ -50,33 +49,15 @@ int GetACSKeys (ACSInfo *acs, Hdr *phdr) {
   
 	if (GetKeyStr (phdr, "APERTURE", USE_DEFAULT, "", acs->aperture, ACS_CBUF))
        return (status);
-    {unsigned int i;
-       for (i=0; i < strlen(acs->aperture); i++) {
-           acs->aperture[i] = toupper (acs->aperture[i]);
-    }}
 
 	if (GetKeyStr (phdr, "OBSTYPE", USE_DEFAULT, "", acs->obstype, ACS_CBUF))
     return (status);
     if (GetKeyStr (phdr, "JWROTYPE", USE_DEFAULT, "", acs->jwrotype, ACS_CBUF))
        return (status);
-    {unsigned int i;
-       for (i=0; i < strlen(acs->jwrotype); i++) {
-           acs->jwrotype[i] = toupper (acs->jwrotype[i]);
-    }}
   
 	if (GetKeyStr (phdr, "DETECTOR", NO_DEFAULT, "", acs->det, ACS_CBUF))
     return (status);
-	if (strcmp (acs->det, "SBC") == 0) {
-    acs->detector = MAMA_DETECTOR;
-	} else if (strcmp (acs->det, "HRC") == 0) {
-    acs->detector = HRC_CCD_DETECTOR;
-	} else if (strcmp (acs->det, "WFC") == 0) {
-    acs->detector = WFC_CCD_DETECTOR;
-	} else {
-    sprintf (MsgText, "DETECTOR = %s is invalid", acs->det);
-    trlerror (MsgText);
-		return (status = HEADER_PROBLEM);
-	}
+
   
   /* Grating or mirror name. */
   if (GetKeyStr (phdr, "FILTER1", USE_DEFAULT, "", acs->filter1, ACS_CBUF))
@@ -86,81 +67,117 @@ int GetACSKeys (ACSInfo *acs, Hdr *phdr) {
   
 	if (GetKeyDbl (phdr, "EXPTIME", NO_DEFAULT, 0., &acs->exptime))
     return (status);
-	if (acs->exptime < 0.) {
-    sprintf (MsgText,"Exposure time is invalid:  %14.6g.", acs->exptime);
-    trlerror (MsgText);
-		return (status = INVALID_EXPTIME);
-	}
+
 	if (GetKeyDbl (phdr, "EXPSTART", NO_DEFAULT, 0., &acs->expstart))
     return (status);
 	if (GetKeyDbl (phdr, "EXPEND", NO_DEFAULT, 0., &acs->expend))
     return (status);
 
-    if ((status = findTotalNumberOfImsets(acs->input, "SCI", &(acs->nimsets))))
-        return status;
+    /* Find out how many extensions there are in this file. */
+    if (GetKeyInt (phdr, "NEXTEND", USE_DEFAULT, EXT_PER_GROUP, &acs->nextend))
+        return (status);
 
-	if (acs->nimsets < 1) {
-    sprintf (MsgText, "NEXTEND = %d; must be at least %d.", nextend, EXT_PER_GROUP);
-    trlerror (MsgText);
-		return (status = INVALID_VALUE);
-	}
-  
-	if (GetKeyBool (phdr, "SUBARRAY", NO_DEFAULT, 0, &subarray))
+	if (GetKeyBool (phdr, "SUBARRAY", NO_DEFAULT, 0, &acs->subarray))
 	  return (status);
-	if (subarray)
-	  acs->subarray = YES;
-	else
-	  acs->subarray = NO;
   
 	/* Get CCD-specific parameters. */
   
-	if (acs->detector != MAMA_DETECTOR) {
-    
-    if (GetKeyStr (phdr, "CCDAMP", NO_DEFAULT, "",
-                   acs->ccdamp, NAMPS))
-      return (status);
-    
-    {unsigned int i;
-    for (i=0; i < strlen(acs->ccdamp) ; i++) {
-      /* Convert each letter in CCDAMP to upper-case. */
-      acs->ccdamp[i] = toupper (acs->ccdamp[i]);
-      
-			/* Verify that only the letters 'ABCD' are in the string. */
-      if (strchr ("ABCD", acs->ccdamp[i]) == NULL) {
-				sprintf (MsgText, "CCDAMP = `%s' is invalid.", acs->ccdamp);
-				trlerror (MsgText);
-				return (status = INVALID_VALUE);
-      }
-    }}
-    
-    if (GetKeyFlt (phdr, "CCDGAIN", USE_DEFAULT, 1, &acs->ccdgain))
-      return (status);
-    /*
-     ASSUMPTION: if no CCDOFST values are found, assume they were
-     taken with the default offset setting of 3.  This will affect
-     which row is selected from CCDTAB for setting the default value
-     of the bias level in case there is no overscan regions for image.
-     */
-    if (GetKeyInt (phdr, "CCDOFSTA", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[0]))
-	    return (status);
-    if (GetKeyInt (phdr, "CCDOFSTB", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[1]))
-	    return (status);
-    if (GetKeyInt (phdr, "CCDOFSTC", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[2]))
-	    return (status);
-    if (GetKeyInt (phdr, "CCDOFSTD", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[3]))
-	    return (status);
-    
-    if (GetKeyInt (phdr, "BINAXIS1", USE_DEFAULT, 1, &acs->binaxis[0]))
-      return (status);
-    if (GetKeyInt (phdr, "BINAXIS2", USE_DEFAULT, 1, &acs->binaxis[1]))
-      return (status);
-    
-  if (GetKeyFlt (phdr, "FLASHDUR", USE_DEFAULT, 0.0, &acs->flashdur))
-    return (status);
-  if (GetKeyStr (phdr, "FLASHSTA", USE_DEFAULT, "", acs->flashstatus, ACS_CBUF))
-    return (status);
-    
-	}
-  
+    if (acs->detector != MAMA_DETECTOR)
+    {
+        if (GetKeyStr (phdr, "CCDAMP", NO_DEFAULT, "",
+                       acs->ccdamp, NAMPS))
+          return (status);
+
+        if (GetKeyFlt (phdr, "CCDGAIN", USE_DEFAULT, 1, &acs->ccdgain))
+          return (status);
+        /*
+         ASSUMPTION: if no CCDOFST values are found, assume they were
+         taken with the default offset setting of 3.  This will affect
+         which row is selected from CCDTAB for setting the default value
+         of the bias level in case there is no overscan regions for image.
+         */
+        if (GetKeyInt (phdr, "CCDOFSTA", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[0]))
+            return (status);
+        if (GetKeyInt (phdr, "CCDOFSTB", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[1]))
+            return (status);
+        if (GetKeyInt (phdr, "CCDOFSTC", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[2]))
+            return (status);
+        if (GetKeyInt (phdr, "CCDOFSTD", USE_DEFAULT, DEFAULT_OFFSET, &acs->ccdoffset[3]))
+            return (status);
+
+        if (GetKeyInt (phdr, "BINAXIS1", USE_DEFAULT, 1, &acs->binaxis[0]))
+          return (status);
+        if (GetKeyInt (phdr, "BINAXIS2", USE_DEFAULT, 1, &acs->binaxis[1]))
+          return (status);
+
+        if (GetKeyFlt (phdr, "FLASHDUR", USE_DEFAULT, 0.0, &acs->flashdur))
+            return (status);
+        if (GetKeyStr (phdr, "FLASHSTA", USE_DEFAULT, "", acs->flashstatus, ACS_CBUF))
+            return (status);
+    }
 	return (status);
+}
+
+int checkACSKeys(ACSInfo *acs)
+{
+    int tmpStatus = HSTCAL_OK;
+
+    if (strcmp (acs->det, "SBC") == 0)
+        acs->detector = MAMA_DETECTOR;
+    else if (strcmp (acs->det, "HRC") == 0)
+        acs->detector = HRC_CCD_DETECTOR;
+    else if (strcmp (acs->det, "WFC") == 0)
+        acs->detector = WFC_CCD_DETECTOR;
+    else
+    {
+        sprintf (MsgText, "DETECTOR = %s is invalid", acs->det);
+        trlerror (MsgText);
+        return HEADER_PROBLEM;
+    }
+
+    if (acs->exptime < 0.)
+    {
+        sprintf (MsgText,"Exposure time is invalid:  %14.6g.", acs->exptime);
+        trlerror (MsgText);
+        return INVALID_EXPTIME;
+    }
+
+    upperCase(&acs->aperture);
+    upperCase(&acs->jwrotype);
+
+    // Convert number of extensions to number of SingleGroups.
+    // NOTE: this is technically incorrect and instead findTotalNumberOfImsets()
+    // should be used. See https://github.com/spacetelescope/hstcal/issues/323
+    acs->nimsets = acs->nextend / EXT_PER_GROUP;
+    if (acs->nimsets < 1)
+    {
+        sprintf (MsgText, "NEXTEND = %d; must be at least %d.", acs->nextend, EXT_PER_GROUP);
+        trlerror (MsgText);
+        return INVALID_VALUE;
+    }
+
+    /* Get CCD-specific parameters. */
+    if (acs->detector != MAMA_DETECTOR)
+    {
+        upperCase(&acs->ccdamp);
+        /* Verify that only the letters 'ABCD' are in the string. */
+        const char * ampAlphabet = "ABCD";
+        if (!isStrInLanguage(acs->ccdamp, ampAlphabet))
+        {
+            sprintf (MsgText, "CCDAMP = `%s' is invalid. Must be in 'ABCD'", acs->ccdamp);
+            trlerror (MsgText);
+            return INVALID_VALUE;
+        }
+    }
+    return HSTCAL_OK;
+}
+
+int getAndCheckACSKeys (ACSInfo *acs, Hdr *phdr)
+{
+    int tmpStatus = HSTCAL_OK;
+    if ((tmpStatus = getACSKeys(acs, phdr)))
+        return tmpStatus;
+    if ((tmpStatus = checkACSKeys(acs)))
+        return tmpStatus;
+    return HSTCAL_OK;
 }


### PR DESCRIPTION
Fixes regression introduced from #330

Includes refactoring of ``GetACSKeys()`` into 2 sep funcs
``getACSKeys()`` & ``checkACSKeys()``, the former doing only the literal
getting.

Fixes #333
Resolves #323

Signed-off-by: James Noss <jnoss@stsci.edu>