### PR TITLE
Update ACS tests to ignore additional keywords

### DIFF
--- a/tests/acs/test_hrc.py
+++ b/tests/acs/test_hrc.py
@@ -12,6 +12,10 @@ class TestMosaic(BaseACS):
     """
     detector = 'hrc'
 
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
+
     def test_4point_mosaic(self):
         """
         Process an HRC mosaic dataset using the standard HRC-MOSAIC-BOX 
@@ -34,7 +38,7 @@ class TestMosaic(BaseACS):
                    ('j6m901c3q_flt.fits', 'j6m901c3q_flt_ref.fits'),
                    ('j6m901d9q_flt.fits', 'j6m901d9q_flt_ref.fits'),
                    ('j6m901deq_flt.fits', 'j6m901deq_flt_ref.fits')]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestMosaic.ignore_keywords)
 
     def test_3point_mosaic(self):
         """ 
@@ -59,4 +63,4 @@ class TestMosaic(BaseACS):
         outputs = [('j8cd02011_crj.fits', 'j8cd02011_sfl_ref.fits'),
                    ('j8cd020a1_crj.fits', 'j8cd020a1_sfl_ref.fits'),
                    ('j8cd020k1_crj.fits', 'j8cd020k1_sfl_ref.fits')]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestMosaic.ignore_keywords)

--- a/tests/acs/test_hrc_single.py
+++ b/tests/acs/test_hrc_single.py
@@ -18,6 +18,10 @@ class TestSingle(BaseACS):
     """
     detector = 'hrc'
 
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
+
     def _single_raw_calib(self, rootname):
         raw_file = '{}_raw.fits'.format(rootname)
 
@@ -30,7 +34,7 @@ class TestSingle(BaseACS):
         # Compare results
         outputs = [('{}_flt.fits'.format(rootname),
                     '{}_flt_ref.fits'.format(rootname))]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestSingle.ignore_keywords)
 
     # NOTE:
     # j8bt02loq = was hrc_single1

--- a/tests/acs/test_sbc.py
+++ b/tests/acs/test_sbc.py
@@ -9,6 +9,9 @@ class TestSingleFrame(BaseACS):
     """Process a single SBC dataset."""
     detector = 'sbc'
 
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
     # NOTE:
     # j9ic01vpq = pre-SM4, was sbc_single1
     # jbdf10ykq = post-SM4, was sbc_single2
@@ -28,4 +31,4 @@ class TestSingleFrame(BaseACS):
         # Compare results
         outputs = [('{}_flt.fits'.format(rootname),
                     '{}_flt_ref.fits'.format(rootname))]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestSingleFrame.ignore_keywords)

--- a/tests/acs/test_wfc_asn.py
+++ b/tests/acs/test_wfc_asn.py
@@ -13,6 +13,9 @@ class TestFullFrameASN(BaseACS):
     standard calibration steps turned on.
     """
     detector = 'wfc'
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
 
     # NOTE:
     # j6lq01010 = pre-SM4, was wfc_asn1
@@ -45,4 +48,4 @@ class TestFullFrameASN(BaseACS):
                          '{}_flt_ref.fits'.format(outroot)),
                         ('{}_flc.fits'.format(outroot),
                          '{}_flc_ref_gen2cte.fits'.format(outroot))]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestFullFrameASN.ignore_keywords)

--- a/tests/acs/test_wfc_single.py
+++ b/tests/acs/test_wfc_single.py
@@ -17,6 +17,9 @@ class TestFullFrameSingle(BaseACS):
     which includes bias shift, cross talk, and destripe corrections.
     """
     detector = 'wfc'
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
 
     def _single_raw_calib(self, rootname):
         raw_file = '{}_raw.fits'.format(rootname)
@@ -32,7 +35,7 @@ class TestFullFrameSingle(BaseACS):
                     '{}_flt_ref.fits'.format(rootname)),
                    ('{}_flc.fits'.format(rootname),
                     '{}_flc_ref_gen2cte.fits'.format(rootname))]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestFullFrameSingle.ignore_keywords)
 
     # NOTE: This is slow test due to PCTECORR=PERFORM
     # NOTE:

--- a/tests/acs/test_wfc_sinkcorr.py
+++ b/tests/acs/test_wfc_sinkcorr.py
@@ -11,6 +11,9 @@ class TestSinkcorr(BaseACS):
     and no PCTE correction.
     """
     detector = 'wfc'
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
 
     def test_fullframe_sinkcorr(self):
         """Ported from ``wfc_sinkcorr``, routine test_sinkcorr_fullframe."""
@@ -24,7 +27,7 @@ class TestSinkcorr(BaseACS):
 
         # Compare results
         outputs = [('jd1y03r5q_flt.fits', 'jd1y03r5q_flt_ref.fits')]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestSinkcorr.ignore_keywords)
 
     def test_subarray_sinkcorr(self):
         """Ported from ``wfc_sinkcorr``, routine test_sinkcorr_subarr."""
@@ -38,4 +41,4 @@ class TestSinkcorr(BaseACS):
 
         # Compare results
         outputs = [('jd0q13ktq_flt.fits', 'jd0q13ktq_flt_ref.fits')]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestSinkcorr.ignore_keywords)

--- a/tests/acs/test_wfc_sub.py
+++ b/tests/acs/test_wfc_sub.py
@@ -9,6 +9,9 @@ class TestWFCSubarray(BaseACS):
     Process a single WFC subarray with all standard calibration steps on.
     """
     detector = 'wfc'
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
 
     # NOTE: This has PCTECORR=OMIT.
     # NOTE:
@@ -30,7 +33,7 @@ class TestWFCSubarray(BaseACS):
         # Compare results
         outputs = [('{}_flt.fits'.format(rootname),
                     '{}_flt_ref.fits'.format(rootname))]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestWFCSubarray.ignore_keywords)
 
     # NOTE: This is slow test due to PCTECORR=PERFORM
     @pytest.mark.slow
@@ -49,4 +52,4 @@ class TestWFCSubarray(BaseACS):
         # Compare results
         outputs = [('jb5s01fnq_flt.fits', 'jb5s01fnq_flt_ref.fits'),
                    ('jb5s01fnq_flc.fits', 'jb5s01fnq_flc_ref_gen2cte.fits')]
-        self.compare_outputs(outputs)
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestWFCSubarray.ignore_keywords)


### PR DESCRIPTION
Updated the ACS tests to ignore a few additional keywords as the comment portion of the FITS cards do not match. 