### PR TITLE
Issue489 fixflash

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,7 @@
+ 03-May-2021   CALACS 10.3.3 Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
+                             keyword was updated in the CRJ/CRC headers to be the sum of
+                             the individual input images as this keyword is used in ACS2D to
+                             scale the flash reference file for flash correction.
  26-Apr-2021   CALACS 10.3.2 Fixed a bug introduced when the build manager reworked code to
                              remove circular dependencies caused by the introduction of the
                              acscteforwardmodel code.  The name of the executable was

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,9 @@
+### 03-May-2021 - MDD - Version 10.3.3
+    Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
+    keyword was updated in the CRJ/CRC headers to be the sum of
+    the individual input images as this keyword is used in ACS2D to
+    scale the flash reference file for flash correction.
+
 ### 26-Apr-2021 - MDD - Version 10.3.2
     Fixed a bug introduced when the build manager reworked code to remove circular
     dependencies caused by the introduction of the acscteforwardmodel code.  The

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,11 @@
+Update for version 10.3.3 - 01-May-2021 (MDD)
+	pkg/acs/calacs/Dates
+	pkg/acs/calacs/History
+	pkg/acs/calacs/Updates
+	pkg/acs/calacs/acsrej/acsrej_check.c
+	pkg/acs/calacs/acsrej/acsrej_do.c
+	pkg/acs/calacs/include/acsversion.h
+
 Update for version 10.3.2 - 26-Apr-2021 (MDD)
 	pkg/acs/calacs/Dates
 	pkg/acs/calacs/History

--- a/pkg/acs/calacs/acsrej/acsrej_do.c
+++ b/pkg/acs/calacs/acsrej/acsrej_do.c
@@ -41,6 +41,8 @@ static void closeSciDq (int, IODescPtr [], IODescPtr [], IODescPtr [], clpar *);
                                 Added doc. Cleaned up codes.
   27-Feb-2019   M.D. DeLaPena   Read the IMAGETYP keyword from Primary of first image
                                 as this info is needed by acsrej_loop.
+  30-Apr-2021   M.D. DeLaPena   Read the FLASHDUR keyword from Primary of all the input
+                                images in order to compute the cumulative value.
 */
 int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
                int newpar[]) {
@@ -84,6 +86,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
     int         non_zero;           /* number of input images with EXPTIME>0 */
     int         found;
     char        imgdefault[CHAR_FNAME_LENGTH];  /* name of first input image with EXPTIME > 0. */
+    float       cumFlashDur;
 
     int     GetSwitch (Hdr *, char *, int *);
     int     UpdateSwitch (char *, int, Hdr *, int *);
@@ -95,7 +98,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
     int     acsrej_check (IRAFPointer, int, int, clpar *, int [],
                           char [][CHAR_FNAME_LENGTH], int [], IODescPtr [],
                           IODescPtr [], IODescPtr [], multiamp *, multiamp *,
-                          int *, int *, int, float []);
+                          int *, int *, int, float [], float *);
     int     cr_scaling (char *, IRAFPointer, float [], int *, double *,
                         double *);
     int     rejpar_in(clpar *, int [], int, float, int *, float []);
@@ -245,7 +248,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
 		/* open input files and temporary files, check the parameters */
 		if (acsrej_check (tpin, extver, numext, par, newpar, imgname, ext,
 						  ipsci, iperr, ipdq, &noise, &gain, &dim_x, &dim_y,
-						  nimgs, efac)) {
+						  nimgs, efac, &cumFlashDur)) {
 			WhichError (status);
 			return(status);
 		}
@@ -395,6 +398,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
                    "Total sky level (electrons)");
         PutKeyFlt (sg.globalhdr, "REJ_RATE", (float)nrej / texpt,
                    "Cosmic ray impact rate (pixels/sec)");
+        PutKeyFlt (sg.globalhdr, "FLASHDUR", cumFlashDur, "");
 
         if (par->shadcorr) {
             logit = 0;

--- a/pkg/acs/calacs/acsrej/acsrej_do.c
+++ b/pkg/acs/calacs/acsrej/acsrej_do.c
@@ -42,7 +42,8 @@ static void closeSciDq (int, IODescPtr [], IODescPtr [], IODescPtr [], clpar *);
   27-Feb-2019   M.D. DeLaPena   Read the IMAGETYP keyword from Primary of first image
                                 as this info is needed by acsrej_loop.
   30-Apr-2021   M.D. DeLaPena   Read the FLASHDUR keyword from Primary of all the input
-                                images in order to compute the cumulative value.
+                                images in order to compute the cumulative value and update
+                                FLASHDUR in the blv_tmp/blc_tmp file(s).
 */
 int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
                int newpar[]) {

--- a/pkg/acs/calacs/acsrej/acsrej_do.c
+++ b/pkg/acs/calacs/acsrej/acsrej_do.c
@@ -399,7 +399,13 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
                    "Total sky level (electrons)");
         PutKeyFlt (sg.globalhdr, "REJ_RATE", (float)nrej / texpt,
                    "Cosmic ray impact rate (pixels/sec)");
+
+        /* Cannot update the comment portion of the FITS card for an existing keyword
+           with the high-level interface so using lower-level functions for the update.
+        */
         PutKeyFlt (sg.globalhdr, "FLASHDUR", cumFlashDur, "");
+        FitsKw kw = findKw(sg.globalhdr, "FLASHDUR");
+        putKwComm(kw, "Cumulative exposure time in seconds");
 
         if (par->shadcorr) {
             logit = 0;

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.3.2 (26-Apr-2021)"
-#define ACS_CAL_VER_NUM "10.3.2"
+#define ACS_CAL_VER "10.3.3 (03-May-2021)"
+#define ACS_CAL_VER_NUM "10.3.3"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR keyword was updated in the CRJ/CRC headers to be the sum of the individual input images as this keyword is used in ACS2D to scale the flash reference file for flash correction.
