### PR TITLE
Modified "dodqi" to accommodate the A-to-D saturation threshold

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,6 @@
+ 29-Apr-2020   CALACS 10.2.3 Modified "dodqi" to accommodate the A-to-D saturation threshold 
+                             which is now defined in the CCDTAB. The threshold is no longer 
+                             a constant and has different behavior pre- and post-SM4.
  10-Jan-2020   CALACS 10.2.2 Removed hard-coded darktime scaling value and read new 
                              post-flashed and unflashed columns from updated CCDTAB reference 
                              file to use for the offset to the DARKTIME FITS keyword value 

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -2,7 +2,7 @@
     Modified "dodqi" to accommodate the A-to-D saturation threshold 
     which is now defined in the CCDTAB. The threshold is no longer 
     a constant and has different behavior pre- and post-SM4.
-    Updated CCDTAB files for HRC and WFC.
+    This modification uses Updated CCDTAB files for HRC and WFC.
 
 ### 10-Jan-2020 - MDD -- Version 10.2.2
     Removed hard-coded darktime scaling value and read new post-flashed and

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,8 @@
+### 29-Apr-2020 - MDD -- Version 10.2.3 
+    Modified "dodqi" to accommodate the A-to-D saturation threshold 
+    which is now defined in the CCDTAB. The threshold is no longer 
+    a constant and has different behavior pre- and post-SM4.
+
 ### 10-Jan-2020 - MDD -- Version 10.2.2
     Removed hard-coded darktime scaling value and read new post-flashed and
     unflashed columns from updated CCDTAB reference file to use for the

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -2,6 +2,7 @@
     Modified "dodqi" to accommodate the A-to-D saturation threshold 
     which is now defined in the CCDTAB. The threshold is no longer 
     a constant and has different behavior pre- and post-SM4.
+    Updated CCDTAB files for HRC and WFC.
 
 ### 10-Jan-2020 - MDD -- Version 10.2.2
     Removed hard-coded darktime scaling value and read new post-flashed and

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,14 @@
+Update for version 10.2.3 - 29-Apr-2020 (MDD)
+	pkg/acs/calacs/Dates
+	pkg/acs/calacs/History
+	pkg/acs/calacs/Updates
+	pkg/acs/calacs/include/acs.h
+	pkg/acs/calacs/include/acsinfo.h
+	pkg/acs/calacs/include/acsversion.h
+	pkg/acs/calacs/lib/acsinfo.c
+	pkg/acs/calacs/lib/getccdtab.c
+	pkg/acs/calacs/lib/dodqi.c
+
 Update for version 10.2.2 - 10-Jan-2020 (MDD)
     pkg/acs/calacs/Dates
     pkg/acs/calacs/History

--- a/pkg/acs/calacs/include/acs.h
+++ b/pkg/acs/calacs/include/acs.h
@@ -25,8 +25,6 @@ typedef unsigned char Byte;
 
 # define MAX_DQ     65535
 
-# define ATOD_SATURATE 65534
-
 /* Number of lines to extract from binned images for unbinning */
 # define SECTLINES  2
 

--- a/pkg/acs/calacs/include/acsinfo.h
+++ b/pkg/acs/calacs/include/acsinfo.h
@@ -12,6 +12,8 @@
         PhotInfo to only contain a single set of arrays for wave and thru.
     2001-12-04 WJH: Added expstart and expend.
     2017-02-21 PLL: Added SINKCORR varibles.
+    2020-01-10 MDD: Added overhead_postflashed and overhead_unflashed variables.
+    2020-04-29 MDD: Added atod_saturate variable.
 */
 
 #include "hstio.h"
