### PR TITLE
Fix explicit declaration of routine and include header

### DIFF
--- a/pkg/acs/calacs/acs2d/dodark.c
+++ b/pkg/acs/calacs/acs2d/dodark.c
@@ -7,6 +7,7 @@
 # include <stdio.h>
 # include <stdlib.h>		/* calloc */
 # include <math.h>		/* fabs */
+# include <string.h>
 
 #include "hstcal_memory.h"
 #include "hstcal.h"

--- a/pkg/acs/calacs/acsccd/doccd.c
+++ b/pkg/acs/calacs/acsccd/doccd.c
@@ -96,6 +96,7 @@ int DoCCD (ACSInfo *acs_info) {
     int FindOverscan (ACSInfo *, int, int, int *, int *);
     int GetCCDTab (ACSInfo *, int, int);
     int GetKeyBool (Hdr *, char *, int, Bool, Bool *);
+    int doFullWellSat(ACSInfo *, SingleGroup *);
 
     /*========================Start Code here =======================*/
 


### PR DESCRIPTION
Added explicit declaration of subroutine, doFullWellSat() in doccd.c (new code).  Added explicit inclusion of the string library in an old routine, dodark.c.