### PR TITLE
Use strncpy for inlist in acsccd.e, better error

### DIFF
--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -117,10 +117,6 @@ int main (int argc, char **argv) {
         freeOnExit(&ptrReg);
         exit (ERROR_RETURN);
     }
-    inlist[0] = '\0';
-    outlist[0] = '\0';
-    input[0] = '\0';
-    output[0] = '\0';
 
     /* Initialize the lists of reference file keywords and names. */
     InitRefFile (&refnames);
@@ -180,7 +176,7 @@ int main (int argc, char **argv) {
                 }
             }
         } else if (inlist[0] == '\0') {
-            strcpy (inlist, argv[i]);
+            strncpy (inlist, argv[i], sizeof(inlist));
         } else if (outlist[0] == '\0') {
             strcpy (outlist, argv[i]);
         } else {

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -62,6 +62,7 @@ int main (int argc, char **argv) {
     int verbose = NO;	/* print additional info? */
     int quiet = NO;	/* print additional info? */
     int too_many = 0;	/* too many command-line arguments? */
+    int too_long = 0; /* command-line argument too long? */
     int i, j;		/* loop indexes */
     int k;
 
@@ -142,6 +143,7 @@ int main (int argc, char **argv) {
             switch_on = 1;
         } else if (argv[i][0] == '-') {
         **********/
+        too_long = strlen(argv[i]) > CHAR_LINE_MAX;
         if (argv[i][0] == '-') {
             if (!(strcmp(argv[i],"--version")))
             {
@@ -176,14 +178,25 @@ int main (int argc, char **argv) {
                 }
             }
         } else if (inlist[0] == '\0') {
-            strncpy (inlist, argv[i], sizeof(inlist));
+            strncpy (inlist, argv[i], CHAR_LINE_LENGTH);
         } else if (outlist[0] == '\0') {
-            strcpy (outlist, argv[i]);
+            strncpy (outlist, argv[i], CHAR_LINE_LENGTH);
         } else {
             too_many = 1;
         }
     }
-    if (inlist[0] == '\0' || too_many) {
+    
+    if (inlist[0] == '\0' || too_many || too_long) {
+        if (too_many) {
+            fprintf(stderr, "ERROR: Too many arguments\n");
+        }
+        
+        if (too_long) {
+            fprintf(stderr, "ERROR: Input path exceeds maximum supported length (%zu > %d)\n",
+                    strlen(argv[i]),
+                    CHAR_LINE_LENGTH);
+        }
+        
         printSyntax();
         /*
         printf ("  command-line switches:\n");

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -192,8 +192,7 @@ int main (int argc, char **argv) {
         }
         
         if (too_long) {
-            fprintf(stderr, "ERROR: Input path exceeds maximum supported length (%zu > %d)\n",
-                    strlen(argv[i]),
+            fprintf(stderr, "ERROR: Input path exceeds maximum supported length (%d)\n",
                     CHAR_LINE_LENGTH);
         }
         

--- a/pkg/acs/calacs/acsccd/mainccd.c
+++ b/pkg/acs/calacs/acsccd/mainccd.c
@@ -143,7 +143,7 @@ int main (int argc, char **argv) {
             switch_on = 1;
         } else if (argv[i][0] == '-') {
         **********/
-        too_long = strlen(argv[i]) > CHAR_LINE_MAX;
+        too_long = strlen(argv[i]) > CHAR_LINE_LENGTH;
         if (argv[i][0] == '-') {
             if (!(strcmp(argv[i],"--version")))
             {


### PR DESCRIPTION
Fix #554 by exiting "gracefully" and giving more useful hint on why it failed. With this patch:

```
ERROR: Input path exceeds maximum supported length (255)
syntax:  acsccd [--help] [-t] [-v] [-q] [--version] [--gitinfo] input output
```

Out of scope: I have no WBS to charge to, so I cannot apply this to CALACS globally. This PR is only meant to solve the immediate problem reported originally over at ACSTOOLS.