### PR TITLE
Added missing import for pytest to the STIS test

### DIFF
--- a/tests/stis/test_lev1_fuvspec.py
+++ b/tests/stis/test_lev1_fuvspec.py
@@ -1,4 +1,5 @@
 import subprocess
+import pytest
 from ci_watson.artifactory_helpers import get_bigdata
 
 from ..helpers import BaseSTIS


### PR DESCRIPTION
The import statement for pytest was added to the test in order to allow the test to be marked properly for skipping (pytest.mark.skip).