### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-addopts = --doctest-ignore-import-errors
 [pytest]
 junit_family = xunit2
 minversion = 4.0
+addopts = --doctest-ignore-import-errors

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
+addopts = --doctest-ignore-import-errors
 [pytest]
 junit_family = xunit2
 minversion = 4.0


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.