### PR TITLE
Fixed bug triggered ONLY when executing the condaforge on MacOS

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,3 +1,8 @@
+ 11-Jan-2022   CALACS 10.3.4 Fixed a bug which was triggered ONLY when executing the condaforge
+                             distribution on MacOS where failure was due to a missing return statement.
+                             Only call computeDarktime() once to compute the updated 
+                             DARKTIME primary keyword and function return is now void. Update
+                             the keyword in main to avoid passing extra data by reference.
  24-May-2021   CALACS 10.3.3 Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
                              keyword was updated in the CRJ/CRC headers to be the sum of
                              the individual input images as this keyword is used in ACS2D to

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,3 +1,10 @@
+### 11-Jan-2022 - MDD - Version 10.3.4   
+    Fixed a bug which was triggered ONLY when executing the condaforge
+    distribution on MacOS where failure was due to a missing return 
+    statement.  Only call computeDarktime() once to compute the updated
+    DARKTIME primary keyword and function return is now void. Update
+    the keyword in main to avoid passing extra data by reference.
+
 ### 24-May-2021 - MDD - Version 10.3.3
     Fixed a bug associated with the FLASHDUR computation.  The FLASHDUR
     keyword was updated in the CRJ/CRC headers to be the sum of

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,3 +1,10 @@
+Update for version 10.3.4 - 11-Jan-2022 (MDD)
+	pkg/acs/calacs/Dates
+	pkg/acs/calacs/History
+	pkg/acs/calacs/Updates
+	pkg/acs/calacs/acsccd/doccd.c
+	pkg/acs/calacs/include/acsversion.h
+
 Update for version 10.3.3 - 24-May-2021 (MDD)
 	pkg/acs/calacs/Dates
 	pkg/acs/calacs/History

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.3.3 (24-May-2021)"
-#define ACS_CAL_VER_NUM "10.3.3"
+#define ACS_CAL_VER "10.3.4 (11-Jan-2022)"
+#define ACS_CAL_VER_NUM "10.3.4"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
Fixed a bug which was triggered ONLY when executing the condaforge
distribution on MacOS where failure was due to a missing return statement.
Only call computeDarktime() once to compute the updated
DARKTIME primary keyword and function return is now void. Update
the keyword in main to avoid passing extra data by reference.