### PR TITLE
Updated JenkinsFile(s) to point to ci-watson 0.4 rather than the...

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ bc1.env_vars = ['PATH=./clone/_install/bin:$PATH',
                 'OMP_NUM_THREADS=4',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_packages = ['python=3.6',
-                     'ci-watson=0.4',
+                     'ci-watson<0.5',
                      'cfitsio',
                      'pkg-config',
                      'pytest',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ bc1.env_vars = ['PATH=./clone/_install/bin:$PATH',
                 'OMP_NUM_THREADS=4',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_packages = ['python=3.6',
-                     'ci-watson',
+                     'ci-watson=0.4',
                      'cfitsio',
                      'pkg-config',
                      'pytest',

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -38,7 +38,7 @@ bc.conda_packages = ['python=3.6',
                      'pytest',
                      'requests',
                      'astropy',
-                     'ci-watson']
+                     'ci-watson=0.4']
 
 bc.build_cmds = ["${configure_cmd} --release-with-symbols",
                   "./waf build",


### PR DESCRIPTION
default/latest version

`ci_watson` has recently released a newer version which seems to be breaking `pytest`  tests

https://github.com/spacetelescope/ci_watson/releases/tag/0.5