### PR TITLE
Fixed a bug associated with the DARKTIME computation and utilization

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,7 +1,13 @@
- 03-May-2021   CALACS 10.3.3 Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
+ 24-May-2021   CALACS 10.3.3 Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
                              keyword was updated in the CRJ/CRC headers to be the sum of
                              the individual input images as this keyword is used in ACS2D to
-                             scale the flash reference file for flash correction.
+                             scale the flash reference file for flash correction.  Fixed a bug
+                             associated with the DARKTIME computation.  Code written for CALACS
+                             10.2.2 was moved from ACS2D to ACSCCD so every BLV_TMP file has the
+                             correct DARKTIME keyword value.  Also, the DARKTIME keyword was updated
+                             in the CRJ/CRC headers to be the sum of the individual input images. Only
+                             the DARKTIME value in the input file header is used to scale the dark
+                             reference file for the dark correction.
  26-Apr-2021   CALACS 10.3.2 Fixed a bug introduced when the build manager reworked code to
                              remove circular dependencies caused by the introduction of the
                              acscteforwardmodel code.  The name of the executable was

--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -4,7 +4,7 @@
                              scale the flash reference file for flash correction.  Fixed a bug
                              associated with the DARKTIME computation.  Code written for CALACS
                              10.2.2 was moved from ACS2D to ACSCCD so every BLV_TMP file has the
-                             correct DARKTIME keyword value.  Also, the DARKTIME keyword was updated
+                             correct DARKTIME keyword value. Also, the DARKTIME keyword was updated
                              in the CRJ/CRC headers to be the sum of the individual input images. Only
                              the DARKTIME value in the input file header is used to scale the dark
                              reference file for the dark correction.

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,8 +1,14 @@
-### 03-May-2021 - MDD - Version 10.3.3
+### 24-May-2021 - MDD - Version 10.3.3
     Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
     keyword was updated in the CRJ/CRC headers to be the sum of
     the individual input images as this keyword is used in ACS2D to
-    scale the flash reference file for flash correction.
+    scale the flash reference file for flash correction.  Fixed a bug
+    associated with the DARKTIME computation.  Code written for CALACS
+    10.2.2 was moved from ACS2D to ACSCCD so every BLV_TMP file has the
+    correct DARKTIME keyword value.  Also, the DARKTIME keyword was updated
+    in the CRJ/CRC headers to be the sum of the individual input images. Only
+    the DARKTIME value in the input file header is used to scale the dark
+    reference file for the dark correction.
 
 ### 26-Apr-2021 - MDD - Version 10.3.2
     Fixed a bug introduced when the build manager reworked code to remove circular

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,7 +1,10 @@
-Update for version 10.3.3 - 01-May-2021 (MDD)
+Update for version 10.3.3 - 24-May-2021 (MDD)
 	pkg/acs/calacs/Dates
 	pkg/acs/calacs/History
 	pkg/acs/calacs/Updates
+    pkg/acs/calacs/acs2d/dodark.c
+    pkg/acs/calacs/acsccd/dobias.c
+    pkg/acs/calacs/acsccd/doccd.c
 	pkg/acs/calacs/acsrej/acsrej_check.c
 	pkg/acs/calacs/acsrej/acsrej_do.c
 	pkg/acs/calacs/include/acsversion.h

