### PR TITLE
Removed parameter being passed to static function printSyntax()

### DIFF
--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -230,7 +230,7 @@ int doMainCTE (int argc, char **argv) {
                 if (argv[i][1] == '-')
                 {
                     printf ("Unrecognized option %s\n", argv[i]);
-                    printSyntax(program);
+                    printSyntax();
                     freeOnExit(&ptrReg);
                     exit (ERROR_RETURN);
                 }

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.3.0 (31-Dec-2020)"
-#define ACS_CAL_VER_NUM "10.3.0"
+#define ACS_CAL_VER "10.3.1 (07-Apr-2021)"
+#define ACS_CAL_VER_NUM "10.3.1"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
Removed parameter being passed to static function printSyntax() as it is incorrect and may be causing serious problems 
(segfault) on some systems with acscte.e. Incremented the calacs version.