### PR TITLE
Free aname after use

### DIFF
--- a/pkg/stis/calstis/cs6/idtalg/calstis6idt.c
+++ b/pkg/stis/calstis/cs6/idtalg/calstis6idt.c
@@ -2130,6 +2130,8 @@ static void BuildTempNames (char *basename, char *out1, char *out2, char *out3) 
 	strcat (out3, separator);
 	strcat (out3, "TEMPIMA1_");
 	strcat (out3, file_name);
+
+	free(aname);
 }
 
 


### PR DESCRIPTION
Fix a minor memory leak in `BuildTempNames`