### PR TITLE
Fix dist tag resolution

### DIFF
--- a/wscript
+++ b/wscript
@@ -218,10 +218,10 @@ def _get_git_details(ctx):
 
     # Report a shadowed release tag if one exists, otherwise fallback to
     # the generic description method. The generic method does NOT
-    # account for shadows. This might retun a release candidate tag if the point
+    # account for shadows. This might return a release candidate tag if the point
     # release tag shares the same commit hash. This is purely aesthetic.
     #
-    # To avoid this scenario one must commit a change to teh repository prior to
+    # To avoid this scenario one must commit a change to the repository prior to
     # tagging a final point release.
     tmp = call(cmd_describe + ' --contains') or \
         call(cmd_describe)

--- a/wscript
+++ b/wscript
@@ -212,15 +212,27 @@ def _get_git_details(ctx):
         _gen_version_header(ctx)
         return
 
-    tmp = call('git describe --contains --dirty --abbrev=7')
+    cmd_describe = 'git describe --dirty --abbrev=7'
+    cmd_hash = 'git rev-parse HEAD'
+    cmd_branch = 'git rev-parse --abbrev-ref HEAD'
+
+    # Report a shadowed release tag if one exists, otherwise fallback to
+    # the generic description method. The generic method does NOT
+    # account for shadows. This might retun a release candidate tag if the point
+    # release tag shares the same commit hash. This is purely aesthetic.
+    #
+    # To avoid this scenario one must commit a change to teh repository prior to
+    # tagging a final point release.
+    tmp = call(cmd_describe + ' --contains') or \
+        call(cmd_describe)
     if tmp:
         VERSION = tmp
 
-    tmp = call('git rev-parse HEAD')
+    tmp = call(cmd_hash)
     if tmp:
         COMMIT = tmp
 
-    tmp = call('git rev-parse --abbrev-ref HEAD')
+    tmp = call(cmd_branch)
     if tmp:
         BRANCH = tmp
 

--- a/wscript
+++ b/wscript
@@ -212,7 +212,7 @@ def _get_git_details(ctx):
         _gen_version_header(ctx)
         return
 
-    tmp = call('git describe --dirty --abbrev=7')
+    tmp = call('git describe --contains --dirty --abbrev=7')
     if tmp:
         VERSION = tmp
 


### PR DESCRIPTION
This change covers an edge case for when `./waf dist` is executed from a branch outside of `master` and no tag is associated with the current commit it returns `UNKNOWN`. All this does is add fallback behavior to ensure `VERSION` gets populated with the closest parent tag rather than `UNKNOWN`.
