### PR TITLE
Add xfail or skip to PyTests

### DIFF
--- a/tests/stis/test_lev1_fuvspec.py
+++ b/tests/stis/test_lev1_fuvspec.py
@@ -4,6 +4,7 @@ from ci_watson.artifactory_helpers import get_bigdata
 from ..helpers import BaseSTIS
 
 
+@pytest.mark.skip(reason="Temporary skip.")
 class TestLev1FUVSpec(BaseSTIS):
     """Level 1 FUV-MAMA spectroscopy."""
     detector = 'fuv-mama'

--- a/tests/wfc3/test_uvis_01asn.py
+++ b/tests/wfc3/test_uvis_01asn.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail(reason="Temporary xfail. New input/truth files on Artifactory, but branch not merged.")
 class TestUVIS01ASN(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_05asn.py
+++ b/tests/wfc3/test_uvis_05asn.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail(reason="Temporary xfail. New input/truth files on Artifactory, but branch not merged.")
 class TestUVIS05ASN(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_32single.py
+++ b/tests/wfc3/test_uvis_32single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail(reason="Temporary xfail. New input/truth files on Artifactory, but branch not merged.")
 class TestUVIS32Single(BaseWFC3):
     """
     Test pos UVIS2 subarray data with CTE correction


### PR DESCRIPTION
Add the xfail marker to the CTE WFC3 tests as they cannot pass at this time.  The input and truth files have already been updated on Artifactory, but the new code which mates with these files has not been merged.  Add skip to the STIS test as the situation is not clear. There have been no commits to STIS software.