### PR TITLE
Fix the name of the standalone executable acscteforwardmodel.e

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,8 +1,25 @@
+ 26-Apr-2021   CALACS 10.3.2 Fixed a bug introduced when the build manager reworked code to
+                             remove circular dependencies caused by the introduction of the
+                             acscteforwardmodel code.  The name of the executable was
+                             inadvertently changed from "acscteforwardmodel.e" to
+                             "acsforwardmodel.e".  The ACS team requested the name be
+                             changed back to the original as scripts and documentation
+                             are impacted.
+ 07-Apr-2021   CALACS 10.3.1 Fixed a bug introduced when the build manager reworked code to
+                             remove circular dependencies caused by the introduction of the
+                             acscteforwardmodel code.  Resolved the segmentation fault when
+                             trying to execute the standalone executables "acscte.e" and
+                             "acsforwardmodel.e".
+ 12-Feb-2021                 Done during build creation for operations for 10.3.0 -
+                             Build manager made changes to the main routines and wscript
+                             files (predominantly) to eliminate some circular dependency.
  31-Dec-2020   CALACS 10.3.0 Implementation to use an image to detect and flag full-well
                              saturation versus a simple scalar.  The new routine,
                              dofwsat.c, is modelled on dobias.c. The detect/flagging
                              occurs after bias correction, conversion to electrons, and
-                             blev correction.
+                             blev correction.  Build manager made changes to the main
+                             routines and wscript files (predominantly) to eliminate
+                             some circular dependency.
  24-Jun-2020:  CALACS 10.2.4 Removed/modified/updated routines which used copyrighted
                              code. Updates implemented Oct 2019, but installation delayed 
                              for higher priority updates.

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,21 @@
+### 26-Apr-2021 - MDD - Version 10.3.2
+    Fixed a bug introduced when the build manager reworked code to remove circular
+    dependencies caused by the introduction of the acscteforwardmodel code.  The
+    name of the executable was inadvertently changed from "acscteforwardmodel.e"
+    to "acsforwardmodel.e".  The ACS team requested the name be changed back to
+    the original as scripts and documentation are impacted.
+
+###  07-Apr-2021 - MDD - Version 10.3.1
+    Fixed a bug introduced when the build manager reworked code to
+    remove circular dependencies caused by the introduction of the
+    acscteforwardmodel code.  Resolved the segmentation fault when
+    trying to execute the standalone executables "acscte.e" and
+    "acsforwardmodel.e".
+
+### 12-Feb-2021 - JH (Done during build creation for operations for 10.3.0)
+    Build manager made changes to the main routines and wscript files (predominantly)
+    to eliminate some circular dependency.
+
 ### 31-Dec-2020 - MDD - Version 10.3.0
     Implementation to use an image to detect and flag full-well
     saturation versus a simple scalar.  The new routine,

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,27 @@
+Update for version 10.3.2 - 26-Apr-2021 (MDD)
+	pkg/acs/calacs/Dates
+	pkg/acs/calacs/History
+	pkg/acs/calacs/Updates
+	pkg/acs/calacs/acscte/maincte.c
+	pkg/acs/calacs/acscte/wscript
+	pkg/acs/calacs/include/acsversion.h
+
+Update for version 10.3.1 - 07-Apr-2021 (MDD)
+	pkg/acs/calacs/acscte/maincte.c
+	pkg/acs/calacs/include/acsversion.h
+
+Update - 12-Feb-2021 (JH)
+    pkg/acs/calacs/acs2d/main2d.c
+    pkg/acs/calacs/acsccd/mainccd.c
+    pkg/acs/calacs/acscte/forward_model/main.c
+    pkg/acs/calacs/acscte/forward_model/wscript
+    pkg/acs/calacs/acscte/maincte.c
+    pkg/acs/calacs/acscte/wscript
+    pkg/acs/calacs/acsrej/mainrej.c
+    pkg/acs/calacs/acssum/mainsum.c
+    pkg/acs/calacs/calacs/acsmain.c
+    pkg/acs/calacs/calacs/wscript
+   
 Update for version 10.3.0 - 31-Dec-2020 (MDD)
 	pkg/acs/calacs/Dates
 	pkg/acs/calacs/History

--- a/pkg/acs/calacs/acscte/maincte.c
+++ b/pkg/acs/calacs/acscte/maincte.c
@@ -151,7 +151,7 @@ int doMainCTE (int argc, char **argv) {
         program = argv[0];
     }
 
-    if (!strcmp(program, "acsforwardmodel.e")) {
+    if (!strcmp(program, "acscteforwardmodel.e")) {
         forwardModelOnly = true;
     }
 

--- a/pkg/acs/calacs/acscte/wscript
+++ b/pkg/acs/calacs/acscte/wscript
@@ -15,4 +15,4 @@ def build(bld):
         rpath=bld.env.LIBPATH_CFITSIO,
         install_path = '${PREFIX}/bin'
         )
-    bld.install_as('${PREFIX}/bin/acsforwardmodel.e', 'acscte.e')
+    bld.install_as('${PREFIX}/bin/acscteforwardmodel.e', 'acscte.e')

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.3.1 (07-Apr-2021)"
-#define ACS_CAL_VER_NUM "10.3.1"
+#define ACS_CAL_VER "10.3.2 (26-Apr-2021)"
+#define ACS_CAL_VER_NUM "10.3.2"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
The name of a standalone executable inadvertently was changed when code was re-arranged by the build manager to address circular references. Changed acsforwardmodel.e back to acscteforwardmodel.e
to aid documentation and script issues.