### PR TITLE
Enable TEST_BIGDATA to be used across multiple repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
 bc1.env_vars = ['PATH=./_install/bin:$PATH',
                 'OMP_NUM_THREADS=8',
-                'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-hstcal']
+                'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
                   "conda install -q -y cfitsio pkg-config pytest requests astropy",
                   "pip install ci-watson",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -16,7 +16,7 @@ bc.nodetype = "RHEL-6"
 bc.name = "release"
 bc.env_vars = ['PATH=./_install/bin:$PATH',
                 'OMP_NUM_THREADS=8',
-                'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/scsb-hstcal',
+                'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
                 'jref=/grp/hst/cdbs/jref/',
                 'iref=/grp/hst/cdbs/iref/',
                 'oref=/grp/hst/cdbs/oref/']

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,9 +61,7 @@ use_calstis = pytest.mark.skipif(not HAS_CALXXX['stis'], reason='no CALSTIS')
 def calref_from_image(input_image):
     """
     Return a list of reference filenames, as defined in the primary
-    header of the given input image, necessary for calibration; i.e.,
-    only those associated with ``*CORR`` set to ``PERFORM`` will be
-    considered.
+    header of the given input image, necessary for calibration.
     """
     # NOTE: Add additional mapping as needed.
     # Map mandatory CRDS reference file for instrument/detector combo.
@@ -115,11 +113,11 @@ def calref_from_image(input_image):
         # Not all images have the CORR step and it is not always on.
         # Download ALL reference files associated with a calibration
         # step present in the header
-        if (step not in hdr):
+        if step not in hdr:
             continue
 
         single_step_files = ref_from_image(input_image, corr_lookup[step])
-        if (single_step_files):
+        if single_step_files:
             ref_files += single_step_files
 
     return ref_files

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,9 +2,10 @@
 
 import os
 from distutils.spawn import find_executable
+from functools import partial
 
 import pytest
-from ci_watson.artifactory_helpers import get_bigdata
+from ci_watson.artifactory_helpers import get_bigdata as _get_bigdata
 from ci_watson.hst_helpers import raw_from_asn, ref_from_image, download_crds
 
 from astropy.io import fits
@@ -14,6 +15,11 @@ __all__ = ['use_calacs', 'use_calwf3', 'use_calstis', 'calref_from_image',
            'BaseACS', 'BaseWFC3', 'BaseSTIS', 'fix_keywords']
 
 HAS_CALXXX = {}   # Set by set_exe_marker()
+
+# Overload generic get_bigdata to include repo root dir.
+# This is to accomodate developers who have to run big data tests across
+# several repositories using the same TEST_BIGDATA env var.
+get_bigdata = partial(_get_bigdata, 'scsb-hstcal')
 
 
 # NOTE: This is because HSTCAL allows partial installation via --targets
@@ -107,7 +113,7 @@ def calref_from_image(input_image):
 
     for step in corr_lookup:
         # Not all images have the CORR step and it is not always on.
-        # Download ALL reference files associated with a calibration 
+        # Download ALL reference files associated with a calibration
         # step present in the header
         if (step not in hdr):
             continue

--- a/tests/stis/test_lev1_fuvspec.py
+++ b/tests/stis/test_lev1_fuvspec.py
@@ -15,7 +15,8 @@ class TestLev1FUVSpec(BaseSTIS):
 
         # Prepare input files.
         self.get_input_file(raw_file)
-        get_bigdata(self.env, 'stis', 'fuv-mama', 'input', wav_file)
+        get_bigdata('scsb-hstcal', self.env, 'stis', 'fuv-mama', 'input',
+                    wav_file)
 
         # Run CALSTIS (equivalent to stistools.calstis.calstis)
         subprocess.call(['cs0.e', raw_file, '-v'])


### PR DESCRIPTION
As discussed with @stsci-hack . For example, what if a developer wishes to run HSTCAL and CALCOS big data tests back to back without wanting to change `TEST_BIGDATA` in their bash startup script?