--- a/pkg/acs/calacs/acsccd/dobias.c
+++ b/pkg/acs/calacs/acsccd/dobias.c
@@ -126,42 +126,39 @@ int doBias (ACSInfo *acs, SingleGroup *x) {
 		}
 	} else {
     
-		/* Loop over all the lines in the science array, and
-     match them to the appropriate line in the reference image... 
-     */
-		/* 
-     i - index for line in science image
-     j - index for line in reference image
-     y0 - line in reference image corresponding to line in input image
-     */
-    initSingleGroupLine (&z);
-    allocSingleGroupLine (&z, x->sci.data.nx);
-		for (i=0, j=y0; i < scilines; i++,j++) { 
+        /* Loop over all the lines in the science array, and
+           match them to the appropriate line in the reference image... 
+           i - index for line in science image
+           j - index for line in reference image
+           y0 - line in reference image corresponding to line in input image
+        */
+        initSingleGroupLine (&z);
+        allocSingleGroupLine (&z, x->sci.data.nx);
+        for (i=0, j=y0; i < scilines; i++,j++) { 
+            /* We are working with a sub-array and need to apply the
+               proper section from the reference image to the science image.
+            */
+            status = getSingleGroupLine (acs->bias.name, j, &y);
+            if (status) {
+                sprintf(MsgText,"Could not read line %d from bias image.",j+1);
+                trlerror(MsgText);
+            }			
+
+            update = NO;
+     
+            /* rx = 1; */
+            if (trim1d (&y, x0, y0, rx, avg, update, &z)) {
+                trlerror ("(biascorr) size mismatch.");
+                return (status);
+            }
+
+            status = sub1d (x, i, &z);
+            if (status)
+                return (status);
       
-	    /* We are working with a sub-array and need to apply the
-       proper section from the reference image to the science image.
-       */
-			status = getSingleGroupLine (acs->bias.name, j, &y);
-			if (status) {
-				sprintf(MsgText,"Could not read line %d from bias image.",j+1);
-				trlerror(MsgText);
-			}			
-      
-			update = NO;
-      
-			/* rx = 1; */
-      if (trim1d (&y, x0, y0, rx, avg, update, &z)) {
-				trlerror ("(biascorr) size mismatch.");
-				return (status);
-      }
-			
-			status = sub1d (x, i, &z);
-      if (status)
-        return (status);
-      
-		}
-    freeSingleGroupLine (&z);			/* done with z */
-	}
+        }
+        freeSingleGroupLine (&z);			/* done with z */
+    }
   
 	closeSingleGroupLine (&y);
 	freeSingleGroupLine (&y);

--- a/pkg/acs/calacs/acsrej/acsrej_do.c
+++ b/pkg/acs/calacs/acsrej/acsrej_do.c
@@ -88,6 +88,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
     int         found;
     char        imgdefault[CHAR_FNAME_LENGTH];  /* name of first input image with EXPTIME > 0. */
     float       cumFlashDur;
+    float       cumDarktime;
 
     int     GetSwitch (Hdr *, char *, int *);
     int     UpdateSwitch (char *, int, Hdr *, int *);
@@ -99,7 +100,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
     int     acsrej_check (IRAFPointer, int, int, clpar *, int [],
                           char [][CHAR_FNAME_LENGTH], int [], IODescPtr [],
                           IODescPtr [], IODescPtr [], multiamp *, multiamp *,
-                          int *, int *, int, float [], float *);
+                          int *, int *, int, float [], float *, float *);
     int     cr_scaling (char *, IRAFPointer, float [], int *, double *,
                         double *);
     int     rejpar_in(clpar *, int [], int, float, int *, float []);
@@ -249,7 +250,7 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
 		/* open input files and temporary files, check the parameters */
 		if (acsrej_check (tpin, extver, numext, par, newpar, imgname, ext,
 						  ipsci, iperr, ipdq, &noise, &gain, &dim_x, &dim_y,
-						  nimgs, efac, &cumFlashDur)) {
+						  nimgs, efac, &cumFlashDur, &cumDarktime)) {
 			WhichError (status);
 			return(status);
 		}
@@ -406,6 +407,10 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
         PutKeyFlt (sg.globalhdr, "FLASHDUR", cumFlashDur, "");
         FitsKw kw = findKw(sg.globalhdr, "FLASHDUR");
         putKwComm(kw, "Cumulative exposure time in seconds");
+
+        PutKeyFlt (sg.globalhdr, "DARKTIME", cumDarktime, "");
+        kw = findKw(sg.globalhdr, "DARKTIME");
+        putKwComm(kw, "Cumulative dark time in seconds");
 
         if (par->shadcorr) {
             logit = 0;

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,7 +2,7 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.3.3 (03-May-2021)"
+#define ACS_CAL_VER "10.3.3 (24-May-2021)"
 #define ACS_CAL_VER_NUM "10.3.3"
 
 /* name and version number of the CTE correction algorithm */


### PR DESCRIPTION
Fixed a bug associated with the DARKTIME computation Code written for CALACS 10.2.2 was moved from ACS2D to ACSCCD so every BLV_TMP file has the correct DARKTIME keyword value.  Also, the DARKTIME keyword was updated in the CRJ/CRC
headers to be the sum of the individual input images. Only the DARKTIME value in the input file header is used to scale the dark reference file for the dark correction.

This PR fixes Git Issue#490.