### PR TITLE
Bug fix to address a problem detected when processing a Tungsten flat with a high background

### DIFF
--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,3 +1,7 @@
+28-Apr-2021 - MDD - Version 3.6.1
+    - Bug fix to address a problem detected when processing a Tungsten flat with a high background.
+      Uninitialized values were used for further computation causing an eventual exception.
+
 31-Dec-2020 - MDD - Version 3.6.0
     - Implementation of a significantly upgraded CTE correction as defined/derived by J. Anderson.
       The upgraded CTE algorithm is also streamlined and executes faster then the previous version.

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,3 +1,7 @@
+### 28-Apr-2021 - MDD - Version 3.6.1
+    - Bug fix to address a problem detected when processing a Tungsten flat with a high background.
+      Uninitialized values were used for further computation causing an eventual exception.
+
 ### 31-Dec-2020 - MDD - Version 3.6.0
     - Implementation of a significantly upgraded CTE correction as defined/derived by J. Anderson.
       The upgraded CTE algorithm is also streamlined and executes faster then the previous version.

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,3 +1,7 @@
+Updates for Version 3.6.1 28-Apr-2021 - MDD
+    - Bug fix to address a problem detected when processing a Tungsten flat with a high background.
+      Uninitialized values were used for further computation causing an eventual exception.
+
 Updates for Version 3.6.0 31-Dec-2020 - MDD
     - Implementation of a significantly upgraded CTE correction as defined/derived by J. Anderson.
       The upgraded CTE algorithm is also streamlined and executes faster then the previous version.

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -4,7 +4,7 @@
 /* This string is written to the output primary header as CAL_VER. */
 
 
-# define WF3_CAL_VER "3.6.0(Dec-31-2020)"
-# define WF3_CAL_VER_NUM "3.6.0"
+# define WF3_CAL_VER "3.6.1(Apr-28-2021)"
+# define WF3_CAL_VER_NUM "3.6.1"
 
 #endif /* INCL_WF3VERSION_H */


### PR DESCRIPTION
Bug fix to address a problem detected when processing a Tungsten flat with a high background… with a high background.

Uninitialized values were used for further computation causing an eventual exception.  The problem detected by this image could happen for images with lower backgrounds with no pixel values less than a threshold minimum (1000) so
it was important to fix for useful science data.