### PR TITLE
WIP - BPIXTAB: Do not use DQ=4 when combining BIAS or DARK images in ACSREJ.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ configure_cmd = "yes '' | ./waf configure --prefix=./_install ${DEFAULT_FLAGS}"
 
 // Define each build configuration, copying and overriding values as necessary.
 bc0 = new BuildConfig()
-bc0.nodetype = "linux-stable"
+bc0.nodetype = "python3.6"
 bc0.name = "debug"
 bc0.env_vars = ['PATH=./_install/bin:$PATH']
 bc0.conda_channels = ['http://ssb.stsci.edu/astroconda']

--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,5 +1,7 @@
  06-Mar-2019:  CALACS 10.2.0 ACSREJ treats Bias and Dark image combination
-                             differently than other data.
+                             differently than other data.  ACSREJ ignores the 
+                             bad pixels (BPIXTAB flag of 4) during the combination 
+                             (i.e. treat bad pixels as normal pixels).
  09-Aug-2018:  CALACS 10.1.0 ACS2D/DARKCORR step works directly on the full 2D
                              data rather than on a line-by-line basis PR#315.
                              ACSCCD/BLEVCORR step accommodates the new supported

--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,7 +1,16 @@
- 19-Jan-2018:  CALACS 10.0.0 ACSREJ calculations are done entirely in electrons. 
-                             Threshold formula uses ERR arrays to account for 
-                             post-flash noise.  CALACS uses amp-dependent read 
-                             noise as threshold to determine if a pixel has enough 
+ 06-Mar-2019:  CALACS 10.2.0 ACSREJ treats Bias and Dark image combination
+                             differently than other data.
+ 09-Aug-2018:  CALACS 10.1.0 ACS2D/DARKCORR step works directly on the full 2D
+                             data rather than on a line-by-line basis PR#315.
+                             ACSCCD/BLEVCORR step accommodates the new supported
+                             subarrays which have both physical and virtual overscan
+                             Forward model functionality was implemented which
+                             simulates (adds) the trails. This functionality should
+                             be accessed via the new ACSTOOLS function, acscteforwardmodel.py
+ 19-Jan-2018:  CALACS 10.0.0 ACSREJ calculations are done entirely in electrons.
+                             Threshold formula uses ERR arrays to account for
+                             post-flash noise.  CALACS uses amp-dependent read
+                             noise as threshold to determine if a pixel has enough
                              S/N such that a reasonable correction can be applied.
  01-Jun-2017:  CALACS 9.2.0 New CTE algorithm implemented.
  21-Feb-2017:  CALACS 9.1.0 New SINKCORR step added in ACSCCD for WFC.

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,8 +1,6 @@
 ### 06-Mar-2019 - MDD -- Version 10.2.0
-    For Bias or Dark images, ACSREJ ignores the BPIXTAB value of 4 (bad detector
-    pixel) during the combination process for the SCI and ERR arrays (i.e. treat
-    bad pixels as normal pixels).  The BPIXTAB pixels are no longer propagated to
-    the output CRJ file in the DQ extension.
+    For bias or dark images, ACSREJ ignores the bad pixels during the combination 
+    process for the SCI and ERR arrays (i.e. treat bad pixels as normal pixels).
 
 ### 09-Aug-2018 - JAN/MDD -- Version 10.1.0
     The dark correction, DARKCORR step of the ACS2D algorithm, has been modified

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,6 +1,7 @@
 ### 06-Mar-2019 - MDD -- Version 10.2.0
