### PR TITLE
PHOTMODE keyword updated with MJD for SBC 

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,7 @@
+ 25-Sep-2019   CALACS 10.2.1 CALACS has been modified to allow the PHOTMODE keyword
+                             to be updated with the MJDUTC for the SBC, in addition to
+                             the HRC and WFC. This will allow time-dependent sensitivity
+                             to be applied properly to SBC.
  06-Mar-2019:  CALACS 10.2.0 ACSREJ treats Bias and Dark image combination
                              differently than other data.  ACSREJ ignores the 
                              bad pixels (BPIXTAB flag of 4) during the combination 

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,8 @@
+### 25-Sep-2019 - MDD -- Version 10.2.1
+    CALACS has been modified to allow the PHOTMODE keyword to be updated with
+    the MJD for the SBC, in addition to the HRC and WFC. This will allow
+    time-dependent sensitivity to be applied properly to SBC.
+
 ### 06-Mar-2019 - MDD -- Version 10.2.0
     For bias or dark images, ACSREJ ignores the bad pixels (BPIXTAB flag of 4) 
     during the combination process for the SCI and ERR arrays (i.e. treat bad 

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,9 @@
+update for version 10.2.1 - 25-Sep-2019 (MDD)
+    pkg/acs/calacs/Dates
+    pkg/acs/calacs/History
+    pkg/acs/calacs/Updates
+    pkg/acs/calacs/acs2d/photmode.c
+
 Update for version 10.2.0 - 06-Mar-2019 (MDD)
     pkg/acs/calacs/acsrej/acsrej_do.c
     pkg/acs/calacs/acsrej/acsrej_loop.c

--- a/pkg/acs/calacs/acs2d/photmode.c
+++ b/pkg/acs/calacs/acs2d/photmode.c
@@ -100,11 +100,10 @@ SingleGroup *x    io: image to be calibrated; primary header is modified
             }
 	    }
     }
-    /* Add 'mjd#' keyword to PHOTMODE string, but only for WFC and HRC */
-	if (acs2d->detector != MAMA_DETECTOR) {
-        sprintf (scratch, " MJD#%0.4f", acs2d->expstart);
-        strcat (photstr,scratch);
-    }
+    /* Add 'mjd#' keyword to PHOTMODE string, modified (Git Issue #435)
+       to apply to all ACS detectors */
+    sprintf (scratch, " MJD#%0.4f", acs2d->expstart);
+    strcat (photstr,scratch);
 
     if (acs2d->verbose){
         sprintf(MsgText,"Keyword PHOTMODE built as: %s",photstr);

--- a/pkg/acs/calacs/acsrej/acsrej_loop.c
+++ b/pkg/acs/calacs/acsrej/acsrej_loop.c
@@ -139,9 +139,13 @@ Code Outline:
   14-Jan-2016   P.L. Lim    Replace threshold formula with ERR. Cleaned up
                             threshold calculation function.
   26-Feb-2019   M.D. DeLaPena Check the IMAGETYP and adjust the dqpat and maskdq
+<<<<<<< HEAD
                             for BIAS and DARK images.  Bad pixels (BPIXTAB flag of 4) 
                             are ignored during the combination process for the 
                             SCI and ERR arrays (i.e. treat bad pixels as normal pixels).
+=======
+                            for BIAS and DARK images.
+>>>>>>> Final adjustments for combining bias and dark images
 */
 int acsrej_loop (IODescPtr ipsci[], IODescPtr iperr[], IODescPtr ipdq[],
                  char imgname[][CHAR_FNAME_LENGTH], int grp [], int nimgs,

--- a/pkg/acs/calacs/acsrej/acsrej_loop.c
+++ b/pkg/acs/calacs/acsrej/acsrej_loop.c
@@ -139,13 +139,9 @@ Code Outline:
   14-Jan-2016   P.L. Lim    Replace threshold formula with ERR. Cleaned up
                             threshold calculation function.
   26-Feb-2019   M.D. DeLaPena Check the IMAGETYP and adjust the dqpat and maskdq
-<<<<<<< HEAD
                             for BIAS and DARK images.  Bad pixels (BPIXTAB flag of 4) 
                             are ignored during the combination process for the 
                             SCI and ERR arrays (i.e. treat bad pixels as normal pixels).
-=======
-                            for BIAS and DARK images.
->>>>>>> Final adjustments for combining bias and dark images
 */
 int acsrej_loop (IODescPtr ipsci[], IODescPtr iperr[], IODescPtr ipdq[],
                  char imgname[][CHAR_FNAME_LENGTH], int grp [], int nimgs,

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.2.0 (19-May-2019)"
-#define ACS_CAL_VER_NUM "10.2.0"
+#define ACS_CAL_VER "10.2.1 (25-Sept-2019)"
+#define ACS_CAL_VER_NUM "10.2.1"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
CALACS has been modified to allow the PHOTMODE keyword to be appended with the MJD for the SBC, as is currently done for HRC and WFC. This will allow time-dependent sensitivity to be applied properly to SBC.

Testing was done before and after the fix.  Before the fix PHOTMODE would contain the following string in the first extension of the FLT:
jc3003qnq_flt.fits[1],PHOTMODE = "ACS SBC F150LP"

After the fix (testing was accomplished using a test IMPHTTAB provided by @rjavila):
jc3003qnq_flt.fits[1],PHOTMODE = "ACS SBC F150LP MJD#56392.6597"

