### PR TITLE
WFC3 Time-dependent photometry update

### DIFF
--- a/pkg/imphttab/getphttab.c
+++ b/pkg/imphttab/getphttab.c
@@ -15,6 +15,10 @@ PLL, 12/2013 Allow MJD extrapolation using simple straight line from
 MLS: 07/2015 Cleand up for unused variables and warning
 MLS: 08/2015 Added some initializations the clang complained about
 
+MDD: 03/2020 Ensure obs->obsmode is an empty string at the beginning of
+             this routine - this was a lurking bug raised in the case of 
+             multiple Imsets and parameterized value.
+
 */
 # include <stdio.h>
 # include <string.h>
@@ -149,7 +153,6 @@ int GetPhotTab (PhotPar *obs, char *photmode) {
     } else {
         tabinfo.parnum = getIntKw(key);
     }
-
 
     /* Read in PHOTZPT keyword value from Primary header */
     key = findKw (&tphdr, "PHOTZPT");
@@ -445,6 +448,9 @@ static int InterpretPhotmode(char *photmode, PhotPar *obs){
      */
     status = AllocPhotPar(obs,n);
 
+    /* Ensure the obs->obsmode is empty */
+    strcpy(obs->obsmode,"");
+
     if (status > PHOT_OK){
         printf("\n==>ERROR: Problems allocating memory for ObsmodeVars.\n");
         return(status);
@@ -521,7 +527,6 @@ static int InterpretPhotmode(char *photmode, PhotPar *obs){
         for (i=0;i<obselems;i++)
             free(obsnames[i]);
         free(obsnames);
-
     } else {
         strcpy(obs->obsmode, photmode);
     }
@@ -958,6 +963,7 @@ static double ComputeValue(PhtRow *tabrow, PhotPar *obs) {
                 bindx[1] = points[pdim][1].pos[deltadim];
                 bvals[0] = points[pdim][0].value;
                 bvals[1] = points[pdim][1].value;
+
                 /* Perform interpolation now and record the results */
                 rinterp = linterp(bindx, 2, bvals, obsvals[deltadim]);
 

--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,3 +1,9 @@
+12-Aug-2020 - MDD - Version 3.5.2
+    - Added MJD as a parameterized variable for the PHOTMODE keyword to
+      enable a time-dependent photometric correction for the UVIS only.
+    - Fixed a bug in the IMPHTTAB package to support properly data with 
+      multiple imsets, in conjunction with a parameterized value.
+
 24-Jun-2020 - MDD - Version 3.5.1
     - Replaced/modified routines based upon copyright numerical recipes routines.
       Updates implemented Oct 2019, but installation delayed for higher priority updates.

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,3 +1,9 @@
+### 12-Aug-2020 - MDD - Version 3.5.2
+    - Added MJD as a parameterized variable for the PHOTMODE keyword to
+      enable a time-dependent photometric correction for the UVIS only.
+    - Fixed a bug in the IMPHTTAB package to support properly data with 
+      multiple imsets, in conjunction with a parameterized value.
+
 ### 24-Jun-2020 - MDD - Version 3.5.1
     - Replaced/modified routines based upon copyright numerical recipes routines.
       Updates implemented Oct 2019, but installation delayed for higher priority updates.

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,3 +1,9 @@
+Updates for Version 3.5.2 12-Aug-2020 - MDD
+    - Added MJD as a parameterized variable for the PHOTMODE keyword to
+      enable a time-dependent photometric correction for the UVIS only.
+    - Fixed a bug in the IMPHTTAB package to support properly data with 
+      multiple imsets, in conjunction with a parameterized value.
+
 Updates for Version 3.5.1 24-Jun-2020 - MDD
     - Replaced/modified routines based upon copyright numerical recipes routines.
       Updates implemented Oct 2019, but installation delayed for higher priority updates.

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -4,7 +4,7 @@
 /* This string is written to the output primary header as CAL_VER. */
 
 
-# define WF3_CAL_VER "3.5.1(Jun-24-2020)"
-# define WF3_CAL_VER_NUM "3.5.1"
+# define WF3_CAL_VER "3.5.2(Aug-12-2020)"
+# define WF3_CAL_VER_NUM "3.5.2"
 
 #endif /* INCL_WF3VERSION_H */

--- a/pkg/wfc3/calwf3/wf32d/dophot.c
+++ b/pkg/wfc3/calwf3/wf32d/dophot.c
@@ -119,8 +119,6 @@ int doPhot (WF3Info *wf32d, SingleGroup *x) {
 		trlmessage (MsgText);
 	}
 
-
-
 	/* Update the photometry keyword values in the SCI and GLOBAL header. */
 	if (PutKeyFlt (&x->sci.hdr, "PHOTFLAM", obs.photflam,
 				"Inverse sensitivity, ergs/cm2/A/e-"))

--- a/pkg/wfc3/calwf3/wf32d/photmode.c
+++ b/pkg/wfc3/calwf3/wf32d/photmode.c
@@ -37,6 +37,8 @@
 	Changed UVIS channel to use UVIS1 and UVIS2 for each chip and to
 	use new "cal" keyword for UVIS channel. Removed use of DN keyword
 	for IR exposures because they're now in units of electrons.
+   M.De La Pena, 2020 Feb 28:
+    Added MJD in order to enable a time-dependent photometric correction.
 */
 
 int PhotMode (WF3Info *wf32d, Hdr *hdr) {
@@ -76,9 +78,10 @@ Hdr *hdr	io: image header to be modified
 	    strcat (photstr, wf32d->filter);
 	}
 
-	/* Add the CAL keyword for UVIS exposures */
+    /* Add 'MJD#' keyword to PHOTMODE string for UVIS detector only */
 	if (wf32d->detector == CCD_DETECTOR)
-	    strcat (photstr, " CAL");
+        sprintf (scratch, " MJD#%0.4f", wf32d->expstart);
+        strcat (photstr, scratch);
 
 	if (wf32d->verbose) {
 	    sprintf (MsgText, "Keyword PHOTMODE built as: %s", photstr);

--- a/tests/wfc3/test_uvis_11single.py
+++ b/tests/wfc3/test_uvis_11single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.skip(reason="Duplicate test.")
 class TestUVIS11Single(BaseWFC3):
     """
     Test pos UVIS2 30 Dor

--- a/tests/wfc3/test_uvis_14single.py
+++ b/tests/wfc3/test_uvis_14single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.skip(reason="Duplicate test.")
 class TestUVIS14Single(BaseWFC3):
     """
     Test pos UVIS2 GD-71

--- a/tests/wfc3/test_uvis_22single.py
+++ b/tests/wfc3/test_uvis_22single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.skip(reason="Duplicate test. Part of ASN test.")
 class TestUVIS22Single(BaseWFC3):
     """
     Test pos UVIS2 NGC4639 data


### PR DESCRIPTION
imphttab
- Fixed an existing bug in getphttab.c by ensuring a string was set to
  the empty string.  The bug would only be manifested for multiple Imsets
  in an input file, in conjunction with a parameterized value.
wfc3
- Added MJD as a parameterized variable for the PHOTMODE keyword to
  enable a time-dependent photometric correction for the UVIS only.
- Removed appending "CAL" to the PHOTMODE keyword.