-    For bias or dark images, ACSREJ ignores the bad pixels during the combination 
-    process for the SCI and ERR arrays (i.e. treat bad pixels as normal pixels).
+    For bias or dark images, ACSREJ ignores the bad pixels (BPIXTAB flag of 4) 
+    during the combination process for the SCI and ERR arrays (i.e. treat bad 
+    pixels as normal pixels).
 
 ### 09-Aug-2018 - JAN/MDD -- Version 10.1.0
     The dark correction, DARKCORR step of the ACS2D algorithm, has been modified

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,6 +1,29 @@
+### 06-Mar-2019 - MDD -- Version 10.2.0
+    For Bias or Dark images, ACSREJ ignores the BPIXTAB value of 4 (bad detector
+    pixel) during the combination process for the SCI and ERR arrays (i.e. treat
+    bad pixels as normal pixels).  The BPIXTAB pixels are no longer propagated to
+    the output CRJ file in the DQ extension.
+
+### 09-Aug-2018 - JAN/MDD -- Version 10.1.0
+    The dark correction, DARKCORR step of the ACS2D algorithm, has been modified
+    to work directly on the full 2D data rather than on a line-by-line basis PR#315.
+
+    The bias shift correction, BLEVCORR step of the ACSCCD algorithm, has been
+    upgraded to accommodate the new supported subarrays which have both physical
+    and virtual overscan PR#312. This is the same algorithm which applies to full
+    frame data.
+
+    Forward model functionality was implemented which exploits the existing CTE
+    code and usage (Generation 2 only). Instead of correcting the CTE trails, the
+    forward model functionality simulates (adds) the trails PR#313. This
+    functionality should be accessed via the new ACSTOOLS function, acscteforwardmodel.py
+
+    Updated ACS library routine, getacskeys, updated to call the new HSTIO function
+    which robustly determines the number of IMSETS in a FITS file PR#330.
+
 ### 19-Jan-2018 - JAN/MDD -- Version 10.0.0
-    ACSREJ calculations now in electrons, threshold uses ERR arrays.  CALACS 
-    uses amp-dependent read noise for threshold to determine if a correction can 
+    ACSREJ calculations now in electrons, threshold uses ERR arrays.  CALACS
+    uses amp-dependent read noise for threshold to determine if a correction can
     be applied. Bug fixes.
 
 ### 01-Jun-2017 - JAN -- Version 9.2.0

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,9 @@
+Update for version 10.2.0 - 06-Mar-2019 (MDD)
+    pkg/acs/calacs/acsrej/acsrej_do.c
+    pkg/acs/calacs/acsrej/acsrej_loop.c
+
+Update for version 10.1.0 - 09-Aug-2018 (JAN/MDD)
+
 Update for version 10.0.0 - 19-Jan-2018 (JAN/MDD)
 
 Update for version 9.2.0 - 01-Jun-2017 (JAN) : git diff f0c177019cb4c159c801e0228be058269701f577  6472dcef5b86b1c240b35933e5bc7284c53dbafd --name-only

--- a/pkg/acs/calacs/acsrej/acsrej_loop.c
+++ b/pkg/acs/calacs/acsrej/acsrej_loop.c
@@ -139,7 +139,9 @@ Code Outline:
   14-Jan-2016   P.L. Lim    Replace threshold formula with ERR. Cleaned up
                             threshold calculation function.
   26-Feb-2019   M.D. DeLaPena Check the IMAGETYP and adjust the dqpat and maskdq
