### PR TITLE
Removed residue sort routine

### DIFF
--- a/pkg/acs/calacs/acsrej/piksrt.c
+++ b/pkg/acs/calacs/acsrej/piksrt.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-# include "trlbuf.h"
 /*
     PIKSRT  -   Sorting by straight insertion. 
     Sorts an array arrayOfFloats[0...n-1] of float type into ascending numerical 
@@ -12,12 +11,15 @@
     There is an assumption the two input arrays are the same size.
 
     Order: n^2
+
+    Date            Author           Description
+    ----            ------           -----------
+    06-Jul-2020     M.D. De La Pena  Removed stray trlmessage causing havoc.
 */
 
 void piksrt (float arrayOfFloats[], int arrayLength) {
     float value;
     int position;
-    trlmessage (MsgText);
 
     /* Loop over the full input array */
     for (int j = 1; j < arrayLength; j++) {
@@ -45,7 +47,6 @@ void ipiksrt (float arrayOfFloats[], int arrayLength, int arrayOfInts[]) {
     float fValue;
     int iValue;
     int position;
-    trlmessage (MsgText);
 
     /* Loop over the input array */
     for (int j = 1; j < arrayLength; j++) {


### PR DESCRIPTION
Removed residue from the piksrt.c sort routines [trlmessage[MsgText)] which was causing memory issues as MsgText was undefined.