### PR TITLE
WFC3 aborts when processing IR IMA file with CRCORR=PERFORM

### DIFF
--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,3 +1,9 @@
+27-May-2021 - MDD - Version 3.6.2
+    - Bug fix to address calwf3.e crashing (Abort trap: 6) when taking an existing *_ima.fits (IR) file
+      (produced with FLATCORR=PERFORM and CRCORR=OMIT) with CRCORR set to PERFORM. This reentrant
+      processing is fundamental to being able to remove the variable IR background during the course
+      of an exposure.  Problem: char variable declared too small to hold its largest possible contents.
+
 28-Apr-2021 - MDD - Version 3.6.1
     - Bug fix to address a problem detected when processing a Tungsten flat with a high background.
       Uninitialized values were used for further computation causing an eventual exception.

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,3 +1,9 @@
+### 27-May-2021 - MDD - Version 3.6.2
+    - Bug fix to address calwf3.e crashing (Abort trap: 6) when taking an existing *_ima.fits (IR) file
+      (produced with FLATCORR=PERFORM and CRCORR=OMIT) with CRCORR set to PERFORM. This reentrant
+      processing is fundamental to being able to remove the variable IR background during the course
+      of an exposure. Problem: char variable declared too small to hold its largest possible contents.
+
 ### 28-Apr-2021 - MDD - Version 3.6.1
     - Bug fix to address a problem detected when processing a Tungsten flat with a high background.
       Uninitialized values were used for further computation causing an eventual exception.

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,3 +1,9 @@
+Updates for Version 3.6.2 27-May-2021 - MDD
+    - Bug fix to address calwf3.e crashing (Abort trap: 6) when taking an existing *_ima.fits (IR) file
+      (produced with FLATCORR=PERFORM and CRCORR=OMIT) with CRCORR set to PERFORM. This reentrant
+      processing is fundamental to being able to remove the variable IR background during the course
+      of an exposure. Problem: char variable declared too small to hold its largest possible contents.
+
 Updates for Version 3.6.1 28-Apr-2021 - MDD
     - Bug fix to address a problem detected when processing a Tungsten flat with a high background.
       Uninitialized values were used for further computation causing an eventual exception.

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -4,7 +4,7 @@
 /* This string is written to the output primary header as CAL_VER. */
 
 
-# define WF3_CAL_VER "3.6.1(Apr-28-2021)"
-# define WF3_CAL_VER_NUM "3.6.1"
+# define WF3_CAL_VER "3.6.2 (May-27-2021)"
+# define WF3_CAL_VER_NUM "3.6.2"
 
 #endif /* INCL_WF3VERSION_H */

--- a/pkg/wfc3/calwf3/wf3ir/groupinfo.c
+++ b/pkg/wfc3/calwf3/wf3ir/groupinfo.c
@@ -97,7 +97,7 @@ int getDataUnits (WF3Info *wf3, Hdr *header) {
 */
 
 	/* Local variables */
-	char units[9];				/* BUNIT keyword value */
+	char units[12];				/* BUNIT keyword value */
 
 	/* Read the BUNIT keyword */
 	units[0] = '\0';


### PR DESCRIPTION
Nor identified a problem with calwf3.e that cropped up during one of the last rewrite: It is no longer possible to process a raw dataset, and then take an ima and **_finish the processing_** with calwf3. This is a feature fundamental to being able to remove the variable IR background during the course of an exposure. The errors I see are just binary -6 errors. Turning on flatcorr when producing the IMA file and CRCORR off works but feeding an IMA processed this way and turning on CRCORR does not and exits with a -6 error code. 
I hope this can be resolved because it is stopping a few of us from progressing with out IR slitless data reduction.