### PR TITLE
TST: Fix gcc not found in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     # Set defaults to avoid repeating in most cases
     - ASTROCONDA=http://ssb.stsci.edu/astroconda
-    - CONDA_DEPS="cfitsio curl gcc pkg-config"
+    - CONDA_DEPS="cfitsio curl pkg-config"
     - EXE_PREFIX="/tmp/miniconda3"
     - PYTHON_VERSION=3.6
     - WAF_ARGS_CONFIGURE="-v"
@@ -32,6 +32,7 @@ before_install:
 
 install:
   - conda install --yes -c $ASTROCONDA $CONDA_DEPS
+  - conda install --yes -c conda-forge gcc
   - ./waf configure --prefix=$CONDA_PREFIX $WAF_ARGS_CONFIGURE
   - ./waf build $WAF_ARGS_BUILD
   - ./waf install $WAF_ARGS_INSTALL

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     # Set defaults to avoid repeating in most cases
     - ASTROCONDA=http://ssb.stsci.edu/astroconda
-    - CONDA_DEPS="cfitsio curl pkg-config"
+    - CONDA_DEPS="cfitsio curl gcc pkg-config"
     - EXE_PREFIX="/tmp/miniconda3"
     - PYTHON_VERSION=3.6
     - WAF_ARGS_CONFIGURE="-v"
@@ -20,6 +20,7 @@ matrix:
     compiler: clang
     env:
       - CC="clang"
+      - CONDA_DEPS="cfitsio curl clang_osx-64 gfortran_osx-64 pkg-config"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CONDA_INSTALLER=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh; fi
@@ -32,7 +33,6 @@ before_install:
 
 install:
   - conda install --yes -c $ASTROCONDA $CONDA_DEPS
-  - conda install --yes -c conda-forge gcc
   - ./waf configure --prefix=$CONDA_PREFIX $WAF_ARGS_CONFIGURE
   - ./waf build $WAF_ARGS_BUILD
   - ./waf install $WAF_ARGS_INSTALL

--- a/waf_patches/g77.py
+++ b/waf_patches/g77.py
@@ -57,7 +57,7 @@ def get_g77_version(conf, fc):
         conf.fatal('Could not determine the compiler type')
 
     # --- now get more detailed info -- see c_config.get_cc_version
-    cmd = fc + ['-dM', '-E', '-']
+    cmd = fc  # + ['-dM', '-E', '-']
     out, err = fc_config.getoutput(conf, cmd, stdin=True)
 
     if out.find('__GNUC__') < 0:


### PR DESCRIPTION
Example log: https://travis-ci.org/spacetelescope/hstcal/builds/580815630

```
PackagesNotFoundError: The following packages are not available from current channels:

  - gcc

Current channels:
  - http://ssb.stsci.edu/astroconda/osx-64
  - http://ssb.stsci.edu/astroconda/noarch
  - https://repo.anaconda.com/pkgs/main/osx-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/osx-64
  - https://repo.anaconda.com/pkgs/r/noarch
```

Note for reviewer: This PR only attempts to fix Travis CI. Jenkins failure is out of scope (see #409).