### PR TITLE
Bootstrap release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+DISTINFO
+*.tar.*
 .lock-waf*
 .waf*
 bin.*

--- a/include/hstcalversion.h
+++ b/include/hstcalversion.h
@@ -1,17 +1,7 @@
 #ifndef HSTCALVERSION_INCL
 #define HSTCALVERSION_INCL
 
-#ifndef VERSION
-#define VERSION "UNKNOWN"
-#endif
-
-#ifndef BRANCH
-#define BRANCH "UNKNOWN"
-#endif
-
-#ifndef COMMIT
-#define COMMIT "UNKNOWN"
-#endif
+#include "version.h"
 
 char * getVersionInfo(char ** buffer);
 char * sprintfGitInfo(char ** buffer);

--- a/wscript
+++ b/wscript
@@ -11,10 +11,23 @@ from waflib import Task
 from waflib import Utils
 from waflib import TaskGen
 
-APPNAME = "HSTCAL"
-
 top = '.'
 out = 'build.' + platform.platform()
+out_include_dir = os.path.abspath(os.path.join(out, 'include'))
+
+APPNAME = "hstcal"
+VERSION = "UNKNOWN"
+BRANCH = "UNKNOWN"
+COMMIT = "UNKNOWN"
+
+# DISTINFO controls distribution archive versioning
+DISTINFO = os.path.abspath(os.path.join(top, "DISTINFO"))
+DISTINFO_KEYS = [
+    "APPNAME",
+    "VERSION",
+    "BRANCH",
+    "COMMIT",
+]
 
 # A list of subdirectories to recurse into
 SUBDIRS = [
@@ -28,9 +41,6 @@ SUBDIRS = [
     'pkg',
     'tables',
     ]
-
-# Have 'waf dist' create tar.gz files, rather than tar.bz2 files
-Scripting.g_gz = 'gz'
 
 # Have gcc supersede clang
 from waflib.Tools.compiler_c import c_compiler
@@ -134,56 +144,120 @@ def call(cmd):
 
     return None
 
+
+def _gen_distinfo(data):
+    """Generates a DISTINFO file
+    data: [["key", "value"], ["key", "value"], ...]
+    """
+
+    # Generate DISTINFO file UNLESS we are building from an archive
+    if os.path.exists('.git') and os.path.exists(DISTINFO):
+        return
+
+    # Write data pairs to DISTINFO file
+    with open(DISTINFO, 'w+') as fp:
+        for key_dist in DISTINFO_KEYS:
+            for name, value in data:
+                if name == key_dist:
+                    fp.write("{}:{}\n".format(name, value))
+
+
+def _get_distinfo():
+    """Creates a DISTINFO file using information from git
+    """
+    global APPNAME
+    global VERSION
+    global BRANCH
+    global COMMIT
+
+    # Die silently when there's nothing to do
+    if not os.path.exists(DISTINFO):
+        return
+
+    with open(DISTINFO, 'r') as fp:
+        for record in fp:
+            record = record.strip()
+            if not record:
+                continue
+
+            name, value = record.split(":", 1)
+            for key_dist in DISTINFO_KEYS:
+                if name == key_dist:
+                    if name == "APPNAME":
+                        APPNAME = value
+                    if name == "VERSION":
+                        VERSION = value
+                    if name == "BRANCH":
+                        BRANCH = value
+                    if name == "COMMIT":
+                        COMMIT = value
+
+
 def _get_git_details(ctx):
+    global APPNAME
+    global VERSION
+    global BRANCH
+    global COMMIT
+
+    # Handle building from a archive
+    if not os.path.exists(".git") and os.path.exists(DISTINFO):
+        print("Using DISTINFO file")
+        _get_distinfo()
+        return
+
     tmp = call('git describe --dirty --abbrev=7')
     if tmp:
-        ctx.env.gitTag = tmp
+        VERSION = tmp
 
     tmp = call('git rev-parse HEAD')
     if tmp:
-        ctx.env.gitCommit = tmp
+        COMMIT = tmp
 
     tmp = call('git rev-parse --abbrev-ref HEAD')
     if tmp:
-        ctx.env.gitBranch = tmp
+        BRANCH = tmp
+
+
+def _gen_version_header(ctx):
+    """Generate a C header to provide versioning data to hstcal's programs
+    """
+    data = [
+        ["APPNAME", APPNAME],
+        ["VERSION", VERSION],
+        ["BRANCH", BRANCH],
+        ["COMMIT", COMMIT],
+    ]
+    _gen_distinfo(data)
+
+    filename = os.path.join(out_include_dir, 'version.h')
+    label = "HEADER_" + os.path.basename(filename).replace(".", "_").upper()
+
+    os.makedirs(out_include_dir, exist_ok=True)
+    with open(filename, 'w+') as hdr:
+        hdr.write("#ifndef {}\n".format(label))
+        hdr.write("#define {}\n".format(label))
+        for key, value in data:
+            hdr.write("#define {} \"{}\"\n".format(key, value))
+        hdr.write("#endif  /* {} */\n".format(label))
+
 
 def _use_git_details(ctx):
     _get_git_details(ctx)
 
+    # Include generated header(s)
+    ctx.env.append_value('CFLAGS', '-I{}'.format(out_include_dir))
+
+    # Inform user
     ctx.start_msg("Building app")
     ctx.end_msg(APPNAME, _warn_color(APPNAME, "UNKNOWN"))
     ctx.start_msg("Version")
-    ctx.end_msg(ctx.env.gitTag, _warn_color(ctx.env.gitTag, "UNKNOWN"))
+    ctx.end_msg(VERSION, _warn_color(VERSION, "UNKNOWN"))
     ctx.start_msg("git HEAD commit")
-    ctx.end_msg(ctx.env.gitCommit, _warn_color(ctx.env.gitCommit, "UNKNOWN"))
+    ctx.end_msg(COMMIT, _warn_color(COMMIT, "UNKNOWN"))
     ctx.start_msg("git branch")
-    ctx.end_msg(ctx.env.gitBranch, _warn_color(ctx.env.gitBranch, "UNKNOWN"))
+    ctx.end_msg(BRANCH, _warn_color(BRANCH, "UNKNOWN"))
 
-    ctx.env.append_value('CFLAGS', '-D APPNAME="{0}"'.format(APPNAME))
-    ctx.env.append_value('CFLAGS', '-D VERSION="{0}"'.format(ctx.env.gitTag))
-    ctx.env.append_value('CFLAGS', '-D BRANCH="{0}"'.format(ctx.env.gitBranch))
-    ctx.env.append_value('CFLAGS', '-D COMMIT="{0}"'.format(ctx.env.gitCommit))
 
-def _is_same_git_details(ctx, diffList):
-    oldTag = ctx.env.gitTag[:]
-    oldCommit = ctx.env.gitCommit[:]
-    oldBranch = ctx.env.gitBranch[:]
-
-    _get_git_details(ctx)
-
-    isSame = True
-
-    if ctx.env.gitTag != oldTag:
-        diffList.append("'{0}' -> '{1}'".format(oldTag, ctx.env.gitTag))
-        isSame = False
-    if ctx.env.gitCommit != oldCommit:
-        diffList.append("'{0}' -> '{1}'\n".format(oldCommit, ctx.env.gitCommit))
-        isSame = False
-    if ctx.env.gitBranch != oldBranch:
-        diffList.append("'{0}' -> '{1}'\n".format(oldBranch, ctx.env.gitBranch))
-        isSame = False
-
-    return isSame
 
 def _check_mac_osx_version(floor_version):
     '''
@@ -300,10 +374,6 @@ def configure(conf):
     # NOTE: All of the variables in conf.env are defined for use by
     # wscript files in subdirectories.
 
-    conf.env.gitTag = "UNKNOWN"
-    conf.env.gitCommit = "UNKNOWN"
-    conf.env.gitBranch = "UNKNOWN"
-
     # Read in options from a file.  The file is just a set of
     # commandline arguments in the same syntax.  May be spread across
     # multiple lines.
@@ -318,6 +388,7 @@ def configure(conf):
         fd.close()
 
     _use_git_details(conf)
+    _gen_version_header(conf)
 
     # Load C compiler support
     conf.load('compiler_c')
@@ -353,7 +424,7 @@ def configure(conf):
 
     _setup_openmp(conf)
 
-    _determine_sizeof_int(conf)
+    #_determine_sizeof_int(conf)
 
     if conf.check_cc(cflags='-std=gnu99'):
         conf.env.append_value('CFLAGS', '-std=gnu99')
@@ -401,17 +472,32 @@ Press any key to continue or Ctrl+c to abort...\033[0m"""
     conf.end_msg(' '.join(conf.env['LDFLAGS']) or None)
 
 
-def build(bld):
-    if bld.cmd == 'build':
-        diffList = []
-        if not _is_same_git_details(bld, diffList):
-            diffString = ''
-            for item in diffList:
-                diffString = diffString + item + '\n'
-            bld.fatal("ERROR: git details differ between current source \
-tree and build configuration. Please run 'configure' again to \
-update the build configuration.\n{0}".format(diffString))
+def dist(ctx):
+    ctx.algo = 'tar.gz'
 
+    # Manually include project files in the archive
+    ctx.files = ctx.path.ant_glob('**/*', excl=[
+        '.git*',
+        '.waf*',
+        '.lock-*',
+        'Makefile',
+        '__pycache__',
+        '**/__pycache__',
+        '.cache',
+        '**/.cache',
+        out,
+        'bin.*',
+        '*.tar.*',
+        '*.zip'])
+
+    # Update version information
+    _get_git_details(ctx)
+
+    # call 'waf dist' directly to generate an archive
+    Scripting.dist(ctx)
+
+
+def build(bld):
     bld(name='lib', always=True)
     bld(name='test', always=True)
 


### PR DESCRIPTION
Thoughts? @mromelfanger @mdlpstsci @BGannon2 

Generate a release archive...

```
$ ./waf dist
New archive created: hstcal-2.7.2-8-gfefa796.tar.gz (sha256='037f67052e2c0825d8ca4dc1ed5443836bdc74b00efd1d9fe3da131a443ccc49')
'dist' finished successfully (0.594s)
```

Now build hstcal using the release archive... Notice how it reports `Using DISTINFO file`

```
$ tar -xf hstcal-2.7.2-8-gfefa796.tar.gz -C /tmp
$ pushd /tmp/hstcal-2.7.2-8-gfefa796
$ ./waf configure --prefix=/tmp/hstcal
Setting top to                           : /tmp/hstcal-2.7.2-8-gfefa796 
Setting out to                           : /tmp/hstcal-2.7.2-8-gfefa796/build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33 
Using DISTINFO file
Building app                             : hstcal 
Version                                  : 2.7.2-8-gfefa796 
git HEAD commit                          : fefa7965a8458d0f46b4c5d2b63b54a79dd225f7 
git branch                               : bootstrap-release 
Checking for 'gcc' (C compiler)          : /usr/bin/gcc 
Checking for 'gfortran' (Fortran compiler) : /usr/bin/gfortran 
Compiling a simple fortran app             : yes 
Checking for 'gcc' (C compiler)            : /usr/bin/gcc 
Checking for program 'pkg-config'          : /usr/bin/pkg-config 
Checking for 'cfitsio'                     : yes 
Checking for OpenMP: -fopenmp              : yes 
Checking for compiler flags -std=gnu99     : yes 
Checking for compiler flags -O2            : yes 
Checking for compiler flags -Wall          : yes 
Checking for compiler flags -fstack-protector-all : yes 
C compiler flags (CFLAGS)                         : -I/tmp/hstcal-2.7.2-8-gfefa796/build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/include -std=gnu99 -O2 -Wall -fstack-protector-all 
Fortran compiler flags (FCFLAGS)                  : not found 
Linker flags (LDFLAGS)                            : not found 
'configure' finished successfully (0.313s)

$ ./waf build
# [...]
Waf: Leaving directory `/tmp/hstcal-2.7.2-8-gfefa796/build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33'
'build' finished successfully (6.374s)

$ ./waf install
Waf: Entering directory `/tmp/hstcal-2.7.2-8-gfefa796/build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33'
+ install /tmp/hstcal/bin/cs0.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs0/cs0.e)
+ install /tmp/hstcal/bin/cs1.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs1/cs1.e)
+ install /tmp/hstcal/bin/cs2.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs2/cs2.e)
+ install /tmp/hstcal/bin/cs4.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs4/cs4.e)
+ install /tmp/hstcal/bin/cs6.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs6/cs6.e)
+ install /tmp/hstcal/bin/cs7.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs7/cs7.e)
+ install /tmp/hstcal/bin/cs11.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs11/cs11.e)
+ install /tmp/hstcal/bin/cs12.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/stis/calstis/cs12/cs12.e)
+ install /tmp/hstcal/bin/calacs.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/calacs/calacs.e)
+ install /tmp/hstcal/bin/acsrej.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/acsrej/acsrej.e)
+ install /tmp/hstcal/bin/acssum.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/acssum/acssum.e)
+ install /tmp/hstcal/bin/acsccd.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/acsccd/acsccd.e)
+ install /tmp/hstcal/bin/acscte.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/acscte/acscte.e)
+ install /tmp/hstcal/bin/acscteforwardmodel.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/acscte/acscte.e)
+ install /tmp/hstcal/bin/acs2d.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/acs/calacs/acs2d/acs2d.e)
+ install /tmp/hstcal/bin/calwf3.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/calwf3/calwf3.e)
+ install /tmp/hstcal/bin/wf3ccd.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/wf3ccd/wf3ccd.e)
+ install /tmp/hstcal/bin/wf3rej.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/wf3rej/wf3rej.e)
+ install /tmp/hstcal/bin/wf3cte.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/wf3cte/wf3cte.e)
+ install /tmp/hstcal/bin/wf3ir.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/wf3ir/wf3ir.e)
+ install /tmp/hstcal/bin/wf32d.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/wf32d/wf32d.e)
+ install /tmp/hstcal/bin/wf3sum.e (from build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33/pkg/wfc3/calwf3/wf3sum/wf3sum.e)
Waf: Leaving directory `/tmp/hstcal-2.7.2-8-gfefa796/build.Linux-5.10.61-1-MANJARO-x86_64-with-glibc2.33'
'install' finished successfully (0.147s)
```

Installation went fine. Checking version data propagation...

```
$ for x in /tmp/hstcal/bin/*.e; do echo $x: ; $x --gitinfo; echo; done
/tmp/hstcal/bin/acs2d.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/acsccd.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/acscte.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

## NOTE: build issue? I didn't do it
/tmp/hstcal/bin/acscteforwardmodel.e:
bash: /tmp/hstcal/bin/acscteforwardmodel.e: Permission denied

## NOTE: --gitinfo not supported
/tmp/hstcal/bin/acsrej.e:
Syntax error: acsrej.e input output [-t] [-v]
                    [-shadcorr] [-crmask] [-readnoise_only] 
                    [-table <filename>] [-scale #]
                    [-init (med|min)] [-sky (none|mode)]
                    [-sigmas #] [-radius #] [-thresh #]
                    [-pdq #]

input             comma-delimited string (e.g., filename or filename1,filename2,filename3)
output            string
-t                print timestamps
-v                turn on verbose mode
-shadcorr         turn on shutter shading correction (intended for CCD images only)
-crmask           flag CR-rejected pixels in the input files
-readnoise_only   use read noise and not Poission noise to create ERR array (intended for BIAS images)
-table filename   cosmic ray rejection table to use for default parameter values
-scale #          multiplicative factor (in percent) applied to noise
-init med|min     scheme for computing initial guess image (median or minimum)
-sky none|mode    scheme for computing sky levels to be subtracted (none:0.0 or mode:most frequently occurring value)
-sigmas #[,#...]  cosmic ray rejection thresholds, no. of thresholds are the no. of iterations
-radius #         radius (in pixels) to propagate the cosmic ray
-thresh #         cosmic ray rejection propagation threshold
-pdq #            data quality flag used for cosmic ray rejection


/tmp/hstcal/bin/acssum.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/calacs.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/calwf3.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/cs0.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/cs11.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/cs12.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/cs1.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/cs2.e:
ERROR  Syntax error: cs2 input output

/tmp/hstcal/bin/cs4.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

## NOTE: --gitinfo not supported
/tmp/hstcal/bin/cs6.e:
Error processing --gitinfo.
         HSTIO error 114:  Filename --gitinfo EXTNAME  EXTVER 0 CFITSIO status 104
failed to find or open the following file: (ffopen)--gitinfo[0]
Error opening image array.
         Open failed.

/tmp/hstcal/bin/cs7.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/wf32d.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/wf3ccd.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/wf3cte.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

/tmp/hstcal/bin/wf3ir.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7

## NOTE: segfault is unrelated to this change
/tmp/hstcal/bin/wf3rej.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7
Segmentation fault (core dumped)

/tmp/hstcal/bin/wf3sum.e:
git tag: 2.7.2-8-gfefa796
git branch: bootstrap-release
HEAD @: fefa7965a8458d0f46b4c5d2b63b54a79dd225f7
```

Yay.