### PR TITLE
Issue 326 darktime updates

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,10 @@
+ 10-Jan-2020   CALACS 10.2.2 Removed hard-coded darktime scaling value and read new 
+                             post-flashed and unflashed columns from updated CCDTAB reference 
+                             file to use for the offset to the DARKTIME FITS keyword value 
+                             under appropropriate date and supported subarray criteria.  The 
+                             DARKTIME keyword value is now the default scaling factor for the 
+                             superdarks, with the offset being an additive correction to DARKTIME 
+                             under appropriate circumstances.
  25-Sep-2019   CALACS 10.2.1 CALACS has been modified to allow the PHOTMODE keyword
                              to be updated with the MJDUTC for the SBC, in addition to
                              the HRC and WFC. This will allow time-dependent sensitivity

--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -4,7 +4,7 @@
                              under appropropriate date and supported subarray criteria.  The 
                              DARKTIME keyword value is now the default scaling factor for the 
                              superdarks, with the offset being an additive correction to DARKTIME 
-                             under appropriate circumstances.
+                             under appropriate circumstances.  The offset only applies to WFC and HRC.
  25-Sep-2019   CALACS 10.2.1 CALACS has been modified to allow the PHOTMODE keyword
                              to be updated with the MJDUTC for the SBC, in addition to
                              the HRC and WFC. This will allow time-dependent sensitivity

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,11 @@
+### 10-Jan-2020 - MDD -- Version 10.2.2
+    Removed hard-coded darktime scaling value and read new post-flashed and
+    unflashed columns from updated CCDTAB reference file to use for the
+    offset to the DARKTIME FITS keyword value under appropropriate
+    date and supported subarray criteria.  The DARKTIME keyword value is 
+    now the default scaling factor for the superdarks, with the offset 
+    being an additive correction to DARKTIME under appropriate circumstances.
+
 ### 25-Sep-2019 - MDD -- Version 10.2.1
     CALACS has been modified to allow the PHOTMODE keyword to be updated with
     the MJD for the SBC, in addition to the HRC and WFC. This will allow

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -4,7 +4,8 @@
     offset to the DARKTIME FITS keyword value under appropropriate
     date and supported subarray criteria.  The DARKTIME keyword value is 
     now the default scaling factor for the superdarks, with the offset 
-    being an additive correction to DARKTIME under appropriate circumstances.
+    being an additive correction to DARKTIME under appropriate circumstances
+    The offset only applies to WFC and HRC.
 
 ### 25-Sep-2019 - MDD -- Version 10.2.1
     CALACS has been modified to allow the PHOTMODE keyword to be updated with

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,4 +1,16 @@
-update for version 10.2.1 - 25-Sep-2019 (MDD)
+Update for version 10.2.2 - 10-Jan-2020 (MDD)
+    pkg/acs/calacs/Dates
+    pkg/acs/calacs/History
+    pkg/acs/calacs/Updates
+    pkg/acs/calacs/acs2d/dodark.c
+    pkg/acs/calacs/include/acs.h
+	pkg/acs/calacs/include/acsinfo.h
+	pkg/acs/calacs/include/acsversion.h
+	pkg/acs/calacs/lib/acsinfo.c
+	pkg/acs/calacs/lib/getacskeys.c
+	pkg/acs/calacs/lib/getccdtab.c
+
+Update for version 10.2.1 - 25-Sep-2019 (MDD)
     pkg/acs/calacs/Dates
     pkg/acs/calacs/History
     pkg/acs/calacs/Updates

--- a/pkg/acs/calacs/acs2d/dodark.c
+++ b/pkg/acs/calacs/acs2d/dodark.c
@@ -56,6 +56,10 @@
  M.D. De La Pena, 2018 June 05:
  Dark correction processing is now done on the entire image instead of 
  line by line. Also, performed some clean up and new commentary.
