### PR TITLE
WFC3: Removed skip from tests which will use inputs with the new SATUFILE

### DIFF
--- a/tests/wfc3/test_uvis_01asn.py
+++ b/tests/wfc3/test_uvis_01asn.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS01ASN(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_06single.py
+++ b/tests/wfc3/test_uvis_06single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS06Single(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_07single.py
+++ b/tests/wfc3/test_uvis_07single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS07Single(BaseWFC3):
     """
     Tests for WFC3/UVIS.

--- a/tests/wfc3/test_uvis_10single.py
+++ b/tests/wfc3/test_uvis_10single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS10Single(BaseWFC3):
     """
     Test pos UVIS2 30 Dor

--- a/tests/wfc3/test_uvis_12single.py
+++ b/tests/wfc3/test_uvis_12single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS12Single(BaseWFC3):
     """
     Test pos UVIS2 BIAS data

--- a/tests/wfc3/test_uvis_13single.py
+++ b/tests/wfc3/test_uvis_13single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS13Single(BaseWFC3):
     """
     Test pos UVIS2 DARK images

--- a/tests/wfc3/test_uvis_16single.py
+++ b/tests/wfc3/test_uvis_16single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS16Single(BaseWFC3):
     """
     Test pos UVIS2 Jupiter impact site data

--- a/tests/wfc3/test_uvis_26single.py
+++ b/tests/wfc3/test_uvis_26single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS26Single(BaseWFC3):
     """
     Test pos UVIS2 NGC104 data

--- a/tests/wfc3/test_uvis_28single.py
+++ b/tests/wfc3/test_uvis_28single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS28Single(BaseWFC3):
     """
     Test pos UVIS2 Omega Cen data

--- a/tests/wfc3/test_uvis_29single.py
+++ b/tests/wfc3/test_uvis_29single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS29Single(BaseWFC3):
     """
     Test pos UVIS2 PN-G351.3+07.6 data

--- a/tests/wfc3/test_uvis_30single.py
+++ b/tests/wfc3/test_uvis_30single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS30Single(BaseWFC3):
     """
     Test pos UVIS2 Tungsten data

--- a/tests/wfc3/test_uvis_33single.py
+++ b/tests/wfc3/test_uvis_33single.py
@@ -4,7 +4,6 @@ import pytest
 from ..helpers import BaseWFC3
 
 
-@pytest.mark.xfail
 class TestUVIS33Single(BaseWFC3):
     """
     Test pos UVIS2 subarray data with on CTE correction


### PR DESCRIPTION
Tests which use input and truth that contain the new SATUFILE keyword had been set to skip.  These files can now be executed.