### PR TITLE
Remove pytest.mark.xfail (Git Issue#352)

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -37,6 +37,6 @@ bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --b
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6
 
-// Iterate over configurations that define the (distibuted) build matrix.
+// Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host of the given nodetype for each combination and run in parallel.
 utils.run([bc])

--- a/tests/acs/test_hrc.py
+++ b/tests/acs/test_hrc.py
@@ -36,7 +36,6 @@ class TestMosaic(BaseACS):
                    ('j6m901deq_flt.fits', 'j6m901deq_flt_ref.fits')]
         self.compare_outputs(outputs)
 
-    @pytest.mark.xfail
     def test_3point_mosaic(self):
         """ 
         Process an HRC mosaic dataset using 3 dither positions with

--- a/tests/acs/test_hrc_single.py
+++ b/tests/acs/test_hrc_single.py
@@ -36,7 +36,6 @@ class TestSingle(BaseACS):
     # j8bt02loq = was hrc_single1
     # j8cd02tyq = was hrc_single2
     # j8bt02lo2 = was hrc_single3 with FLSHCORR
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         'rootname', ['j8bt02loq', 'j8cd02tyq', 'j8bt02lo2'])
     def test_fullframe_single(self, rootname):

--- a/tests/acs/test_wfc_sinkcorr.py
+++ b/tests/acs/test_wfc_sinkcorr.py
@@ -12,7 +12,6 @@ class TestSinkcorr(BaseACS):
     """
     detector = 'wfc'
 
-    @pytest.mark.xfail
     def test_fullframe_sinkcorr(self):
         """Ported from ``wfc_sinkcorr``, routine test_sinkcorr_fullframe."""
         raw_file = 'jd1y03r5q_raw.fits'
@@ -27,7 +26,6 @@ class TestSinkcorr(BaseACS):
         outputs = [('jd1y03r5q_flt.fits', 'jd1y03r5q_flt_ref.fits')]
         self.compare_outputs(outputs)
 
-    @pytest.mark.xfail
     def test_subarray_sinkcorr(self):
         """Ported from ``wfc_sinkcorr``, routine test_sinkcorr_subarr."""
         raw_file = 'jd0q13ktq_raw.fits'

--- a/tests/wfc3/test_uvis_01asn.py
+++ b/tests/wfc3/test_uvis_01asn.py
@@ -12,7 +12,6 @@ class TestUVIS01ASN(BaseWFC3):
 
     detector = 'uvis'
 
-    @pytest.mark.xfail
     def test_uvis_01asn(self):
         """Ported from ``calwf3_uvis_01``."""
         asn_file = 'iaao01010_asn.fits'

--- a/tests/wfc3/test_uvis_05asn.py
+++ b/tests/wfc3/test_uvis_05asn.py
@@ -11,7 +11,6 @@ class TestUVIS05ASN(BaseWFC3):
 
     detector = 'uvis'
 
-    @pytest.mark.xfail
     def test_uvis_05asn(self):
         """Ported from ``calwf3_uvis_05``."""
         asn_file = 'iacr51010_asn.fits'


### PR DESCRIPTION
Created new truth files and uploaded the files to Artifactory.  As such, the `xfail` is obsolete.