### PR TITLE
ACSREJ algorithm modified for ERR array

### DIFF
--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,9 +1,8 @@
- 11-Jan-2022   CALACS 10.3.4 Update to the cosmic ray rejection algorithm as to the way
+ 08-Feb-2022   CALACS 10.3.5 Update to the cosmic ray rejection algorithm as to the way
                              the output ERR extension is computed for the CRJ file. The 
                              output ERR is now propagated from the usable input ERR extensions
                              versus being computed by a model.
-
-                             Fixed a bug which was triggered ONLY when executing the condaforge
+ 11-Jan-2022   CALACS 10.3.4 Fixed a bug which was triggered ONLY when executing the condaforge
                              distribution on MacOS where failure was due to a missing return statement.
                              Only call computeDarktime() once to compute the updated 
                              DARKTIME primary keyword and function return is now void. Update

--- a/pkg/acs/calacs/Dates
+++ b/pkg/acs/calacs/Dates
@@ -1,4 +1,9 @@
- 11-Jan-2022   CALACS 10.3.4 Fixed a bug which was triggered ONLY when executing the condaforge
+ 11-Jan-2022   CALACS 10.3.4 Update to the cosmic ray rejection algorithm as to the way
+                             the output ERR extension is computed for the CRJ file. The 
+                             output ERR is now propagated from the usable input ERR extensions
+                             versus being computed by a model.
+
+                             Fixed a bug which was triggered ONLY when executing the condaforge
                              distribution on MacOS where failure was due to a missing return statement.
                              Only call computeDarktime() once to compute the updated 
                              DARKTIME primary keyword and function return is now void. Update

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,4 +1,9 @@
 ### 11-Jan-2022 - MDD - Version 10.3.4   
+    Update to the cosmic ray rejection algorithm as to the way
+    the output ERR extension is computed for the CRJ file. The 
+    output ERR is now propagated from the usable input ERR extensions
+    versus being computed by a model.
+
     Fixed a bug which was triggered ONLY when executing the condaforge
     distribution on MacOS where failure was due to a missing return 
     statement.  Only call computeDarktime() once to compute the updated

--- a/pkg/acs/calacs/History
+++ b/pkg/acs/calacs/History
@@ -1,9 +1,10 @@
-### 11-Jan-2022 - MDD - Version 10.3.4   
+### 08-Feb-2022 - MDD - Version 10.3.5   
     Update to the cosmic ray rejection algorithm as to the way
     the output ERR extension is computed for the CRJ file. The 
     output ERR is now propagated from the usable input ERR extensions
     versus being computed by a model.
 
+### 11-Jan-2022 - MDD - Version 10.3.4   
     Fixed a bug which was triggered ONLY when executing the condaforge
     distribution on MacOS where failure was due to a missing return 
     statement.  Only call computeDarktime() once to compute the updated

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -1,10 +1,17 @@
+Update for version 10.3.5 - 08-Feb-2022 (MDD)
+	pkg/acs/calacs/Dates
+	pkg/acs/calacs/History
+	pkg/acs/calacs/Updates
+	pkg/acs/calacs/include/acsversion.h
+    pkg/acs/calacs/acsrej/acsrej_do.c
+    pkg/acs/calacs/acsrej/acsrej_loop.c
+
 Update for version 10.3.4 - 11-Jan-2022 (MDD)
 	pkg/acs/calacs/Dates
 	pkg/acs/calacs/History
 	pkg/acs/calacs/Updates
 	pkg/acs/calacs/acsccd/doccd.c
 	pkg/acs/calacs/include/acsversion.h
-    pkg/acs/calacs/acsrej/acsrej_loop.c
 
 Update for version 10.3.3 - 24-May-2021 (MDD)
 	pkg/acs/calacs/Dates

--- a/pkg/acs/calacs/Updates
+++ b/pkg/acs/calacs/Updates
@@ -4,6 +4,7 @@ Update for version 10.3.4 - 11-Jan-2022 (MDD)
 	pkg/acs/calacs/Updates
 	pkg/acs/calacs/acsccd/doccd.c
 	pkg/acs/calacs/include/acsversion.h
+    pkg/acs/calacs/acsrej/acsrej_loop.c
 
 Update for version 10.3.3 - 24-May-2021 (MDD)
 	pkg/acs/calacs/Dates

--- a/pkg/acs/calacs/acsrej/acsrej_do.c
+++ b/pkg/acs/calacs/acsrej/acsrej_do.c
@@ -360,8 +360,6 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
                     /* SCI: Convert e/s to electrons, add sky back in */
                     PPix(&sg.sci.data, i, j) = (PPix(&sg.sci.data, i, j) *
                                                 texpt) + skysum;
-                    /* ERR: Convert e/s to electrons */
-                    PPix(&sg.err.data, i, j) *= texpt;
                 }
             }
         } else {

--- a/pkg/acs/calacs/acsrej/acsrej_do.c
+++ b/pkg/acs/calacs/acsrej/acsrej_do.c
@@ -362,6 +362,11 @@ int acsrej_do (IRAFPointer tpin, char *outfile, char *mtype, clpar *par,
                                                 texpt) + skysum;
                 }
             }
+            /* Set at least one pixel to a different value to insure
+               that an image array actually gets produced.  This was done
+               so the result of a test where the input ERR are all zero will
+               produce an actual output ERR array. */
+            PPix(&sg.err.data, 0, 0) = -1.;
         } else {
             /* DQ values here do not make sense, but I guess it is not
                a real issue because the output is dummy anyway. */

--- a/pkg/acs/calacs/include/acsversion.h
+++ b/pkg/acs/calacs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.3.4 (11-Jan-2022)"
-#define ACS_CAL_VER_NUM "10.3.4"
+#define ACS_CAL_VER "10.3.5 (08-Feb-2022)"
+#define ACS_CAL_VER_NUM "10.3.5"
 
 /* name and version number of the CTE correction algorithm */
 #define ACS_GEN1_CTE_NAME "PixelCTE 2012"


### PR DESCRIPTION
Update to the cosmic ray rejection algorithm as to the way the output ERR extension is computed for the CRJ/CRC file. The output ERR is now propagated from the usable input ERR extensions versus being computed by a model.

Resolves #371.