### PR TITLE
wscript: Fix _check_mac_osx_version() on modern MacOS systems

### DIFF
--- a/wscript
+++ b/wscript
@@ -317,7 +317,13 @@ def _check_mac_osx_version(floor_version):
         return None
 
     # Extract the integer values between the '.'s
-    osx_version_major, osx_version_minor, osx_version_patch = tuple(int(x) for x in s.strip().split('.'))
+    osx_version_data = tuple(int(x) for x in s.strip().split('.'))
+    osx_version_major = osx_version_data[0]
+    osx_version_minor = osx_version_data[1]
+    osx_version_patch = 0
+
+    if len(osx_version_data) > 2:
+        osx_version_patch = osx_version_data[2]
 
     # Convert major/minor/patch values into a single 24-bit integer
     osx_version = (osx_version_major & 0xff) << 16 | (osx_version_minor & 0xff) << 8 | (osx_version_patch & 0xff )


### PR DESCRIPTION
If there's no PATCH version available then handle it.

Close #570