@@ -82,6 +84,7 @@ typedef struct {
     double blev[NAMPS];  /* bias level value fit for each amp from overscan*/
     int ampx;           /* first column affected by amps on 2/4amp readout*/
     int ampy;           /* first row affected by amps on 2/4amp readout*/
+    int atod_saturate;  /* A-to-D saturation level */
     float saturate;     /* CCD saturation level */
     int trimx[2];       /* Width of overscan to trim off ends of each line */
     int trimy[2];       /* Amount of overscan to trim off ends of each col */

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.2.2 (10-Jan-2020)"
-#define ACS_CAL_VER_NUM "10.2.2"
+#define ACS_CAL_VER "10.2.3 (29-Apr-2020)"
+#define ACS_CAL_VER_NUM "10.2.3"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"

--- a/pkg/acs/calacs/lib/acsinfo.c
+++ b/pkg/acs/calacs/lib/acsinfo.c
@@ -12,6 +12,7 @@
    12-Dec-2012 PLL - added CTE corrected flash reference file.
    12-Aug-2013 PLL - Tidied up code layout.
    05-Dec-2019 MDD - Added overhead for post-flash, unflashed, and DARKTIME values.
+   29-Apr-2020 MDD - Added overhead for atod_saturate value.
 */
 #include <string.h>
 
@@ -86,6 +87,7 @@ void ACSInit (ACSInfo *acs) {
     }
     acs->ampx = 0;
     acs->ampy = 0;
+    acs->atod_saturate = 0;
     acs->saturate = 0.;
     acs->trimx[0] = 0;
     acs->trimx[1] = 0;

--- a/tests/acs/test_hrc_single.py
+++ b/tests/acs/test_hrc_single.py
@@ -38,10 +38,9 @@ class TestSingle(BaseACS):
 
     # NOTE:
     # j8bt02loq = was hrc_single1
-    # j8cd02tyq = was hrc_single2
-    # j8bt02lo2 = was hrc_single3 with FLSHCORR
+    # j8bt02lo2 = was hrc_single1 with FLSHCORR
     @pytest.mark.parametrize(
-        'rootname', ['j8bt02loq', 'j8cd02tyq', 'j8bt02lo2'])
+        'rootname', ['j8bt02loq', 'j8bt02lo2'])
     def test_fullframe_single(self, rootname):
         self._single_raw_calib(rootname)
 

--- a/tests/acs/test_hrc_single.py
+++ b/tests/acs/test_hrc_single.py
@@ -6,14 +6,13 @@ from ..helpers import BaseACS
 
 class TestSingle(BaseACS):
     """
-    Process single HRC dataset using using all standard calibration 
-    steps.
+    Process single HRC dataset using all standard calibration steps.
 
     Process single HRC dataset with DQICORR, BLEVCORR, BIASCORR,
     DARKCORR, FLATCORR, PHOTCORR, RPTCORR, and DITHCORR set to PERFORM.
     RPTCORR not actually done as there is only one image.
 
-    Process single HRC dataset using using all standard calibration 
+    Process single HRC dataset using all standard calibration 
     steps and FLSHCORR.
     """
     detector = 'hrc'

--- a/tests/acs/test_hrc_single.py
+++ b/tests/acs/test_hrc_single.py
@@ -12,8 +12,7 @@ class TestSingle(BaseACS):
     DARKCORR, FLATCORR, PHOTCORR, RPTCORR, and DITHCORR set to PERFORM.
     RPTCORR not actually done as there is only one image.
 
-    Process single HRC dataset using all standard calibration 
-    steps and FLSHCORR.
+    Process single HRC dataset using all standard calibration steps and FLSHCORR.
     """
     detector = 'hrc'
 


### PR DESCRIPTION
The new A-to-D saturation threshold is no longer a constant value and has different behavior pre- and post-SM4.  The CCDTAB files have been updated by the ACS team to contain a new column, ATODSAT, which contains the saturation threshold value.

Please be aware the old code compared a science pixel value to the saturation threshold as only **_greater than_**.  In contrast, the new code is **_greater than or equal to_** as specified in the issue.

This PR fixes Git Issue #460.