### PR TITLE
Use -std=gnu99

### DIFF
--- a/wscript
+++ b/wscript
@@ -352,8 +352,8 @@ def configure(conf):
 
     _determine_sizeof_int(conf)
 
-    if conf.check_cc(cflags='-std=c99'):
-        conf.env.append_value('CFLAGS', '-std=c99')
+    if conf.check_cc(cflags='-std=gnu99'):
+        conf.env.append_value('CFLAGS', '-std=gnu99')
 
     # check whether the compiler supports -02 and add it to CFLAGS if it does
     if conf.options.debug:


### PR DESCRIPTION
* This is compatible with Apple Clang
* (non-GNU) `strdup()` was producing garbage

Let's see if the tests fair better...