### PR TITLE
BUG: main2d not setting suffix correctly

### DIFF
--- a/pkg/acs/calacs/acs2d/main2d.c
+++ b/pkg/acs/calacs/acs2d/main2d.c
@@ -72,7 +72,7 @@ int main (int argc, char **argv) {
     char *isuffix[] = {"_raw", "_blv_tmp", "_blc_tmp", "_crj_tmp", "_crc_tmp"};
     char *osuffix[] = {"_flt", "_flt",     "_flc",     "_crj",     "_crc"};
 
-    int nsuffix = 3;
+    int nsuffix = 5;
 
     /* A structure to pass the calibration switches to acs2d */
     CalSwitch acs2d_sw;


### PR DESCRIPTION
`acs2d.e` on `crj_tmp` input does not produce `crj` as expected. Without this patch, it produces `crj_tmp_flt`. I think I forgot to increase the counter all those years ago back in 510b2184682ede529e9a5.

For comparison, look at the correct counter deeper in the code here:

https://github.com/spacetelescope/hstcal/blob/f5680b59b8a1eeab3d92de708ea4a44c2dfe8550/pkg/acs/calacs/acs2d/acs2d.c#L190

Disclaimer: The code has changed enough since I last tried build it from source that now I am no longer able to build it successfully on my local Linux machine, so I am not sure how to test this patch. 🤷‍♀  (Also see #472)