### PR TITLE
Unpin pytest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ bc1.conda_packages = ['python=3.6',
                      'ci-watson',
                      'cfitsio',
                      'pkg-config',
-                     'pytest=3.8.2',
+                     'pytest',
                      'requests',
                      'astropy']
 bc1.build_cmds = ["${configure_cmd} --release-with-symbols",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -35,7 +35,7 @@ bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',
                      'cfitsio',
                      'pkg-config',
-                     'pytest=3.8.2',
+                     'pytest',
                      'requests',
                      'astropy',
                      'ci-watson']

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 junit_family = xunit2
+
+[pytest]
+minversion = 4.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 junit_family = xunit2
-
-[pytest]
 minversion = 4.0


### PR DESCRIPTION
`pytest >= 4.0` is required to allow `junit_family` to be specified in the pytest configuration so that test report XML will be produced in way that's compatible with Jenkins. Without specifying `junit_family = xunit2`, test results fail to be imported.

Addresses #372