+ M.D. De La Pena, 2019 November 26:
+ Remove hard-coded darkscaling value and read new post-flashed and
+ unflashed columns from updated CCDTAB reference file. 
+ 
  */
 
 int doDark (ACSInfo *acs2d, SingleGroup *x, float *meandark) {
@@ -68,7 +72,7 @@ int doDark (ACSInfo *acs2d, SingleGroup *x, float *meandark) {
   
   extern int status;
 
-  const float darkscaling = 3.0;  /* Extra idle time */
+  //const float darkscaling = 3.0;  /* Extra idle time */
   
   int extver = 1;	/* get this imset from dark image */
 

--- a/pkg/acs/calacs/acs2d/dodark.c
+++ b/pkg/acs/calacs/acs2d/dodark.c
@@ -149,8 +149,9 @@ int doDark (ACSInfo *acs2d, SingleGroup *x, float *meandark) {
 
      /* Full-frame data */
      if (acs2d->subarray == NO) {
-         if (acs2d->expstart >= SM4MJD)
+         if (acs2d->expstart >= SM4MJD) {
               darktime = darktimeFromHeader + darktimeOffset;
+         }
          sprintf(MsgText, "Full Frame adjusted Darktime: %f\n", darktime);
          trlmessage(MsgText);
 
@@ -173,11 +174,13 @@ int doDark (ACSInfo *acs2d, SingleGroup *x, float *meandark) {
      reference image to correspond to CHIP in science data.
   */
   if (acs2d->pctecorr == PERFORM) {
-     if (DetCCDChip (acs2d->darkcte.name, acs2d->chip, acs2d->nimsets, &extver) )
+     if (DetCCDChip (acs2d->darkcte.name, acs2d->chip, acs2d->nimsets, &extver) ) {
         return (status);
+     }
   } else {
-     if (DetCCDChip (acs2d->dark.name, acs2d->chip, acs2d->nimsets, &extver) )
+     if (DetCCDChip (acs2d->dark.name, acs2d->chip, acs2d->nimsets, &extver) ) {
         return (status);
+     }
   }
 	
   if (acs2d->verbose) {
@@ -266,13 +269,6 @@ int doDark (ACSInfo *acs2d, SingleGroup *x, float *meandark) {
      return (status);
   }
 
-  /* Compute the weighted mean for the image */	
-  /* *** MDD FIX - Not sure this is really needed anymore */
-  /*
-  *meandark = 0.0;
-  if ( (weight > 0.0) && (scirows > 0) )
-     *meandark = (float) (mean / weight); 
-  */
   /* This is to force a compatibility match to the previous version of the
      code.  
   */

--- a/pkg/acs/calacs/acs2d/dodark.c
+++ b/pkg/acs/calacs/acs2d/dodark.c
@@ -63,7 +63,8 @@
  under appropropriate date and supported subarray criteria.  The
  DARKTIME keyword value is now the default scaling factor for the
  superdarks, with the offset being an additive correction to DARKTIME
- under appropriate circumstances.
+ under appropriate circumstances. The offset values is applicable for 
+ WFC and HRC only.
  */
 static const char *subApertures[] = {"WFC1A-2K", "WFC1B-2K", "WFC2C-2K", "WFC2D-2K",
                                      "WFC1A-1K", "WFC1B-1K", "WFC2C-1K", "WFC2D-1K",
@@ -139,6 +140,9 @@ int doDark (ACSInfo *acs2d, SingleGroup *x, float *meandark) {
      The full-frame overhead offset is applicable to all data post-SM4.  The subarray 
      overhead offset is applicable to all data post-CYCLE24 and ONLY for supported
      subarrays. 
+
+     Effectively the additive factor only applies to ACS/WFC as the HRC was no longer
+     operational by SM4MJD or CYCLE24, and SBC is a MAMA detector.
   */
   darktime = darktimeFromHeader;  /* Default */
   if (acs2d->detector != MAMA_DETECTOR) {

--- a/pkg/acs/calacs/include/acs.h
+++ b/pkg/acs/calacs/include/acs.h
@@ -87,6 +87,9 @@ void errchk ();                 /* HSTIO error check */
 
 # define        SM4MJD          54967
 
+/* October 01, 2016: Date of first observation in Cycle 24. The new ACS subarray configurations validated for Cycle 24. */
+# define        CYCLE24         57662
+
 /* A reference image. */
 typedef struct {
     char name[CHAR_FNAME_LENGTH];            /* name of image */

--- a/pkg/acs/calacs/include/acsinfo.h
+++ b/pkg/acs/calacs/include/acsinfo.h
@@ -91,7 +91,6 @@ typedef struct {
     int biassectb[2];   /* Columns to use for trailing overscan region */
     float flashdur; 	/* duration of post-flash (in seconds) */
     char flashstatus[ACS_CBUF+1];		/* status of post-flash exposure */
-    float ovrhfls;      /* Overhead */
     float overhead_postflashed;  /* Overhead for post-flashed observations (s) */
     float overhead_unflashed;    /* Overhead for unflashed observations (s) */
     double darktime;    /* total time for dark current to accrue (s) */

--- a/pkg/acs/calacs/include/acsinfo.h
+++ b/pkg/acs/calacs/include/acsinfo.h
@@ -91,6 +91,10 @@ typedef struct {
     int biassectb[2];   /* Columns to use for trailing overscan region */
     float flashdur; 	/* duration of post-flash (in seconds) */
     char flashstatus[ACS_CBUF+1];		/* status of post-flash exposure */
+    float ovrhfls;      /* Overhead */
+    float overhead_postflashed;  /* Overhead for post-flashed observations (s) */
+    float overhead_unflashed;    /* Overhead for unflashed observations (s) */
+    double darktime;    /* total time for dark current to accrue (s) */
 
     /* calibration flags (switches) for ACSCCD */
     int dqicorr;        /* data quality initialization */

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.2.1 (25-Sept-2019)"
-#define ACS_CAL_VER_NUM "10.2.1"
+#define ACS_CAL_VER "10.2.2 (10-Jan-2020)"
+#define ACS_CAL_VER_NUM "10.2.2"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"

--- a/pkg/acs/calacs/lib/acsinfo.c
+++ b/pkg/acs/calacs/lib/acsinfo.c
@@ -11,6 +11,7 @@
    17-Apr-2002 WJH - removed all references to 'statcorr'.
    12-Dec-2012 PLL - added CTE corrected flash reference file.
    12-Aug-2013 PLL - Tidied up code layout.
+   05-Dec-2019 MDD - Added overhead for post-flash, unflashed, and DARKTIME values.
 */
 #include <string.h>
 
@@ -100,6 +101,9 @@ void ACSInit (ACSInfo *acs) {
     acs->biassectb[1] = 0;
     acs->flashdur = 0;
     acs->flashstatus[0] = '\0';
+    acs->overhead_postflashed = 0.;
+    acs->overhead_unflashed = 0.;
+    acs->darktime = 0.;
 
     /* Initialize Calibration switches */
     acs->dqicorr = OMIT;

--- a/pkg/acs/calacs/lib/getacskeys.c
+++ b/pkg/acs/calacs/lib/getacskeys.c
@@ -22,6 +22,7 @@
  4-Dec-2001 WJH - Read in EXPSTART and EXPEND for computing darktime.
  12-Dec-2012 PLL - Changed FLASHDUR and FLASHSTA defaults.
  26-Jul-2018 MDD - Convert APERTURE and JWROTYPE values to upper-case. 
+ 05-Dec-2019 MDD - Read the DARKTIME keyword and convert FLASHSTA to upper-case.
  */
 
 int getACSKeys (ACSInfo *acs, Hdr *phdr) {
@@ -113,6 +114,9 @@ int getACSKeys (ACSInfo *acs, Hdr *phdr) {
             return (status);
         if (GetKeyStr (phdr, "FLASHSTA", USE_DEFAULT, "", acs->flashstatus, ACS_CBUF))
             return (status);
+
+	    if (GetKeyDbl (phdr, "DARKTIME", USE_DEFAULT, 0., &acs->darktime))
+        return (status);
     }
 	return (status);
 }
@@ -143,6 +147,7 @@ int checkACSKeys(ACSInfo *acs)
 
     upperCase(&acs->aperture);
     upperCase(&acs->jwrotype);
+    upperCase(&acs->flashstatus);
 
     // Convert number of extensions to number of SingleGroups.
     // NOTE: this is technically incorrect and instead findTotalNumberOfImsets()

--- a/pkg/acs/calacs/lib/getccdtab.c
+++ b/pkg/acs/calacs/lib/getccdtab.c
@@ -171,6 +171,10 @@ int     dimy      i: number of lines in exposure
 		    sprintf (MsgText, "Row %d of CCDTAB is DUMMY.", row);
 			trlwarn (MsgText);
 		}
+      
+        /* Read the overhead time (s) for post-flashed and unflashed observations */
+        acs->overhead_postflashed = tabrow.overhead_postflashed;
+        acs->overhead_unflashed = tabrow.overhead_unflashed;
 
 		for (i = 0; i < NAMPS; i++){
 			/* If the amp is used, keep the value, otherwise set to zero*/
@@ -192,7 +196,14 @@ int     dimy      i: number of lines in exposure
 		acs->ampx = (tabrow.ampx > dimx) ? dimx : tabrow.ampx;
 		acs->ampy = tabrow.ampy;		
 		acs->saturate = tabrow.saturate;
-		break;
+		//break;
+	    sprintf (MsgText, "Matching row FOUND in CCDTAB `%s'.", acs->ccdpar.name);
+        trlmessage(MsgText);
+		sprintf (MsgText, "CCDAMP %s, CCDGAIN %4.1f, CCDOFFST %d,%d,%d,%d, OVERHEADPOST %f OVERHEADUN %f",
+		acs->ccdamp, acs->ccdgain, acs->ccdoffset[0], acs->ccdoffset[1],
+		acs->ccdoffset[2], acs->ccdoffset[3], acs->overhead_postflashed, acs->overhead_unflashed);
+        trlmessage(MsgText);
+        break;
 	    }
 	}
 

--- a/pkg/acs/calacs/lib/getccdtab.c
+++ b/pkg/acs/calacs/lib/getccdtab.c
@@ -196,14 +196,7 @@ int     dimy      i: number of lines in exposure
 		acs->ampx = (tabrow.ampx > dimx) ? dimx : tabrow.ampx;
 		acs->ampy = tabrow.ampy;		
 		acs->saturate = tabrow.saturate;
-		//break;
-	    sprintf (MsgText, "Matching row FOUND in CCDTAB `%s'.", acs->ccdpar.name);
-        trlmessage(MsgText);
-		sprintf (MsgText, "CCDAMP %s, CCDGAIN %4.1f, CCDOFFST %d,%d,%d,%d, OVERHEADPOST %f OVERHEADUN %f",
-		acs->ccdamp, acs->ccdgain, acs->ccdoffset[0], acs->ccdoffset[1],
-		acs->ccdoffset[2], acs->ccdoffset[3], acs->overhead_postflashed, acs->overhead_unflashed);
-        trlmessage(MsgText);
-        break;
+		break;
 	    }
 	}
 

--- a/pkg/acs/calacs/lib/getccdtab.c
+++ b/pkg/acs/calacs/lib/getccdtab.c
@@ -8,6 +8,8 @@
 # include "acsinfo.h"
 # include "hstcalerr.h"
 
+/* This is the number of non-optional columns */
+/* The two additional columns, PEDIGREE and DESCRIP, are optional */
 # define NUMCOLS 26			/* Defined locally to be specific to CCDTAB */
 
 typedef struct {
@@ -26,6 +28,8 @@ typedef struct {
 	IRAFPointer cp_saturate;
 	IRAFPointer cp_pedigree;
 	IRAFPointer cp_descrip;
+    IRAFPointer cp_overhead_postflashed;  /* overhead for post-flashed observations */
+    IRAFPointer cp_overhead_unflashed; /* overhead for unflashed observations */
     int intgain;
 	int nrows;			/* number of rows in table */
 } TblInfo;
@@ -43,6 +47,8 @@ typedef struct {
 	int ampx;
 	int ampy;
 	float saturate;
+    float overhead_postflashed;
+    float overhead_unflashed;
 } TblRow;
 
 static int OpenCCDTab (char *, TblInfo *);
@@ -67,6 +73,8 @@ static int CloseCCDTab (TblInfo *);
 		SATURATE:  CCD saturation threshold
 		AMPX:	first column affected by second amp on multiamp readout (int)
 		AMPY: 	first line affected by second set of amps on multiamp readout (int)
+        OVRHFLS:  overhead for post-flashed observations
+        OVRHUFLS: overhead for unflashed observations
 
    The table is read to find the row for which the CCDAMP matches the
    expected amplifier string (from the image header) and for which the
@@ -75,8 +83,8 @@ static int CloseCCDTab (TblInfo *);
    must match exactly the value read from the row, including the order of
    the AMPs listed in CCDAMP.  The AMPs should be listed in increasing
    value, from A to D, for whichever AMPs are used.  The matching row is
-   then read to get the actual gain, bias, readnoise, and saturation
-   level.
+   then read to get the actual gain, bias, readnoise, saturation level,
+   and observational overheads.
    
 ** This was only modified to read ACS specific columns from CCDTAB.  May
 **	still need to be modified to support multiple AMP readout from a single
@@ -92,6 +100,8 @@ static int CloseCCDTab (TblInfo *);
     29-Oct-2001 WJH: Revised to replace CCDBIAS column with CCDBIAS[A,B,C,D]
         to table.  Also use CCDOFST[A,B,C,D] to select appropriate row as 
         well. 
+    26-Nov-2019 MDD: Updated to read the OVRHFLS and OVRHUFLS columns containing
+        the commanding overheads for post-flashed and unflashed observations.
 */
 
 int GetCCDTab (ACSInfo *acs, int dimx, int dimy) {
@@ -205,8 +215,7 @@ int     dimy      i: number of lines in exposure
 }
 
 /* This routine opens the CCD parameters table, finds the columns that we
-   need, and gets the total number of rows in the table.  The columns are 
-   CCDAMP, CCDGAIN, CCDBIAS, and READNSE.
+   need, and gets the total number of rows in the table.
 */
 
 static int OpenCCDTab (char *tname, TblInfo *tabinfo) {
@@ -224,7 +233,7 @@ static int OpenCCDTab (char *tname, TblInfo *tabinfo) {
 	char *colnames[NUMCOLS] ={"CCDAMP", "CCDCHIP", "CCDGAIN", "BINAXIS1",
     "BINAXIS2", "CCDOFSTA", "CCDOFSTB", "CCDOFSTC", "CCDOFSTD","CCDBIASA", 
     "CCDBIASB","CCDBIASC","CCDBIASD","ATODGNA", "ATODGNB", "ATODGNC", "ATODGND", "READNSEA", "READNSEB", 
-    "READNSEC", "READNSED", "AMPX", "AMPY", "SATURATE"};
+    "READNSEC", "READNSED", "AMPX", "AMPY", "SATURATE", "OVRHFLS", "OVRHUFLS"};
 
 	int PrintMissingCols (int, int, int *, char **, char *, IRAFPointer);
 
@@ -244,7 +253,6 @@ static int OpenCCDTab (char *tname, TblInfo *tabinfo) {
 	    trlerror ("Out of memory.\n");
 	    return (OUT_OF_MEMORY);
 	}
-
 
 	tabinfo->tp = c_tbtopn (tname, IRAF_READ_ONLY, 0);
 	if (c_iraferr()) {
@@ -280,6 +288,8 @@ static int OpenCCDTab (char *tname, TblInfo *tabinfo) {
 	c_tbcfnd1 (tabinfo->tp, "AMPX", &tabinfo->cp_ampx);
 	c_tbcfnd1 (tabinfo->tp, "AMPY", &tabinfo->cp_ampy);
 	c_tbcfnd1 (tabinfo->tp, "SATURATE", &tabinfo->cp_saturate);
+	c_tbcfnd1 (tabinfo->tp, "OVRHFLS", &tabinfo->cp_overhead_postflashed);
+	c_tbcfnd1 (tabinfo->tp, "OVRHUFLS", &tabinfo->cp_overhead_unflashed);
 	
 	/* Initialize counters here... */
 	missing = 0;
@@ -312,6 +322,8 @@ static int OpenCCDTab (char *tname, TblInfo *tabinfo) {
 	if (tabinfo->cp_ampx == 0 ) { missing++; nocol[i] = YES;} i++;
 	if (tabinfo->cp_ampy == 0 ) { missing++; nocol[i] = YES;} i++;
 	if (tabinfo->cp_saturate == 0) { missing++; nocol[i] = YES;} i++;
+	if (tabinfo->cp_overhead_postflashed == 0) { missing++; nocol[i] = YES;} i++;
+	if (tabinfo->cp_overhead_unflashed == 0) { missing++; nocol[i] = YES;} i++;
 	
 	if (PrintMissingCols (missing, NUMCOLS, nocol, colnames, "CCDTAB", tabinfo->tp) )
 		return(status);
@@ -367,9 +379,7 @@ IRAFPointer tp		i: pointer to table, close it if necessary
 	}
 	return(status);
 }
-/* This routine reads the relevant data from one row.  The amplifier
-   number, CCD gain, bias, and readnoise are gotten.
-*/
+/* This routine reads all the relevant data from one row. */
 
 static int ReadCCDTab (TblInfo *tabinfo, int row, TblRow *tabrow) {
 
@@ -459,6 +469,13 @@ static int ReadCCDTab (TblInfo *tabinfo, int row, TblRow *tabrow) {
 	    return (status = TABLE_ERROR);
 		
 	c_tbegtr (tabinfo->tp, tabinfo->cp_saturate, row, &tabrow->saturate);
+	if (c_iraferr())
+	    return (status = TABLE_ERROR);
+
+	c_tbegtr (tabinfo->tp, tabinfo->cp_overhead_postflashed, row, &tabrow->overhead_postflashed);
+	if (c_iraferr())
+	    return (status = TABLE_ERROR);
+	c_tbegtr (tabinfo->tp, tabinfo->cp_overhead_unflashed, row, &tabrow->overhead_unflashed);
 	if (c_iraferr())
 	    return (status = TABLE_ERROR);
 

--- a/tests/acs/test_wfc_darktime.py
+++ b/tests/acs/test_wfc_darktime.py
@@ -55,6 +55,7 @@ class TestDarktimeSingle(BaseACS):
     # j59l54gjq, pre-SM4, unflashed, full-frame
     # jch001zdq, post-SM4, postflashed, full-frame
     # jdw002gdq, post-SM4, unflashed, full-frame
+    @pytest.mark.skip(reason="CTE is too slow to run under nominal conditions.")
     @pytest.mark.bigdata
     @pytest.mark.slow
     @pytest.mark.parametrize(

--- a/tests/acs/test_wfc_darktime.py
+++ b/tests/acs/test_wfc_darktime.py
@@ -1,0 +1,74 @@
+import subprocess
+import pytest
+
+from ..helpers import BaseACS
+
+
+class TestDarktimeSingle(BaseACS):
+    """
+    The updated darktime correction (March 2020) is applied to data
+    according to the following categories:
+    Full-frame, flashed and unflashed, pre-SM4
+    Full-frame, flashed and unflashed, post-SM4
+    Subarrays, flashed and unflashed, pre-Cycle 24
+    Subarrays, flashed and unflashed, post-Cycle 24
+    """
+    detector = 'wfc'
+    ignore_keywords = ['filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'opus_ver', 'cal_ver', 'proctime', 'history',
+                       'bitpix', 'naxis', 'extend', 'simple']
+
+    def _single_raw_cte(self, rootname):
+        raw_file = '{}_raw.fits'.format(rootname)
+
+        # Prepare input file.
+        self.get_input_file(raw_file)
+
+        # Run CALACS
+        subprocess.call(['calacs.e', raw_file, '-v'])
+
+        # Compare results
+        outputs = [('{}_flt.fits'.format(rootname),
+                    '{}_flt_ref.fits'.format(rootname)),
+                   ('{}_flc.fits'.format(rootname),
+                    '{}_flc_ref.fits'.format(rootname))]
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestDarktimeSingle.ignore_keywords)
+
+    def _single_raw(self, rootname):
+        raw_file = '{}_raw.fits'.format(rootname)
+
+        # Prepare input file.
+        self.get_input_file(raw_file)
+
+        # Run CALACS
+        subprocess.call(['calacs.e', raw_file, '-v'])
+
+        # Compare results
+        outputs = [('{}_flt.fits'.format(rootname),
+                    '{}_flt_ref.fits'.format(rootname))]
+        self.compare_outputs(outputs, ignore_keywords_overwrite=TestDarktimeSingle.ignore_keywords)
+
+    # FULL-FRAME
+    # NOTE: This is slow test due to PCTECORR=PERFORM
+    # 
+    # j8ux05d3q, pre-SM4, postflashed, full-frame
+    # j59l54gjq, pre-SM4, unflashed, full-frame
+    # jch001zdq, post-SM4, postflashed, full-frame
+    # jdw002gdq, post-SM4, unflashed, full-frame
+    @pytest.mark.bigdata
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        'rootname', ['j8ux05d3q', 'j59l54gjq', 'jch001zdq', 'jdw002gdq'])
+    def test_fullframe_darktime_single(self, rootname):
+        self._single_raw_cte(rootname)
+
+    # SUBARRAYS
+    # no data,  pre-Cycle24, postflashed, subarray
+    # j8mv02r4q, pre-Cycle24, unflashed, subarray
+    # jdtr02oqq, post-Cycle24, postflashed, subarray
+    # jdd701acq, post-Cycle24, unflashed, subarray
+    @pytest.mark.bigdata
+    @pytest.mark.parametrize(
+        'rootname', ['j8mv02r4q', 'jdtr02oqq','jdd701acq'])
+    def test_subarray_darktime_single(self, rootname):
+        self._single_raw(rootname)


### PR DESCRIPTION
This PR addresses Issue #326.  (FYI - @nmiles2718 @mmcdonald123)

Removed hard-coded darktime scaling value and read new post-flashed and unflashed columns from updated CCDTAB reference files (WFC and HRC) to use for the offset to the DARKTIME FITS keyword value under appropropriate date and supported subarray criteria.  The DARKTIME keyword value is now the default scaling factor for the superdarks (WFC, HRC, and SBC), with the offset being an additive correction to DARKTIME under appropriate circumstances.  The offset only applies to WFC and HRC.

This software update changes data and requires new reference files for WFC and HRC.

A new PyTest was created for regression testing of the new algorithm.
