### PR TITLE
Set certain WFC3/UVIS tests to XFAIL

### DIFF
--- a/tests/wfc3/test_uvis_01asn.py
+++ b/tests/wfc3/test_uvis_01asn.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS01ASN(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_06single.py
+++ b/tests/wfc3/test_uvis_06single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS06Single(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_07single.py
+++ b/tests/wfc3/test_uvis_07single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS07Single(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_10single.py
+++ b/tests/wfc3/test_uvis_10single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS10Single(BaseWFC3):
     """
     Test pos UVIS2 30 Dor

--- a/tests/wfc3/test_uvis_12single.py
+++ b/tests/wfc3/test_uvis_12single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS12Single(BaseWFC3):
     """
     Test pos UVIS2 BIAS data

--- a/tests/wfc3/test_uvis_13single.py
+++ b/tests/wfc3/test_uvis_13single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS13Single(BaseWFC3):
     """
     Test pos UVIS2 DARK images

--- a/tests/wfc3/test_uvis_16single.py
+++ b/tests/wfc3/test_uvis_16single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS16Single(BaseWFC3):
     """
     Test pos UVIS2 Jupiter impact site data

--- a/tests/wfc3/test_uvis_26single.py
+++ b/tests/wfc3/test_uvis_26single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS26Single(BaseWFC3):
     """
     Test pos UVIS2 NGC104 data

--- a/tests/wfc3/test_uvis_28single.py
+++ b/tests/wfc3/test_uvis_28single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS28Single(BaseWFC3):
     """
     Test pos UVIS2 Omega Cen data

--- a/tests/wfc3/test_uvis_29single.py
+++ b/tests/wfc3/test_uvis_29single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS29Single(BaseWFC3):
     """
     Test pos UVIS2 PN-G351.3+07.6 data

--- a/tests/wfc3/test_uvis_30single.py
+++ b/tests/wfc3/test_uvis_30single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS30Single(BaseWFC3):
     """
     Test pos UVIS2 Tungsten data

--- a/tests/wfc3/test_uvis_33single.py
+++ b/tests/wfc3/test_uvis_33single.py
@@ -4,6 +4,7 @@ import pytest
 from ..helpers import BaseWFC3
 
 
+@pytest.mark.xfail
 class TestUVIS33Single(BaseWFC3):
     """
     Test pos UVIS2 subarray data with on CTE correction


### PR DESCRIPTION
Set certain WFC3/UVIS tests to XFAIL as the truth files on Artifactory have been updated for the new software, but this software is NOT being delivered as part of the build (HSTDP-2023.1.0) to operations.

The issue is there are many packages which are part of the "operations build".  In order for the nightly regression tests to pass, when new software is checked in, the corresponding Truth files on Artifactory must be updated.  However, if the software is not to be included in the next build to be delivered, the PyTests for this package will fail as there is only one source of Input and Truth files.  

This means there must be manual gating of the packages which contribute to the build which is not realistic.