### PR TITLE
Pin pytest to 3.8.2 to avoid  problem in 3.9.1; normalize package list.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,10 +27,15 @@ bc1.name = "release"
 bc1.env_vars = ['PATH=./_install/bin:$PATH',
                 'OMP_NUM_THREADS=8',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
-bc1.build_cmds = ["conda config --add channels http://ssb.stsci.edu/astroconda",
-                  "conda install -q -y cfitsio pkg-config pytest requests astropy",
-                  "pip install ci-watson",
-                  "${configure_cmd} --release-with-symbols",
+bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
+bc.conda_packages = ['python=3.6',
+                     'ci-watson',
+                     'cfitsio',
+                     'pkg-config',
+                     'pytest=3.8.2',
+                     'requests',
+                     'astropy']
+bc1.build_cmds = ["${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
                   "calacs.e --version"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ bc1.conda_packages = ['python=3.6',
                      'ci-watson',
                      'cfitsio',
                      'pkg-config',
-                     'pytest<=3.8.2',
+                     'pytest=3.8.2',
                      'requests',
                      'astropy']
 bc1.build_cmds = ["${configure_cmd} --release-with-symbols",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ bc1.conda_packages = ['python=3.6',
                      'ci-watson',
                      'cfitsio',
                      'pkg-config',
-                     'pytest=3.8.2',
+                     'pytest<=3.8.2',
                      'requests',
                      'astropy']
 bc1.build_cmds = ["${configure_cmd} --release-with-symbols",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -24,7 +24,7 @@ bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',
                      'cfitsio',
                      'pkg-config',
-                     'pytest=3.8.2',
+                     'pytest<=3.8.2',
                      'requests',
                      'astropy']
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -24,7 +24,7 @@ bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',
                      'cfitsio',
                      'pkg-config',
-                     'pytest',
+                     'pytest=3.8.2',
                      'requests',
                      'astropy']
 

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -24,7 +24,7 @@ bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',
                      'cfitsio',
                      'pkg-config',
-                     'pytest<=3.8.2',
+                     'pytest=3.8.2',
                      'requests',
                      'astropy']
 


### PR DESCRIPTION
Behavior of `--basetemp` flag in `pytest` appears to have changed in recently published `pytest 3.9.1`, breaking RT tests. Reverting to `3.8.2` works around the issue until the pytest situation is sorted out.