-                            for BIAS and DARK images.
+                            for BIAS and DARK images.  Bad pixels (BPIXTAB flag of 4) 
+                            are ignored during the combination process for the 
+                            SCI and ERR arrays (i.e. treat bad pixels as normal pixels).
 */
 int acsrej_loop (IODescPtr ipsci[], IODescPtr iperr[], IODescPtr ipdq[],
                  char imgname[][CHAR_FNAME_LENGTH], int grp [], int nimgs,

--- a/pkg/acs/calacs/acsrej/acsrej_loop.c
+++ b/pkg/acs/calacs/acsrej/acsrej_loop.c
@@ -138,7 +138,7 @@ Code Outline:
   12-Jan-2016   P.L. Lim    Calculations now entirely in electrons.
   14-Jan-2016   P.L. Lim    Replace threshold formula with ERR. Cleaned up
                             threshold calculation function.
-  26-Feb-2019   M.D. DeLaPena Check the IMAGETYP and adjust the maskdq
+  26-Feb-2019   M.D. DeLaPena Check the IMAGETYP and adjust the dqpat and maskdq
                             for BIAS and DARK images.
 */
 int acsrej_loop (IODescPtr ipsci[], IODescPtr iperr[], IODescPtr ipdq[],
@@ -203,7 +203,7 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr iperr[], IODescPtr ipdq[],
     float   sig2, psig2, rej2;  /* square of something */
     float   *exp2;              /* square of exptime per image*/
     float   scale, val, dum;
-    short   sval, crflag, nocr, nospill, dqpat, nobadpix;
+    short   sval, crflag, nocr, nospill, dqpat;
     short   maskdq;
 
     float   efacn, skyvaln;
@@ -255,34 +255,28 @@ int acsrej_loop (IODescPtr ipsci[], IODescPtr iperr[], IODescPtr ipdq[],
     /********************************** Begin Code ****************************/
     /* Initialization */
     crflag = par->crval;
-    dqpat = par->badinpdq;
     
     scale = par->scalense / 100.;
     nocr = ~crflag;
     nospill = ~SPILL;
 
-    /* Here nobadpix is using EXCLUDE just as a convenience as EXCLUDE is set to 4, but 
-       EXCLUDE is a local variable only.  The nobadpix is turning ON all bit settings 
-       except for the bad pixel value of 4 which would come from the bad pixel table.
-    */
-    nobadpix = ~EXCLUDE;
-
     numpix = dim_x * dim_y;
     readnoise_only = par->readnoise_only;
 
     /* If BIAS or DARK frames, do not use the EXCLUDE value pixels for maskdq  
-       per Git Issue #373.  
+       and dqpat per Git Issue #373.  
 
        Set up maskdq for detecting CR-affected pixels
     */
+    dqpat = par->badinpdq;
     upperCase(imagetyp);
     maskdq = OK | HIT;
     maskdq = maskdq | SPILL;
     if ( (strncmp(imagetyp, "BIAS", 4) != 0) && (strncmp(imagetyp, "DARK", 4) != 0) ) {
         maskdq = maskdq | EXCLUDE;
+    } else {
+        dqpat = dqpat & (~EXCLUDE);
     }
-sprintf (MsgText, "********** dqpat %d crflag %d niter %d maskdq %d", dqpat, crflag, niter, maskdq);
-trlmessage (MsgText);
 
     /* Define the buffer size for scrolling up the image. */
     width = (int) ceil(par->radius);  /* radius (pix) to propagate CR */
@@ -828,13 +822,6 @@ trlmessage (MsgText);
                                the output image array */
                             } else {
                                 sval = sval & nocr;
-                            }
-
-                            /* If BIAS or DARK frames, remove the BADPIXEL value 
-                               from the final output DQ array */
-                            if ( (strncmp(imagetyp, "BIAS", 4) == 0) || 
-                                 (strncmp(imagetyp, "DARK", 4) == 0) ) {
-                                 sval = sval & nobadpix;
                             }
 
                             /* Store the values arrived at so far in the

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.1.0 (09-Aug-2018)"
-#define ACS_CAL_VER_NUM "10.1.0"
+#define ACS_CAL_VER "10.2.0 (19-May-2019)"
+#define ACS_CAL_VER_NUM "10.2.0"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
Addresses IT #373.

The value of IMAGETYP is used to determine whether or not the data to be processed via ACSREJ is a set of BIAS or DARK images.  If BIAS or DARK images are processed, the DQ=4 value (Bad pixel detector) is ignored during the combination of the SCI and ERR extensions, though the DQ=4 value is present in the DQ extension of the final *_crj.fits file.  Results based upon the updates to the CALACS pipeline can be found in /user/mdelapena/acs where the asn, raw, and spt input files were provided by @nmiles2718.  Please see these files for correctness.  Also, my branch (issue373_bpixtab) can be accessed to allow you to process datasets yourself.  If you have any issues, please let me know.

