### PR TITLE
Fixed the check on argv[0]

### DIFF
--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -142,8 +142,13 @@ int doMainCTE (int argc, char **argv) {
 
     /* Obtain program basename */
     if ((program = strrchr(argv[0], '/')) != NULL) {
+
         strcpy(program_buf, program + 1);
         program = program_buf;
+
+    } else {
+
+        program = argv[0];
     }
 
     if (!strcmp(program, "acsforwardmodel.e")) {


### PR DESCRIPTION
Fixed the check on argv[0] to ensure the variable "program" always contains the base program name.  This cures the seg fault generated on the build machines.