### PR TITLE
Fix PATH value to allow tests to run.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ bc0.build_cmds = ["${configure_cmd} --debug",
 bc1 = utils.copy(bc0)
 bc1.name = "release"
 // Would be nice if Jenkins can access /grp/hst/cdbs/xxxx directly.
-bc1.env_vars = ['PATH=./_install/bin:$PATH',
+bc1.env_vars = ['PATH=./clone/_install/bin:$PATH',
                 'OMP_NUM_THREADS=8',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_packages = ['python=3.6',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ configure_cmd = "yes '' | ./waf configure --prefix=./_install ${DEFAULT_FLAGS}"
 bc0 = new BuildConfig()
 bc0.nodetype = "python3.6"
 bc0.name = "debug"
-bc0.env_vars = ['PATH=./_install/bin:$PATH']
+bc0.env_vars = ['PATH=./clone/_install/bin:$PATH']
 bc0.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc0.conda_packages = ['python=3.6',
                      'cfitsio',
@@ -22,6 +22,7 @@ bc0.build_cmds = ["${configure_cmd} --debug",
                   "./waf build",
                   "./waf install",
                   "calacs.e --version"]
+
 
 bc1 = utils.copy(bc0)
 bc1.name = "release"
@@ -36,10 +37,7 @@ bc1.conda_packages = ['python=3.6',
                      'pytest=3.8.2',
                      'requests',
                      'astropy']
-bc1.build_cmds = ["pwd",
-                  "ls",
-                  "env",
-                  "${configure_cmd} --release-with-symbols",
+bc1.build_cmds = ["${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
                   "calacs.e --version"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,10 @@ bc1.conda_packages = ['python=3.6',
                      'pytest=3.8.2',
                      'requests',
                      'astropy']
-bc1.build_cmds = ["${configure_cmd} --release-with-symbols",
+bc1.build_cmds = ["pwd",
+                  "ls",
+                  "env",
+                  "${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
                   "calacs.e --version"]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -24,7 +24,7 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 bc = new BuildConfig()
 bc.nodetype = "RHEL-6"
 bc.name = "release"
-bc.env_vars = ['PATH=./_install/bin:$PATH',
+bc.env_vars = ['PATH=./clone/_install/bin:$PATH',
                 'OMP_NUM_THREADS=8',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
                 'jref=/grp/hst/cdbs/jref/',

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -39,7 +39,9 @@ bc.conda_packages = ['python=3.6',
                      'astropy',
                      'ci-watson']
 
-bc.build_cmds = ["${configure_cmd} --release-with-symbols",
+bc.build_cmds = ["pwd",
+		"env",
+		  "${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
                   "calacs.e --version"]

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -24,6 +24,7 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 bc = new BuildConfig()
 bc.nodetype = "RHEL-6"
 bc.name = "release"
+// Note: The source tree is placed in the 'clone' subdir by the CI system.
 bc.env_vars = ['PATH=./clone/_install/bin:$PATH',
                 'OMP_NUM_THREADS=8',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
@@ -39,9 +40,7 @@ bc.conda_packages = ['python=3.6',
                      'astropy',
                      'ci-watson']
 
-bc.build_cmds = ["pwd",
-		"env",
-		  "${configure_cmd} --release-with-symbols",
+bc.build_cmds = ["${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
                   "calacs.e --version"]


### PR DESCRIPTION
The change in https://github.com/spacetelescope/jenkins_shared_ci_utils/pull/52 moved the source tree cloned for the target project of the CI job into a `clone` subdir. This PR updates the `PATH` definition in `JenkinsfileRT` to allow the tests to execute.