### PR TITLE
Switch to pip install of ci-watson and pytest in Jenkinsfiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,16 +31,14 @@ bc1.env_vars = ['PATH=./clone/_install/bin:$PATH',
                 'OMP_NUM_THREADS=4',
                 'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.conda_packages = ['python=3.6',
-                     'ci-watson',
                      'cfitsio',
                      'pkg-config',
-                     'pytest',
-                     'requests',
                      'astropy']
 bc1.build_cmds = ["${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
-                  "calacs.e --version"]
+                  "calacs.e --version",
+                  "pip install pytest ci-watson"]
 bc1.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata -v"]
 bc1.failedUnstableThresh = 1
 bc1.failedFailureThresh = 6

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -35,15 +35,13 @@ bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.6',
                      'cfitsio',
                      'pkg-config',
-                     'pytest',
-                     'requests',
-                     'astropy',
-                     'ci-watson']
+                     'astropy']
 
 bc.build_cmds = ["${configure_cmd} --release-with-symbols",
                   "./waf build",
                   "./waf install",
-                  "calacs.e --version"]
+                  "calacs.e --version",
+                  "pip install pytest ci-watson"]
 bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,1 @@
 """Custom ``pytest`` configurations."""
-
-pytest_plugins = ["pytest_ciwatson"]


### PR DESCRIPTION
We will eventually stop delivering conda packages for `ci-watson`. Just `pip install` it.

Resolves #464 
