### PR TITLE
HLA-1136: Flag full-well saturated pixels in the overscan regions in DQICORR

### DIFF
--- a/pkg/wfc3/calwf3/Dates
+++ b/pkg/wfc3/calwf3/Dates
@@ -1,12 +1,20 @@
+18-Oct-2023 - MDD - Version 3.7.1
+    - Updates to reconcile the old and new algorithms for flagging full-well saturated pixels.  
+      The new algorithm uses a saturation image which is applied after BLECORR/BIASCORR, and
+      the image is already trimmed of the overscan regions. The old algorithm used a single
+      scalar value applied to the ENTIRE readout (science data and overscan).  Added flagging 
+      in DQICORR of the overscan regions when the saturation image of the new algorithm is to 
+      be applied later in the processing.
+
 08-June-2023 - MDD - Version 3.7.0
-    -  Implementation to use an image to detect and flag full-well saturation versus a simple scalar.
-       The new routine, dofwsat.c, is similar to what has been done for calacs. The WFC3 implementation
-       is more complicated in that there are serial virtual overscan columns, as well as binned images,
-       to accommodate.  The detection/flagging occurs after blev and bias corrections while the output is
-       still in counts.  If the SATUFILE keyword is missing from the FITS header, or the keyword does
-       not have a valid filename as a value, the code will revert to using the original method of flagging
-       full-well saturation.  The flagging will be done in doDQI and use a single value as the saturation 
-       threshold.
+    - Implementation to use an image to detect and flag full-well saturation versus a simple scalar.
+      The new routine, dofwsat.c, is similar to what has been done for calacs. The WFC3 implementation
+      is more complicated in that there are serial virtual overscan columns, as well as binned images,
+      to accommodate.  The detection/flagging occurs after blev and bias corrections while the output is
+      still in counts.  If the SATUFILE keyword is missing from the FITS header, or the keyword does
+      not have a valid filename as a value, the code will revert to using the original method of flagging
+      full-well saturation.  The flagging will be done in doDQI and use a single value as the saturation 
+      threshold.
 
 27-May-2021 - MDD - Version 3.6.2
     - Bug fix to address calwf3.e crashing (Abort trap: 6) when taking an existing *_ima.fits (IR) file

--- a/pkg/wfc3/calwf3/History
+++ b/pkg/wfc3/calwf3/History
@@ -1,12 +1,20 @@
+### 18-Oct-2023 - MDD - Version 3.7.1
+    - Updates to reconcile the old and new algorithms for flagging full-well saturated pixels.  
+      The new algorithm uses a saturation image which is applied after BLECORR/BIASCORR, and
+      the image is already trimmed of the overscan regions. The old algorithm used a single
+      scalar value applied to the ENTIRE readout (science data and overscan).  Added flagging 
+      in DQICORR of the overscan regions when the saturation image of the new algorithm is to 
+      be applied later in the processing.
+
 ### 08-Jun-2023 - MDD - Version 3.7.0
-    -  Implementation to use an image to detect and flag full-well saturation versus a simple scalar.
-       The new routine, dofwsat.c, is similar to what has been done for calacs. The WFC3 implementation
-       is more complicated in that there are serial virtual overscan columns, as well as binned images,
-       to accommodate.  The detection/flagging occurs after blev and bias corrections while the output is
-       still in counts.  If the SATUFILE keyword is missing from the FITS header, or the keyword does
-       not have a valid filename as a value, the code will revert to using the original method of flagging
-       full-well saturation.  The flagging will be done in doDQI and use a single value as the saturation 
-       threshold.
+    - Implementation to use an image to detect and flag full-well saturation versus a simple scalar.
+      The new routine, dofwsat.c, is similar to what has been done for calacs. The WFC3 implementation
+      is more complicated in that there are serial virtual overscan columns, as well as binned images,
+      to accommodate.  The detection/flagging occurs after blev and bias corrections while the output is
+      still in counts.  If the SATUFILE keyword is missing from the FITS header, or the keyword does
+      not have a valid filename as a value, the code will revert to using the original method of flagging
+      full-well saturation.  The flagging will be done in doDQI and use a single value as the saturation 
+      threshold.
 
 ### 27-May-2021 - MDD - Version 3.6.2
     - Bug fix to address calwf3.e crashing (Abort trap: 6) when taking an existing *_ima.fits (IR) file

--- a/pkg/wfc3/calwf3/Updates
+++ b/pkg/wfc3/calwf3/Updates
@@ -1,12 +1,20 @@
+Updates for Version 3.7.1 18-Oct-2023 - MDD
+    - Updates to reconcile the old and new algorithms for flagging full-well saturated pixels.  
+      The new algorithm uses a saturation image which is applied after BLECORR/BIASCORR, and
+      the image is already trimmed of the overscan regions. The old algorithm used a single
+      scalar value applied to the ENTIRE readout (science data and overscan).  Added flagging 
+      in DQICORR of the overscan regions when the saturation image of the new algorithm is to 
+      be applied later in the processing.
+
 Updates for Version 3.7.0 08-Jun-2023 - MDD
-    -  Implementation to use an image to detect and flag full-well saturation versus a simple scalar.
-       The new routine, dofwsat.c, is similar to what has been done for calacs. The WFC3 implementation
-       is more complicated in that there are serial virtual overscan columns, as well as binned images,
-       to accommodate.  The detection/flagging occurs after blev and bias corrections while the output is
-       still in counts.  If the SATUFILE keyword is missing from the FITS header, or the keyword does
-       not have a valid filename as a value, the code will revert to using the original method of flagging
-       full-well saturation.  The flagging will be done in doDQI and use a single value as the saturation 
-       threshold.
+    - Implementation to use an image to detect and flag full-well saturation versus a simple scalar.
+      The new routine, dofwsat.c, is similar to what has been done for calacs. The WFC3 implementation
+      is more complicated in that there are serial virtual overscan columns, as well as binned images,
+      to accommodate.  The detection/flagging occurs after blev and bias corrections while the output is
+      still in counts.  If the SATUFILE keyword is missing from the FITS header, or the keyword does
+      not have a valid filename as a value, the code will revert to using the original method of flagging
+      full-well saturation.  The flagging will be done in doDQI and use a single value as the saturation 
+      threshold.
 
 Updates for Version 3.6.2 27-May-2021 - MDD
     - Bug fix to address calwf3.e crashing (Abort trap: 6) when taking an existing *_ima.fits (IR) file

--- a/pkg/wfc3/calwf3/include/wf3version.h
+++ b/pkg/wfc3/calwf3/include/wf3version.h
@@ -4,7 +4,7 @@
 /* This string is written to the output primary header as CAL_VER. */
 
 
-# define WF3_CAL_VER "3.7.0 (Jun-08-2023)"
-# define WF3_CAL_VER_NUM "3.7.0"
+# define WF3_CAL_VER "3.7.1 (Oct-18-2023)"
+# define WF3_CAL_VER_NUM "3.7.1"
 
 #endif /* INCL_WF3VERSION_H */

--- a/pkg/wfc3/calwf3/lib/computelimits.c
+++ b/pkg/wfc3/calwf3/lib/computelimits.c
@@ -55,8 +55,6 @@ ComputeLimits(WF3Info *wf3, int xdim, int ydim, int begx[2], int begy[2], int en
     sprintf(MsgText,"Amp: %s chip: %d ccdamp: %s ", wf3->ccdamp, wf3->chip, ccdamp);
     trlmessage(MsgText);
 
-    /* Set up the 2 AMPS used per line */
-
     /* How many amps are used for this chip */
     numamps = strlen(ccdamp);
     sprintf(MsgText,"Number of amps %d", numamps);
@@ -81,7 +79,7 @@ ComputeLimits(WF3Info *wf3, int xdim, int ydim, int begx[2], int begy[2], int en
                     ydim - trimy2;
 
         /* Make sure that endx and endy do not extend beyond the bounds of
-        ** the image... HAB 7 May 2001 (same as calacs change). */
+        ** the image */
         if (endx[amp] > xdim) endx[amp] = xdim;
         if (endy[amp] > ydim) endy[amp] = ydim;
     }

--- a/pkg/wfc3/calwf3/lib/computelimits.c
+++ b/pkg/wfc3/calwf3/lib/computelimits.c
@@ -1,0 +1,90 @@
+# include <stdio.h>
+# include <string.h>
+
+# include "hstcal.h"
+# include "hstio.h"
+# include "wf3.h"
+# include "wf3dq.h"
+# include "wf3info.h"
+# include "hstcalerr.h"
+
+/*
+  Michele De La Pena, 2023 October 16
+
+*/
+
+/* Because the pixels representing the serial virtual overscan are present
+   in the saturation image, it is necessary to skip over these pixels when
+   determining the flagging for full-well saturation.
+
+   This routine is based upon code in doblev.c.
+*/
+void
+ComputeLimits(WF3Info *wf3, int xdim, int ydim, int begx[2], int begy[2], int endx[2], int endy[2]) {
+    int amp;			/* Counter for amps used */
+    int numamps;		/* Number of AMPS used to readout chip */
+    char *ccdamp;		/* Amps which are used for this chip */
+    char *amploc;
+    int trimx1, trimx2;	/* width to trim off ends of each line */
+    int trimx3, trimx4;	/* width to trim off middle of each line */
+    int trimy1, trimy2;	/* amount to trim off ends of each column */
+    int bias_loc;
+    int bias_ampx, bias_ampy;
+    int bias_orderx[4] = {0,1,0,1};
+    int bias_ordery[4] = {0,0,1,1};
+
+    void parseWFCamps (char *, int, char *);
+
+    /* Copy out overscan size information for ease of reference in this function */
+    trimx1 = wf3->trimx[0];	/* Left serial physical */
+    trimx2 = wf3->trimx[1];	/* Right serial physical */
+    trimx3 = wf3->trimx[2]; /* Left serial virtual */
+    trimx4 = wf3->trimx[3]; /* Right serial virtual */
+    trimy1 = wf3->trimy[0]; /* Bottom (Chip 1) parallel virtual */
+    trimy2 = wf3->trimy[1]; /* Top (Chip 2) parallel virtual */
+
+    /* Establish which amps from ccdamp string are appropriate
+    ** for this chip */
+    ccdamp = (char *) calloc (NAMPS+1, sizeof(char));
+    ccdamp[0] = '\0';
+
+    /* Set up the 2 AMPS used per line */
+    if (wf3->detector == CCD_DETECTOR) {
+        parseWFCamps (wf3->ccdamp, wf3->chip, ccdamp);
+    }
+    sprintf(MsgText,"Amp: %s chip: %d ccdamp: %s ", wf3->ccdamp, wf3->chip, ccdamp);
+    trlmessage(MsgText);
+
+    /* Set up the 2 AMPS used per line */
+
+    /* How many amps are used for this chip */
+    numamps = strlen(ccdamp);
+    sprintf(MsgText,"Number of amps %d", numamps);
+    trlmessage(MsgText);
+
+    for (amp = 0; amp < numamps; amp++) {
+        bias_loc = 0;
+
+        /* determine which section goes with the amp */
+        /* bias_amp = 0 for BIASSECTA, = 1 for BIASSECTB */
+        amploc = strchr (AMPSORDER, ccdamp[amp]);
+        bias_loc = *amploc - *ccdamp;
+        bias_ampx = bias_orderx[bias_loc];
+        bias_ampy = bias_ordery[bias_loc];
+
+        /* Compute range of pixels affected by each amp */
+        begx[amp] = trimx1 + (wf3->ampx + trimx3 + trimx4) * bias_ampx;
+        endx[amp] = (bias_ampx == 0 && wf3->ampx != 0) ? wf3->ampx + trimx1 :
+                    xdim - trimx2;
+        begy[amp] = trimy1 + wf3->ampy* bias_ampy;
+        endy[amp] = (bias_ampy == 0 && wf3->ampy != 0) ? wf3->ampy +trimy1 :
+                    ydim - trimy2;
+
+        /* Make sure that endx and endy do not extend beyond the bounds of
+        ** the image... HAB 7 May 2001 (same as calacs change). */
+        if (endx[amp] > xdim) endx[amp] = xdim;
+        if (endy[amp] > ydim) endy[amp] = ydim;
+    }
+
+    free(ccdamp);
+}

--- a/pkg/wfc3/calwf3/lib/dodqi.c
+++ b/pkg/wfc3/calwf3/lib/dodqi.c
@@ -21,32 +21,32 @@
 # define MIN(a,b) (a < b ? a : b)
 
 typedef struct {
-	IRAFPointer tp;			/* pointer to table descriptor */
-	IRAFPointer cp_xstart, cp_ystart; /* starting pixel for bad values */
-	IRAFPointer cp_length;		/* this many bad values */
-	IRAFPointer cp_axis;		/* repeat along X or Y axis (1 or 2) */
-	IRAFPointer cp_flag;		/* this is the data quality value */
-	IRAFPointer cp_amp;		/* selection columns */
-	IRAFPointer cp_ccdchip;
-	IRAFPointer cp_ccdgain;
-	int axlen1, axlen2;		/* DQ array size specified in header */
-	int nrows;			/* number of rows in table */
+    IRAFPointer tp;			/* pointer to table descriptor */
+    IRAFPointer cp_xstart, cp_ystart; /* starting pixel for bad values */
+    IRAFPointer cp_length;		/* this many bad values */
+    IRAFPointer cp_axis;		/* repeat along X or Y axis (1 or 2) */
+    IRAFPointer cp_flag;		/* this is the data quality value */
+    IRAFPointer cp_amp;		/* selection columns */
+    IRAFPointer cp_ccdchip;
+    IRAFPointer cp_ccdgain;
+    int axlen1, axlen2;		/* DQ array size specified in header */
+    int nrows;			/* number of rows in table */
 } TblInfo;
 
 typedef struct {
-	/* values read from a table row */
-	int xstart, ystart;
-	int length;
-	int axis;
-	short flag;
-	/* values used for selecting row to be used */
-	char ccdamp[SZ_CBUF+1];
-	float ccdgain;
-	int ccdchip;
+    /* values read from a table row */
+    int xstart, ystart;
+    int length;
+    int axis;
+    short flag;
+    /* values used for selecting row to be used */
+    char ccdamp[SZ_CBUF+1];
+    float ccdgain;
+    int ccdchip;
 } TblRow;
 
 static void FirstLast (double *, double *, int *, int *, int *, int *,
-		       int *, int *);
+                       int *, int *);
 
 /* This routine ORs the data quality array in the input SingleGroup x
    with the pixels flagged in the data quality initialization table.
@@ -86,7 +86,7 @@ static void FirstLast (double *, double *, int *, int *, int *, int *,
 	ri_m[1] = LTM2_2
 	ri_v[0] = LTV1 + (LTM1_1 - 1)
 	ri_v[1] = LTV2 + (LTM2_2 - 1)
-  
+
    Warren Hack, 1998 June 2:
     Revised for ACS data... Based on original CALSTIS code by Phil Hodge.
 
@@ -109,7 +109,7 @@ static void FirstLast (double *, double *, int *, int *, int *, int *,
     saturated DQ flag (following CALACS change).
 
    H.Bushouse, 2006 July 17:
-    Added new ToWF3RawCoords routine to adjust BPIXTAB pixel coords for 
+    Added new ToWF3RawCoords routine to adjust BPIXTAB pixel coords for
     presence of serial virtual overscan in WFC3 raw images. Also fixed
     loop limits in assigning scratch image flags to binned science image
     flags.
@@ -132,295 +132,433 @@ static void FirstLast (double *, double *, int *, int *, int *, int *,
     Resurrected the ability to flag full-well saturated pixels based upon
     a science pixel value being greater than a defined scalar value.  This
     was done at the request of the WFC3 team so that a user can have their
-    processed data flagged even if no saturation image is present. 
+    processed data flagged even if no saturation image is present.
+
+   M. De La Pena, 2023 October
+    When a saturation image is used to flag full-well saturation after
+    the BLEVCORR/BIASCORR, the image is already trimmed.  In order to
+    force the science data values to be closer to what they were when only
+    a scalar threshold was used and the ENTIRE readout (science data and
+    overscan) was flagged, added flagging here of only the overscan regions
+    when a saturation image is to be used later in the processing.
 
 */
 
-int doDQI (WF3Info *wf3, SingleGroup *x) {
+int doDQI (WF3Info *wf3, SingleGroup *x, int overscan) {
 
-/* arguments:
-WF3Info *wf3    i: calibration switches, etc
-SingleGroup *x    io: image to be calibrated; DQ array written to in-place
-*/
+    /* arguments:
+    WF3Info *wf3    i: calibration switches, etc
+    SingleGroup *x    io: image to be calibrated; DQ array written to in-place
+    */
 
-	extern int status;
+    extern int status;
 
-	TblInfo tabinfo;	/* pointer to table descriptor, etc */
-	TblRow tabrow;		/* values read from a table row */
+    TblInfo tabinfo;	/* pointer to table descriptor, etc */
+    TblRow tabrow;		/* values read from a table row */
 
-	DQHdrData ydq;		/* scratch space */
+    DQHdrData ydq;		/* scratch space */
 
-	/* mappings from one coordinate system to another */
-	double ri_m[2], ri_v[2];	/* reference to image */
-	double rs_m[2], rs_v[2];	/* reference to scratch */
-	double si_m[2], si_v[2];	/* scratch to image */
+    /* mappings from one coordinate system to another */
+    double ri_m[2], ri_v[2];	/* reference to image */
+    double rs_m[2], rs_v[2];	/* reference to scratch */
+    double si_m[2], si_v[2];	/* scratch to image */
 
-	/* for copying from scratch array (only copy overlap region) */
-	int first[2], last[2];	/* corners of overlap region in image coords */
-	int sfirst[2];		/* lower left corner of overlap in scratch */
-	int rbin[2];		/* bin size of image relative to ref bin size */
+    int xbeg[2], ybeg[2];		/* beginning limits of science data */
+    int xend[2], yend[2];		/* ending limits of science data */
 
-	int snpix[2];		/* size of scratch array */
-	int npix[2];		/* size of current image */
+    int xoscan_beg1 = 0;		/* Limits of Leading serial physical overscan */
+    int xoscan_end1 = 0;		/* Limits of Leading serial physical overscan */
+    int xoscan_beg2 = 0;		/* Limits of Serial virtual overscan */
+    int xoscan_end2 = 0;		/* Limits of Serial virtual overscan */
+    int xoscan_beg3 = 0;		/* Limits of Trailing serial physical overscan */
+    int xoscan_end3 = 0;		/* Limits of Trailing serial physical overscan */
+    int xoscan_beg = 0;			/* Limits of of physical serial physical overscan for subarray */
+    int xoscan_end = 0;			/* Limits of of physical serial physical overscan for subarray */
+    int yoscan_beg1 = 0;		/* Beginning limit of physical virtual overscan rows */
+    int yoscan_end1 = 0;		/* Ending limit of physical virtual overscan rows */
+    int ydata_beg = 0;			/* Beginning limit of full column */
+    int ydata_end = 0;			/* Ending limit of full column */
 
-	int in_place;		/* true if same bin size */
-	int i, j, i0, j0;	/* indexes for scratch array ydq */
-	int m, n;		/* indexes for data quality array in x */
-	short sum_dq;		/* for binning data quality array */
-	float sat;			/* saturation threshold */
+    /* for copying from scratch array (only copy overlap region) */
+    int first[2], last[2];	/* corners of overlap region in image coords */
+    int sfirst[2];		/* lower left corner of overlap in scratch */
+    int rbin[2];		/* bin size of image relative to ref bin size */
 
-	int row;		/* loop index for row number */
-	int dimx, dimy;
-	int nrows;		/* number of rows applied to DQ array */
-	int sameamp, samegain, samechip;
+    int snpix[2];		/* size of scratch array */
+    int npix[2];		/* size of current image */
 
-	int GetLT0 (Hdr *, double *, double *);
-	int SameInt (int, int);
-	int SameFlt (float, float);
-	int SameString (char *, char *);
+    int in_place;		/* true if same bin size */
+    int i, j, i0, j0;	/* indexes for scratch array ydq */
+    int m, n;		/* indexes for data quality array in x */
+    short sum_dq;		/* for binning data quality array */
+    float sat;			/* saturation threshold */
 
-	int OpenBpixTab (char *, TblInfo *);
-	int ReadBpixTab (TblInfo *, int, TblRow *);
-	int CloseBpixTab (TblInfo *);
+    int row;		/* loop index for row number */
+    int dimx, dimy;
+    int nrows;		/* number of rows applied to DQ array */
+    int sameamp, samegain, samechip;
 
-	void DQINormal (DQHdrData *, double *, TblRow *);
-	void ToWF3RawCoords (WF3Info *, double *, TblRow *);
+    int GetLT0 (Hdr *, double *, double *);
+    int SameInt (int, int);
+    int SameFlt (float, float);
+    int SameString (char *, char *);
 
-	/* We could still flag saturation even if the bpixtab was dummy. */
-	if (wf3->dqicorr != PERFORM && wf3->dqicorr != DUMMY)
-	    return (status);
+    int OpenBpixTab (char *, TblInfo *);
+    int ReadBpixTab (TblInfo *, int, TblRow *);
+    int CloseBpixTab (TblInfo *);
 
-	/* Issue a message so it is clear that saturation flagging is 
-		being done here in DODQI using scalar *IF* wf3->scalar_satflag is True.
-	*/
-	if (wf3->scalar_satflag == True) {
-		sprintf (MsgText, "Full-well saturation flagging being applied during doDQI using a single threshold value.");
-		trlmessage (MsgText);
-	}
+    void DQINormal (DQHdrData *, double *, TblRow *);
+    void ToWF3RawCoords (WF3Info *, double *, TblRow *);
+    void ComputeLimits(WF3Info *, int, int, int *, int *, int *, int *);
 
-	/* For the CCD, check for and flag saturation. */
-	sat = wf3->saturate;
-	if (wf3->detector != IR_DETECTOR) {
-            dimx = x->sci.data.nx;
-            dimy = x->sci.data.ny;
+    /* Get the dimensions of the data image */
+    dimx = x->sci.data.nx;
+    dimy = x->sci.data.ny;
 
-	    for (j = 0;  j < dimy;  j++) {
-			for (i = 0;  i < dimx;  i++) {
-				/* Flag a-to-d saturated pixels with 2048 dq bit */
-				if (Pix (x->sci.data, i, j) > ATOD_SATURATE) {
-					sum_dq = DQPix (x->dq.data, i, j) | ATODSAT;
-					DQSetPix (x->dq.data, i, j, sum_dq); /* atod sat */
-				}
+    /* Initialize limits which indicate the regions of science data */
+    {   unsigned int i;
+        for (i = 0; i < 2; i++) {
+            xbeg[i] = -1;
+            xend[i] = -1;
+            ybeg[i] = -1;
+            yend[i] = -1;
+        }
+    }
 
-				if (wf3->scalar_satflag == True) {
-					/* Flag full-well or a-to-d saturated pixels with 256 bit */
-					if (Pix (x->sci.data, i, j) > sat || Pix (x->sci.data, i, j) > ATOD_SATURATE) {
-						sum_dq = DQPix (x->dq.data, i, j) | SATPIXEL;
-						DQSetPix (x->dq.data, i, j, sum_dq);	/* saturated */
-					}
-				}
-			}
-	    }
-	}
+    /* We could still flag saturation even if the bpixtab was dummy. */
+    if (wf3->dqicorr != PERFORM && wf3->dqicorr != DUMMY)
+        return (status);
 
-	/* Get the linear transformations. */
-	if (GetLT0 (&x->sci.hdr, ri_m, ri_v))		/* zero indexed LTV */
-	    return (status);
+    /*
+       This is only the a-to-d saturation flagging which should be done in all cases.
+    */
+    if (wf3->detector != IR_DETECTOR) {
+        for (j = 0;  j < dimy;  j++) {
+            for (i = 0;  i < dimx;  i++) {
+                /* Flag a-to-d saturated pixels with 2048 dq bit */
+                if (Pix (x->sci.data, i, j) > ATOD_SATURATE) {
+                    sum_dq = DQPix (x->dq.data, i, j) | ATODSAT;
+                    DQSetPix (x->dq.data, i, j, sum_dq); /* atod sat */
+                }
+            }
+        }
+    }
 
-	/* There might not be any bad pixel table.  If not, quit now. */
-	if (wf3->bpix.exists == EXISTS_NO || wf3->dqicorr != PERFORM)
-	    return (status);
+    /*
+       This is the fall-back case where the SATUFILE is missing or does not
+       contain viable information.  Instead we fall-back to using a single
+       scalar value to flag full-well saturation.  The flagging is done
+       over the entire read-out which is comprised of science data and
+       overscan regions.
 
-	/* In some cases (when the science data are not binned) we can
-	** set the DQ flags directly in the DQ array, but in other cases
-	** (when the science data are binned) we must create a scratch
-	** array and copy back to the original. */
+       Issue a message so it is clear that saturation flagging is
+       being done here in DODQI using a scalar *IF* wf3->scalar_satflag is True.
+    */
+    sat = wf3->saturate;
+    if ((wf3->detector != IR_DETECTOR) && (wf3->scalar_satflag == True)) {
+        sprintf (MsgText, "Full-well saturation flagging being applied during doDQI using a single threshold value.");
+        trlmessage (MsgText);
+        for (j = 0;  j < dimy;  j++) {
+            for (i = 0;  i < dimx;  i++) {
+                // Flag full-well or a-to-d saturated pixels with 256 bit
+                if (Pix (x->sci.data, i, j) > sat || Pix (x->sci.data, i, j) > ATOD_SATURATE) {
+                    sum_dq = DQPix (x->dq.data, i, j) | SATPIXEL;
+                    DQSetPix (x->dq.data, i, j, sum_dq);
+                }
+            }
+        }
+    }
 
-	if (wf3->bin[0] == 1 && wf3->bin[1] == 1)
-	    in_place = 1;				/* no binning */
-	else
-	    in_place = 0;
+    /*
+       Determine the limits of science data as this information is needed
+       in order to AVOID flagging science data in these regions at this time.
+       This section is ONLY for the case when the saturation image is being used
+       (wf3->scalar_satflag = False).
+    */
+    if (overscan) {
+        /* Full-frame image */
+        if (wf3->subarray == NO) {
+            ComputeLimits(wf3, dimx, dimy, xbeg, ybeg, xend, yend);
 
-	/* Get the other linear transformations (ri_m and ri_v were gotten
-	** earlier, just after checking for saturation). */
+            xoscan_beg1 = 0;
+            xoscan_end1 = xbeg[0] - 1;
+            xoscan_beg2 = xend[0];
+            xoscan_end2 = xbeg[1] - 1;
+            xoscan_beg3 = xend[1];
+            xoscan_end3 = dimx - 1;
 
-	if (!in_place) {
+            /* Set the full rows to be flagged for the physical virtual overscan */
+            if (ybeg[0] == 0) {
+                yoscan_beg1 = yend[0];
+                yoscan_end1 = dimy - 1;
+            } else {
+                yoscan_beg1 = 0;
+                yoscan_end1 = ybeg[0] - 1;
+            }
 
-	    /* scratch array will be in reference table coords */
-	    rs_m[0] = 1.;
-	    rs_m[1] = 1.;
-	    rs_v[0] = 0.;
-	    rs_v[1] = 0.;
-	    /* assumes rs_m = 1, rs_v = 0 */
-	    si_m[0] = ri_m[0];
-	    si_m[1] = ri_m[1];
-	    si_v[0] = ri_v[0];
-	    si_v[1] = ri_v[1];
-	}
+            /*
+               For the full columns to be flagged, just set the start to zero
+               and the end to the ydim
+            */
+            ydata_end = dimy;
 
-	/* Open the data quality initialization table, find columns, etc. */
-	if (OpenBpixTab (wf3->bpix.name, &tabinfo))
-	    return (status);
+            /*
+               This set of for loops cover the case where the full saturation image
+               is in use.  However, the serial and and physical overscan regions which are
+               flagged in the fall-back case are not flagged when using the saturation image
+               in dofwsat.c, and they need to be flagged here.  Only the overscan regions will
+               be flagged here.
 
-	/* Size of scratch image */
-	snpix[0] = tabinfo.axlen1;
-	snpix[1] = tabinfo.axlen2;
+               Flag full-well or a-to-d saturated pixels with 256 bit
+            */
+            if ((wf3->detector != IR_DETECTOR) && (wf3->scalar_satflag == False)) {
 
-	/* Size of current image */
-	npix[0] = x->dq.data.nx;
-	npix[1] = x->dq.data.ny;
+                for (j = 0;  j < dimy;  j++) {
+                    for (i = 0;  i < dimx;  i++) {
+                        // Flag full rows for the parallel virtual overscan
+                        if ( ((j >= yoscan_beg1) && (j <=yoscan_end1)) ||
+                                // Flag leading serial physical overscan
+                                ((j >= ydata_beg) && (j <= ydata_end) && (i >= xoscan_beg1) && (i <= xoscan_end1)) ||
+                                // Serial virtual overscan
+                                ((j >= ydata_beg) && (j <= ydata_end) && (i >= xoscan_beg2) && (i <= xoscan_end2)) ||
+                                // Trailing serial physical overscan
+                                ((j >= ydata_beg) && (j <= ydata_end) && (i >= xoscan_beg3) && (i <= xoscan_end3)) ) {
+                            // Flag full-well or a-to-d saturated pixels with 256 bit
+                            if (Pix (x->sci.data, i, j) > sat || Pix (x->sci.data, i, j) > ATOD_SATURATE) {
+                                sum_dq = DQPix (x->dq.data, i, j) | SATPIXEL;
+                                DQSetPix (x->dq.data, i, j, sum_dq);
+                            }
+                        }
+                    }
+                }
+            }
+        /* Subarray - only serial physical overscan */ 
+        } else  {
+            if (wf3->trimx[0] > 0) {
+                xoscan_beg1 = 0;
+                xoscan_end1 = wf3->trimx[0] - 1;
+                xoscan_beg = 0;
+                xoscan_end = wf3->trimx[0] - 1;
+            } else if (wf3->trimx[1] > 0) {
+                xoscan_beg3 = dimx - wf3->trimx[1];
+                xoscan_end3 = dimx - 1;
+                xoscan_beg = dimx - wf3->trimx[1];
+                xoscan_end = dimx - 1;
+            }
 
-	/* Allocate space for scratch array */
-	initShortHdrData (&ydq);
-	if (!in_place) {
-	    allocShortHdrData (&ydq, snpix[0], snpix[1], True);
-	    if (hstio_err()) {
-		trlerror ("doDQI couldn't allocate data quality array.");
-		return (status = OUT_OF_MEMORY);
-	    }
-	    for (j=0; j < snpix[1]; j++)
-		 for (i=0; i < snpix[0]; i++)
-		      DQSetPix (ydq.data, i, j, 0);	/* initially OK */
-	}
+            if ((wf3->detector != IR_DETECTOR) && (wf3->scalar_satflag == False)) {
+                for (j = 0;  j < dimy;  j++) {
+                    for (i = xoscan_beg;  i < xoscan_end;  i++) {
+                        // Flag full-well or a-to-d saturated pixels with 256 bit
+                        if (Pix (x->sci.data, i, j) > sat || Pix (x->sci.data, i, j) > ATOD_SATURATE) {
+                            sum_dq = DQPix (x->dq.data, i, j) | SATPIXEL;
+                            DQSetPix (x->dq.data, i, j, sum_dq);
+                        }
+                    }
+                }
+            }
+        } /* End Subarray */
+    } /* End for overscan being present */
 
-	/* Read each row of the table, and fill in data quality values. */
-	nrows = 0;
-	for (row = 1;  row <= tabinfo.nrows;  row++) {
+    /* Get the linear transformations. */
+    if (GetLT0 (&x->sci.hdr, ri_m, ri_v))		/* zero indexed LTV */
+        return (status);
 
-	    if (ReadBpixTab (&tabinfo, row, &tabrow)) {
-		trlerror ("Error reading BPIXTAB.");
-		return (status);
-	    }
+    /* There might not be any bad pixel table.  If not, quit now. */
+    if (wf3->bpix.exists == EXISTS_NO || wf3->dqicorr != PERFORM)
+        return (status);
 
-	    /* If CCDAMP column does not exist or it has a wildcard value,
-	    ** always return a match. */
-	    if (tabinfo.cp_amp == 0 || SameString(tabrow.ccdamp, "N/A")) {
-		sameamp = 1;
-	    } else {
-		sameamp = SameString (tabrow.ccdamp, wf3->ccdamp);
-	    }
+    /* In some cases (when the science data are not binned) we can
+    ** set the DQ flags directly in the DQ array, but in other cases
+    ** (when the science data are binned) we must create a scratch
+    ** array and copy back to the original. */
 
-	    /* If CCDGAIN column does not exist or it has a wildcard value,
-	    ** always return a match. */
-	    if (tabinfo.cp_ccdgain == 0 || tabrow.ccdgain == -999) {
-		samegain = 1;
-	    } else {
-		samegain = SameFlt (tabrow.ccdgain, wf3->ccdgain);
-	    }
+    if (wf3->bin[0] == 1 && wf3->bin[1] == 1)
+        in_place = 1;				/* no binning */
+    else
+        in_place = 0;
 
-	    /* If CCDCHIP column does not exist or it has a wildcard value,
-	    ** always return a match. */
-	    if (tabinfo.cp_ccdchip == 0 || tabrow.ccdchip == -999) {
-		samechip = 1;
-	    } else {
-		samechip = SameInt (tabrow.ccdchip, wf3->chip);
-	    }
+    /* Get the other linear transformations (ri_m and ri_v were gotten
+    ** earlier, just after checking for saturation). */
 
-	    /* Check for a match with selection criteria */
-	    if (sameamp && samegain && samechip) {
+    if (!in_place) {
 
-		/* Adjust BPIXTAB pixel coords for presence of serial
-		   virtual overscan pixels in WFC3 raw images */
-		ToWF3RawCoords (wf3, ri_m, &tabrow);
+        /* scratch array will be in reference table coords */
+        rs_m[0] = 1.;
+        rs_m[1] = 1.;
+        rs_v[0] = 0.;
+        rs_v[1] = 0.;
+        /* assumes rs_m = 1, rs_v = 0 */
+        si_m[0] = ri_m[0];
+        si_m[1] = ri_m[1];
+        si_v[0] = ri_v[0];
+        si_v[1] = ri_v[1];
+    }
 
-	        /* Assign the flag value to all relevant pixels. */
-	        if (in_place)
-		    DQINormal (&x->dq, ri_v, &tabrow);
-	        else
-	            DQINormal (&ydq, rs_v, &tabrow);
-		nrows += 1;
-	    }
-	}
+    /* Open the data quality initialization table, find columns, etc. */
+    if (OpenBpixTab (wf3->bpix.name, &tabinfo))
+        return (status);
 
-	if (CloseBpixTab (&tabinfo))		/* done with the table */
-	    return (status);
+    /* Size of scratch image */
+    snpix[0] = tabinfo.axlen1;
+    snpix[1] = tabinfo.axlen2;
 
-	if (nrows == 0) {
-	    sprintf (MsgText, "No rows from BPIXTAB applied to DQ array.");
-	    trlwarn (MsgText);
+    /* Size of current image */
+    npix[0] = x->dq.data.nx;
+    npix[1] = x->dq.data.ny;
 
-	}
+    /* Allocate space for scratch array */
+    initShortHdrData (&ydq);
+    if (!in_place) {
+        allocShortHdrData (&ydq, snpix[0], snpix[1], True);
+        if (hstio_err()) {
+            trlerror ("doDQI couldn't allocate data quality array.");
+            return (status = OUT_OF_MEMORY);
+        }
+        for (j=0; j < snpix[1]; j++)
+            for (i=0; i < snpix[0]; i++)
+                DQSetPix (ydq.data, i, j, 0);	/* initially OK */
+    }
 
-	/* Copy scratch contents into input DQ array */
-	if (!in_place) {
+    /* Read each row of the table, and fill in data quality values. */
+    nrows = 0;
+    for (row = 1;  row <= tabinfo.nrows;  row++) {
 
-	    /* Get corners of region of overlap between image
-	       and scratch array */
-	    FirstLast (si_m, si_v, snpix, npix, rbin, first, last, sfirst);
+        if (ReadBpixTab (&tabinfo, row, &tabrow)) {
+            trlerror ("Error reading BPIXTAB.");
+            return (status);
+        }
 
-	    /* We have been writing to a scratch array ydq. Now copy
-	       or bin the values down to the actual size of image x */
+        /* If CCDAMP column does not exist or it has a wildcard value,
+        ** always return a match. */
+        if (tabinfo.cp_amp == 0 || SameString(tabrow.ccdamp, "N/A")) {
+            sameamp = 1;
+        } else {
+            sameamp = SameString (tabrow.ccdamp, wf3->ccdamp);
+        }
 
-	    j0 = sfirst[1];
-	    for (n = first[1]; n <= last[1]; n++) {
-		 i0 = sfirst[0];
-		 for (m = first[0]; m <= last[0]; m++) {
-		      sum_dq = DQPix (x->dq.data, m, n);
-		      for (j = j0; j < MIN(j0+rbin[1], ydq.data.ny); j++) {
-			   for (i = i0; i < MIN(i0+rbin[0], ydq.data.nx); i++) {
-				if (i >= 0 && j >= 0)
-				    sum_dq |= DQPix (ydq.data, i, j);
-		      }}
-		      DQSetPix (x->dq.data, m, n, sum_dq);
-		      i0 += rbin[0];
-		 }
-		 j0 += rbin[1];
-	    }
+        /* If CCDGAIN column does not exist or it has a wildcard value,
+        ** always return a match. */
+        if (tabinfo.cp_ccdgain == 0 || tabrow.ccdgain == -999) {
+            samegain = 1;
+        } else {
+            samegain = SameFlt (tabrow.ccdgain, wf3->ccdgain);
+        }
 
-	    freeShortHdrData (&ydq);		/* done with ydq */
-	}
+        /* If CCDCHIP column does not exist or it has a wildcard value,
+        ** always return a match. */
+        if (tabinfo.cp_ccdchip == 0 || tabrow.ccdchip == -999) {
+            samechip = 1;
+        } else {
+            samechip = SameInt (tabrow.ccdchip, wf3->chip);
+        }
 
-	return (status);
+        /* Check for a match with selection criteria */
+        if (sameamp && samegain && samechip) {
+
+            /* Adjust BPIXTAB pixel coords for presence of serial
+               virtual overscan pixels in WFC3 raw images */
+            ToWF3RawCoords (wf3, ri_m, &tabrow);
+
+            /* Assign the flag value to all relevant pixels. */
+            if (in_place)
+                DQINormal (&x->dq, ri_v, &tabrow);
+            else
+                DQINormal (&ydq, rs_v, &tabrow);
+            nrows += 1;
+        }
+    }
+
+    if (CloseBpixTab (&tabinfo))		/* done with the table */
+        return (status);
+
+    if (nrows == 0) {
+        sprintf (MsgText, "No rows from BPIXTAB applied to DQ array.");
+        trlwarn (MsgText);
+
+    }
+
+    /* Copy scratch contents into input DQ array */
+    if (!in_place) {
+
+        /* Get corners of region of overlap between image
+           and scratch array */
+        FirstLast (si_m, si_v, snpix, npix, rbin, first, last, sfirst);
+
+        /* We have been writing to a scratch array ydq. Now copy
+           or bin the values down to the actual size of image x */
+
+        j0 = sfirst[1];
+        for (n = first[1]; n <= last[1]; n++) {
+            i0 = sfirst[0];
+            for (m = first[0]; m <= last[0]; m++) {
+                sum_dq = DQPix (x->dq.data, m, n);
+                for (j = j0; j < MIN(j0+rbin[1], ydq.data.ny); j++) {
+                    for (i = i0; i < MIN(i0+rbin[0], ydq.data.nx); i++) {
+                        if (i >= 0 && j >= 0)
+                            sum_dq |= DQPix (ydq.data, i, j);
+                    }
+                }
+                DQSetPix (x->dq.data, m, n, sum_dq);
+                i0 += rbin[0];
+            }
+            j0 += rbin[1];
+        }
+
+        freeShortHdrData (&ydq);		/* done with ydq */
+    }
+
+    return (status);
 }
 
 int OpenBpixTab (char *tname, TblInfo *tabinfo) {
 
-	extern int status;
+    extern int status;
 
-	tabinfo->tp = c_tbtopn (tname, IRAF_READ_ONLY, 0);
-	if (c_iraferr())
-	    return (status = OPEN_FAILED);
+    tabinfo->tp = c_tbtopn (tname, IRAF_READ_ONLY, 0);
+    if (c_iraferr())
+        return (status = OPEN_FAILED);
 
-	tabinfo->nrows = c_tbpsta (tabinfo->tp, TBL_NROWS);
-	if (tabinfo->nrows < 1) {
-	    return (status);			/* nothing to do */
-	}
+    tabinfo->nrows = c_tbpsta (tabinfo->tp, TBL_NROWS);
+    if (tabinfo->nrows < 1) {
+        return (status);			/* nothing to do */
+    }
 
-	/* Find the columns. */
-	c_tbcfnd1 (tabinfo->tp, "CCDAMP", &tabinfo->cp_amp);
-	c_tbcfnd1 (tabinfo->tp, "CCDCHIP", &tabinfo->cp_ccdchip);
-	c_tbcfnd1 (tabinfo->tp, "CCDGAIN", &tabinfo->cp_ccdgain);
-	c_tbcfnd1 (tabinfo->tp, "PIX1", &tabinfo->cp_xstart);
-	c_tbcfnd1 (tabinfo->tp, "PIX2", &tabinfo->cp_ystart);
-	c_tbcfnd1 (tabinfo->tp, "LENGTH", &tabinfo->cp_length);
-	c_tbcfnd1 (tabinfo->tp, "AXIS", &tabinfo->cp_axis);
-	c_tbcfnd1 (tabinfo->tp, "VALUE", &tabinfo->cp_flag);
-	if (tabinfo->cp_xstart == 0 ||
-	    tabinfo->cp_ystart == 0 ||
-	    tabinfo->cp_length == 0 ||
-	    tabinfo->cp_axis == 0 ||
-	    tabinfo->cp_ccdchip == 0 ||
-	    tabinfo->cp_flag == 0) {
-	    c_tbtclo (tabinfo->tp);
-	    trlerror ("Column not found in BPIXTAB.");
-	    return (status = COLUMN_NOT_FOUND);
-	}
+    /* Find the columns. */
+    c_tbcfnd1 (tabinfo->tp, "CCDAMP", &tabinfo->cp_amp);
+    c_tbcfnd1 (tabinfo->tp, "CCDCHIP", &tabinfo->cp_ccdchip);
+    c_tbcfnd1 (tabinfo->tp, "CCDGAIN", &tabinfo->cp_ccdgain);
+    c_tbcfnd1 (tabinfo->tp, "PIX1", &tabinfo->cp_xstart);
+    c_tbcfnd1 (tabinfo->tp, "PIX2", &tabinfo->cp_ystart);
+    c_tbcfnd1 (tabinfo->tp, "LENGTH", &tabinfo->cp_length);
+    c_tbcfnd1 (tabinfo->tp, "AXIS", &tabinfo->cp_axis);
+    c_tbcfnd1 (tabinfo->tp, "VALUE", &tabinfo->cp_flag);
+    if (tabinfo->cp_xstart == 0 ||
+            tabinfo->cp_ystart == 0 ||
+            tabinfo->cp_length == 0 ||
+            tabinfo->cp_axis == 0 ||
+            tabinfo->cp_ccdchip == 0 ||
+            tabinfo->cp_flag == 0) {
+        c_tbtclo (tabinfo->tp);
+        trlerror ("Column not found in BPIXTAB.");
+        return (status = COLUMN_NOT_FOUND);
+    }
 
-	/* Find out how large a full-size data quality array should be. */
-	tabinfo->axlen1 = c_tbhgti (tabinfo->tp, "SIZAXIS1");
-	if (c_iraferr ()) {
-	    c_tbtclo (tabinfo->tp);
-	    trlerror ("Couldn't get SIZAXIS1 from BPIXTAB header.");
-	    return (status = TABLE_ERROR);
-	}
-	tabinfo->axlen2 = c_tbhgti (tabinfo->tp, "SIZAXIS2");
-	if (c_iraferr ()) {
-	    c_tbtclo (tabinfo->tp);
-	    trlerror ("Couldn't get SIZAXIS2 from BPIXTAB header.");
-	    return (status = TABLE_ERROR);
-	}
+    /* Find out how large a full-size data quality array should be. */
+    tabinfo->axlen1 = c_tbhgti (tabinfo->tp, "SIZAXIS1");
+    if (c_iraferr ()) {
+        c_tbtclo (tabinfo->tp);
+        trlerror ("Couldn't get SIZAXIS1 from BPIXTAB header.");
+        return (status = TABLE_ERROR);
+    }
+    tabinfo->axlen2 = c_tbhgti (tabinfo->tp, "SIZAXIS2");
+    if (c_iraferr ()) {
+        c_tbtclo (tabinfo->tp);
+        trlerror ("Couldn't get SIZAXIS2 from BPIXTAB header.");
+        return (status = TABLE_ERROR);
+    }
 
-	return (status);
+    return (status);
 }
 
 
@@ -432,74 +570,74 @@ int OpenBpixTab (char *tname, TblInfo *tabinfo) {
 
 int ReadBpixTab (TblInfo *tabinfo, int row, TblRow *tabrow) {
 
-	extern int status;
+    extern int status;
 
-	/* read in values from selection columns */
-	/* If AMP column exists, read it, otherwise it is not necessary */
-	if (tabinfo->cp_amp != 0) {
-	    c_tbegtt (tabinfo->tp, tabinfo->cp_amp, row, tabrow->ccdamp,
-		      SZ_CBUF);
-	    if (c_iraferr())
-	        return (status = TABLE_ERROR);
-	}
-	c_tbegti (tabinfo->tp, tabinfo->cp_ccdchip, row, &tabrow->ccdchip);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	/* If GAIN column exists, read it, otherwise it is not necessary */
-	if (tabinfo->cp_ccdgain != 0) {
-	    c_tbegtr (tabinfo->tp, tabinfo->cp_ccdgain, row, &tabrow->ccdgain);
-	    if (c_iraferr())
-	        return (status = TABLE_ERROR);
-	}
-	
-	/* read in bad pixel value description columns */
-	c_tbegti (tabinfo->tp, tabinfo->cp_xstart, row, &tabrow->xstart);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	tabrow->xstart--;
-	c_tbegti (tabinfo->tp, tabinfo->cp_ystart, row, &tabrow->ystart);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	tabrow->ystart--;
-	c_tbegti (tabinfo->tp, tabinfo->cp_length, row, &tabrow->length);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_axis, row, &tabrow->axis);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegts (tabinfo->tp, tabinfo->cp_flag, row, &tabrow->flag);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    /* read in values from selection columns */
+    /* If AMP column exists, read it, otherwise it is not necessary */
+    if (tabinfo->cp_amp != 0) {
+        c_tbegtt (tabinfo->tp, tabinfo->cp_amp, row, tabrow->ccdamp,
+                  SZ_CBUF);
+        if (c_iraferr())
+            return (status = TABLE_ERROR);
+    }
+    c_tbegti (tabinfo->tp, tabinfo->cp_ccdchip, row, &tabrow->ccdchip);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    /* If GAIN column exists, read it, otherwise it is not necessary */
+    if (tabinfo->cp_ccdgain != 0) {
+        c_tbegtr (tabinfo->tp, tabinfo->cp_ccdgain, row, &tabrow->ccdgain);
+        if (c_iraferr())
+            return (status = TABLE_ERROR);
+    }
 
-	if (tabrow->axis !=1 && tabrow->axis != 2) {
-	    sprintf (MsgText, "Axis = %d in BPIXTAB, but it must be 1 or 2.",
-		     tabrow->axis);
-	    trlerror (MsgText);
-	    c_tbtclo (tabinfo->tp);
-	    return (status = TABLE_ERROR);
-	}
-	if (tabrow->length <= 0) {
-	    sprintf (MsgText,"Length = %d in BPIXTAB, but it must be positive.",
-		     tabrow->length);
-	    trlerror (MsgText);
-	    c_tbtclo (tabinfo->tp);
-	    return (status = TABLE_ERROR);
-	}
+    /* read in bad pixel value description columns */
+    c_tbegti (tabinfo->tp, tabinfo->cp_xstart, row, &tabrow->xstart);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    tabrow->xstart--;
+    c_tbegti (tabinfo->tp, tabinfo->cp_ystart, row, &tabrow->ystart);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    tabrow->ystart--;
+    c_tbegti (tabinfo->tp, tabinfo->cp_length, row, &tabrow->length);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_axis, row, &tabrow->axis);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegts (tabinfo->tp, tabinfo->cp_flag, row, &tabrow->flag);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	return (status);
+    if (tabrow->axis !=1 && tabrow->axis != 2) {
+        sprintf (MsgText, "Axis = %d in BPIXTAB, but it must be 1 or 2.",
+                 tabrow->axis);
+        trlerror (MsgText);
+        c_tbtclo (tabinfo->tp);
+        return (status = TABLE_ERROR);
+    }
+    if (tabrow->length <= 0) {
+        sprintf (MsgText,"Length = %d in BPIXTAB, but it must be positive.",
+                 tabrow->length);
+        trlerror (MsgText);
+        c_tbtclo (tabinfo->tp);
+        return (status = TABLE_ERROR);
+    }
+
+    return (status);
 }
 
 /* This routine closes the bpixtab table. */
 
 int CloseBpixTab (TblInfo *tabinfo) {
 
-	extern int status;
+    extern int status;
 
-	c_tbtclo (tabinfo->tp);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbtclo (tabinfo->tp);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	return (status);
+    return (status);
 }
 
 /* This routine adds an offset to the DQ pixel coords read from the
@@ -509,45 +647,45 @@ int CloseBpixTab (TblInfo *tabinfo) {
 
 void ToWF3RawCoords (WF3Info *wf3, double *ltm, TblRow *tabrow) {
 
-/* arguments:
-WF3Info *wf3	     i: WFC3 calibration info
-double ltm[2]        i: scale factor of science data
-TblRow *tabrow       io: data quality info read from one row of BPIXTAB
-*/
+    /* arguments:
+    WF3Info *wf3	     i: WFC3 calibration info
+    double ltm[2]        i: scale factor of science data
+    TblRow *tabrow       io: data quality info read from one row of BPIXTAB
+    */
 
-	int rbin; 	/* binning factor */
+    int rbin; 	/* binning factor */
 
-	int streq_ic (char *, char *);	/* string comparison */
+    int streq_ic (char *, char *);	/* string comparison */
 
-	rbin = NINT (1. / ltm[0]);
+    rbin = NINT (1. / ltm[0]);
 
-	/* The correction is only needed for four-amp readouts, because they
-	** are the only ones to have virtual overscan columns in the middle
-	** of an image. All other two- and one-amp modes have the virtual
-	** columns at either end of the image and are already accounted for
-	** in the LTV values in the raw image header. */
-	if (streq_ic (wf3->ccdamp, "ABCD")) {
+    /* The correction is only needed for four-amp readouts, because they
+    ** are the only ones to have virtual overscan columns in the middle
+    ** of an image. All other two- and one-amp modes have the virtual
+    ** columns at either end of the image and are already accounted for
+    ** in the LTV values in the raw image header. */
+    if (streq_ic (wf3->ccdamp, "ABCD")) {
 
-	    /* Only apply the offset if the flagged pixel is located to
-	    ** to the right (i.e. higher pixel index) of the serial virtual
-	    ** overscan columns. This applies to all pixels in the domain
-	    ** of the second readout amp for the chip (i.e. amp B for AB,
-	    ** and amp D for CD. */
-	    if (tabrow->xstart >= wf3->ampx * rbin) {
+        /* Only apply the offset if the flagged pixel is located to
+        ** to the right (i.e. higher pixel index) of the serial virtual
+        ** overscan columns. This applies to all pixels in the domain
+        ** of the second readout amp for the chip (i.e. amp B for AB,
+        ** and amp D for CD. */
+        if (tabrow->xstart >= wf3->ampx * rbin) {
 
-		/* Add an offset equal to the number of virtual overscan
-		** columns that occur in the middle of an unbinned raw image.
-		** We get the number of colums from the trim information in
-		** the OSCNTAB reference table, multiplied back up to
-		** unbinned space. */
-		tabrow->xstart += (wf3->trimx[2] + wf3->trimx[3]) * rbin;
+            /* Add an offset equal to the number of virtual overscan
+            ** columns that occur in the middle of an unbinned raw image.
+            ** We get the number of colums from the trim information in
+            ** the OSCNTAB reference table, multiplied back up to
+            ** unbinned space. */
+            tabrow->xstart += (wf3->trimx[2] + wf3->trimx[3]) * rbin;
 
-		/* Raw images with a binning factor of 2 use a smaller
-		** trim value, therefore we need to add an extra offset. */
-		if (rbin == 2)
-		    tabrow->xstart += 2;
-	    }
-	}
+            /* Raw images with a binning factor of 2 use a smaller
+            ** trim value, therefore we need to add an extra offset. */
+            if (rbin == 2)
+                tabrow->xstart += 2;
+        }
+    }
 }
 
 /* This routine assigns data quality values as specified in one row of
@@ -556,120 +694,120 @@ TblRow *tabrow       io: data quality info read from one row of BPIXTAB
 
 void DQINormal (DQHdrData *ydq, double *ltv, TblRow *tabrow) {
 
-/* arguments:
-DQHdrData *ydq	    io: data quality array
-double ltv[2]        i: offset of array within detector
-TblRow *tabrow       i: data quality info read from one row
-*/
+    /* arguments:
+    DQHdrData *ydq	    io: data quality array
+    double ltv[2]        i: offset of array within detector
+    TblRow *tabrow       i: data quality info read from one row
+    */
 
-	int xstart, ystart;	/* from tabrow, but scaled and shifted */
-	int xlow, xhigh;	/* limits for loop on i */
-	int ylow, yhigh;	/* limits for loop on j */
-	int i, j;		/* indexes for scratch array ydq */
-	short sum_dq;		/* for binning data quality array */
+    int xstart, ystart;	/* from tabrow, but scaled and shifted */
+    int xlow, xhigh;	/* limits for loop on i */
+    int ylow, yhigh;	/* limits for loop on j */
+    int i, j;		/* indexes for scratch array ydq */
+    short sum_dq;		/* for binning data quality array */
 
-	/* Take account of possible subarray or overscan.  We use ltv,
-	   but we assume ltm = 1.
-	*/
-	xstart = tabrow->xstart + ltv[0];
-	ystart = tabrow->ystart + ltv[1];
+    /* Take account of possible subarray or overscan.  We use ltv,
+       but we assume ltm = 1.
+    */
+    xstart = tabrow->xstart + ltv[0];
+    ystart = tabrow->ystart + ltv[1];
 
-	if (tabrow->axis == 1) {
+    if (tabrow->axis == 1) {
 
-	    /* The range for x is the repeat count. */
-	    xlow = xstart;
-	    xhigh = xstart + tabrow->length - 1;
+        /* The range for x is the repeat count. */
+        xlow = xstart;
+        xhigh = xstart + tabrow->length - 1;
 
-	    /* out of range? */
-	    if (xhigh < 0 || xlow >= ydq->data.nx ||
-		ystart < 0 || ystart >= ydq->data.ny)
-		    return;
+        /* out of range? */
+        if (xhigh < 0 || xlow >= ydq->data.nx ||
+                ystart < 0 || ystart >= ydq->data.ny)
+            return;
 
-	    if (xlow < 0)
-	    	xlow = 0;
-	    if (xhigh >= ydq->data.nx)
-    		xhigh = ydq->data.nx - 1;
+        if (xlow < 0)
+            xlow = 0;
+        if (xhigh >= ydq->data.nx)
+            xhigh = ydq->data.nx - 1;
 
-	    j = ystart;
-	    for (i = xlow;  i <= xhigh;  i++) {
-		    sum_dq = tabrow->flag | PDQPix (&ydq->data, i, j);
-		    PDQSetPix (&ydq->data, i, j, sum_dq);
-	    }
+        j = ystart;
+        for (i = xlow;  i <= xhigh;  i++) {
+            sum_dq = tabrow->flag | PDQPix (&ydq->data, i, j);
+            PDQSetPix (&ydq->data, i, j, sum_dq);
+        }
 
-	} else if (tabrow->axis == 2) {
+    } else if (tabrow->axis == 2) {
 
-	    /* The range for y is the repeat count. */
-	    ylow = ystart;
-	    yhigh = ystart + tabrow->length - 1;
+        /* The range for y is the repeat count. */
+        ylow = ystart;
+        yhigh = ystart + tabrow->length - 1;
 
-	    /* out of range? */
-	    if (xstart < 0 || xstart >= ydq->data.nx ||
-		yhigh < 0 || ylow >= ydq->data.ny)
-		    return;
+        /* out of range? */
+        if (xstart < 0 || xstart >= ydq->data.nx ||
+                yhigh < 0 || ylow >= ydq->data.ny)
+            return;
 
-	    if (ylow < 0)
-		    ylow = 0;
-	    if (yhigh >= ydq->data.ny)
-		    yhigh = ydq->data.ny - 1;
+        if (ylow < 0)
+            ylow = 0;
+        if (yhigh >= ydq->data.ny)
+            yhigh = ydq->data.ny - 1;
 
-	    i = xstart;
-	    for (j = ylow;  j <= yhigh;  j++) {
-		    sum_dq = tabrow->flag | PDQPix (&ydq->data, i, j);
-		    PDQSetPix (&ydq->data, i, j, sum_dq);
-	    }
-	}
+        i = xstart;
+        for (j = ylow;  j <= yhigh;  j++) {
+            sum_dq = tabrow->flag | PDQPix (&ydq->data, i, j);
+            PDQSetPix (&ydq->data, i, j, sum_dq);
+        }
+    }
 }
 
 # define TOLERANCE (0.001)
 
 static void FirstLast (double *ltm, double *ltv, int *snpix, int *npix,
-		int *rbin, int *first, int *last, int *sfirst) {
+                       int *rbin, int *first, int *last, int *sfirst) {
 
-/* arguments:
-double ltm[2], ltv[2]   i: linear transformation from scratch to image coords
-				(adjusted for use with zero indexed coords)
-int snpix[2]            i: size of scratch image
-int npix[2]             i: size of actual image
-int rbin[2]             o: number of pixels in scratch for one image pixel
-int first[2], last[2]   o: corners of overlap region, in image coords
-int sfirst[2]           o: lower left corner of overlap, in scratch array
-*/
+    /* arguments:
+    double ltm[2], ltv[2]   i: linear transformation from scratch to image coords
+    				(adjusted for use with zero indexed coords)
+    int snpix[2]            i: size of scratch image
+    int npix[2]             i: size of actual image
+    int rbin[2]             o: number of pixels in scratch for one image pixel
+    int first[2], last[2]   o: corners of overlap region, in image coords
+    int sfirst[2]           o: lower left corner of overlap, in scratch array
+    */
 
-	double scr;		/* pixel coordinate in scratch array */
-	int i, k;
+    double scr;		/* pixel coordinate in scratch array */
+    int i, k;
 
-	rbin[0] = NINT (1. / ltm[0]);
-	rbin[1] = NINT (1. / ltm[1]);
+    rbin[0] = NINT (1. / ltm[0]);
+    rbin[1] = NINT (1. / ltm[1]);
 
-	for (k = 0;  k < 2;  k++) {	/* axis number */
-	    /* Search for the first pixel in the image array that maps to a
-		point that is completely within the scratch array.  The left
-		(lower) edge of pixel i is (i - 0.5).  Map (i - 0.5) to the
-		scratch array, and if that point is within the scratch array,
-		i is the first fully illuminated pixel.
-	    */
-	    for (i = 0;  i < npix[k];  i++) {
-		scr = (i - 0.5 - ltv[k]) / ltm[k];
-		/* -0.5 is left (lower) edge of first pixel in scratch */
-		if (scr+TOLERANCE >= -0.5) {
-		    first[k] = i;
-		    sfirst[k] = NINT (scr+0.5);
-		    break;
-		}
-	    }
-	    /* Now look for the last fully illuminated pixel, using the
-		right (upper) edge of the image pixels.
-	    */
-	    for (i = npix[k]-1;  i > 0;  i--) {
-		scr = (i + 0.5 - ltv[k]) / ltm[k];
-		/* compare scr with right (upper) edge of last pixel in the
-		   scratch array
-		*/
-		if (scr-TOLERANCE <= snpix[k]-1. + 0.5) {
-		    last[k] = i;
-		    break;
-		}
-	    }
-	}
+    for (k = 0;  k < 2;  k++) {	/* axis number */
+        /* Search for the first pixel in the image array that maps to a
+        point that is completely within the scratch array.  The left
+        (lower) edge of pixel i is (i - 0.5).  Map (i - 0.5) to the
+        scratch array, and if that point is within the scratch array,
+        i is the first fully illuminated pixel.
+        */
+        for (i = 0;  i < npix[k];  i++) {
+            scr = (i - 0.5 - ltv[k]) / ltm[k];
+            /* -0.5 is left (lower) edge of first pixel in scratch */
+            if (scr+TOLERANCE >= -0.5) {
+                first[k] = i;
+                sfirst[k] = NINT (scr+0.5);
+                break;
+            }
+        }
+        /* Now look for the last fully illuminated pixel, using the
+        right (upper) edge of the image pixels.
+        */
+        for (i = npix[k]-1;  i > 0;  i--) {
+            scr = (i + 0.5 - ltv[k]) / ltm[k];
+            /* compare scr with right (upper) edge of last pixel in the
+               scratch array
+            */
+            if (scr-TOLERANCE <= snpix[k]-1. + 0.5) {
+                last[k] = i;
+                break;
+            }
+        }
+    }
 }
 

--- a/pkg/wfc3/calwf3/lib/wscript
+++ b/pkg/wfc3/calwf3/lib/wscript
@@ -7,7 +7,7 @@ def build(bld):
     t = bld.stlib(
         source = """
             wf3hist.c  wf3info.c   wf3sect.c   addk2d.c  bin2d.c   bincoords.c
-            binupdate.c   comparenum.c   defswitch.c   detchip.c
+            binupdate.c   comparenum.c   computelimits.c defswitch.c   detchip.c
             detnsegn.c   div1d.c   dodqi.c   donoise.c   dostat.c
             err.c   fileexists.c   findbin.c   findroot.c   fromlt.c
             getccdtab.c   getcorner.c  getgrp.c  getkeys.c  getlt.c

--- a/pkg/wfc3/calwf3/wf32d/do2d.c
+++ b/pkg/wfc3/calwf3/wf32d/do2d.c
@@ -40,7 +40,9 @@
     in the code that are doing a case sensative check. I'm going to try and make
     those case insensitive as well
    M. Sosey, 2013 July 3
-   Added code to implement new FLUXCORR step, see #1011
+    Added code to implement new FLUXCORR step, see #1011
+   M. De La Pena October 2023
+    Added overscan as a parameter to the doDQI function signature.
 
 */
 
@@ -85,10 +87,13 @@ int extver       i: "imset" number, the current set of extensions
 	char buff[SZ_FITS_REC+1];
 	Bool subarray;
 
+    /* The value of this parameter should NOT be changed from zero. */ 
+    int overscan = 0;	/* New parameter necessary for API change to doDQi */
+
 	int CCDHistory (WF3Info *, Hdr *);
 	int doDark (WF3Info *, SingleGroup *, float *);
 	int darkHistory (WF3Info *, Hdr *);
-	int doDQI (WF3Info *, SingleGroup *);
+	int doDQI (WF3Info *, SingleGroup *, int overscan);
 	int dqiHistory (WF3Info *, Hdr *);
 	int doFlat (WF3Info *, int, SingleGroup *);
 	int flatHistory (WF3Info *, Hdr *);
@@ -230,7 +235,7 @@ int extver       i: "imset" number, the current set of extensions
 	dqiMsg (wf32d, extver);
 	if (wf32d->dqicorr == PERFORM ||
 	    (wf32d->dqicorr == DUMMY && wf32d->detector != IR_DETECTOR)) {
-	    if (doDQI (wf32d, &x))
+	    if (doDQI (wf32d, &x, overscan))
 		return (status);
 	    PrSwitch ("dqicorr", COMPLETE);
 	    if (wf32d->printtime)

--- a/pkg/wfc3/calwf3/wf3ccd/doccd.c
+++ b/pkg/wfc3/calwf3/wf3ccd/doccd.c
@@ -64,6 +64,9 @@
     the header.  If the keyword is missing or does not contain a filename,
     the algorithm will indicate the original method of flagging saturated
     pixels by using a single value threshold should be used.
+ 
+    M. De La Pena October 2023
+    Added overscan as a parameter to the doDQI function signature.
 
  */
 
@@ -235,7 +238,7 @@ int DoCCD (WF3Info *wf3, int extver) {
     /* DATA QUALITY INITIALIZATION AND (FOR THE CCDS) CHECK SATURATION. */
     dqiMsg (wf3, extver);
     if (wf3->dqicorr == PERFORM || wf3->dqicorr == DUMMY) {
-        if (doDQI (wf3, &x))
+        if (doDQI (wf3, &x, overscan))
             return (status);
         PrSwitch ("dqicorr", COMPLETE);
         if (wf3->printtime)

--- a/pkg/wfc3/calwf3/wf3ccd/doccd.h
+++ b/pkg/wfc3/calwf3/wf3ccd/doccd.h
@@ -21,7 +21,7 @@ int flashHistory (WF3Info *, Hdr *);
 int doBlev (WF3Info *, SingleGroup *, int, float *, int *, int *);
 int blevHistory (WF3Info *, Hdr *, int, int);
 int CCDHistory (WF3Info *, Hdr *);
-int doDQI (WF3Info *, SingleGroup *);
+int doDQI (WF3Info *, SingleGroup *, int overscan);
 int dqiHistory (WF3Info *, Hdr *);
 int doNoise (WF3Info *, SingleGroup *, int *);
 int noiseHistory (Hdr *);

--- a/pkg/wfc3/calwf3/wf3ccd/findover.c
+++ b/pkg/wfc3/calwf3/wf3ccd/findover.c
@@ -14,67 +14,67 @@
 # define NUMCOLS 28
 
 typedef struct {
-	IRAFPointer tp;			/* pointer to table descriptor */
-	IRAFPointer cp_amp;		/* column descriptors */
-	IRAFPointer cp_chip;
-	IRAFPointer cp_binx;
-	IRAFPointer cp_biny;	
-	IRAFPointer cp_nx;
-	IRAFPointer cp_ny;
-	IRAFPointer cp_trimx1;
-	IRAFPointer cp_trimx2;
-	IRAFPointer cp_trimx3;
-	IRAFPointer cp_trimx4;
-	IRAFPointer cp_trimy1;
-	IRAFPointer cp_trimy2;
-	IRAFPointer cp_vx1;
-	IRAFPointer cp_vx2;
-	IRAFPointer cp_vx3;
-	IRAFPointer cp_vx4;
-	IRAFPointer cp_vy1;
-	IRAFPointer cp_vy2;
-	IRAFPointer cp_vy3;
-	IRAFPointer cp_vy4;
-	IRAFPointer cp_biassecta1;
-	IRAFPointer cp_biassecta2;		
-	IRAFPointer cp_biassectb1;
-	IRAFPointer cp_biassectb2;		
-	IRAFPointer cp_biassectc1;
-	IRAFPointer cp_biassectc2;		
-	IRAFPointer cp_biassectd1;
-	IRAFPointer cp_biassectd2;		
-	int nrows;			/* number of rows in table */
+    IRAFPointer tp;			/* pointer to table descriptor */
+    IRAFPointer cp_amp;		/* column descriptors */
+    IRAFPointer cp_chip;
+    IRAFPointer cp_binx;
+    IRAFPointer cp_biny;
+    IRAFPointer cp_nx;
+    IRAFPointer cp_ny;
+    IRAFPointer cp_trimx1;
+    IRAFPointer cp_trimx2;
+    IRAFPointer cp_trimx3;
+    IRAFPointer cp_trimx4;
+    IRAFPointer cp_trimy1;
+    IRAFPointer cp_trimy2;
+    IRAFPointer cp_vx1;
+    IRAFPointer cp_vx2;
+    IRAFPointer cp_vx3;
+    IRAFPointer cp_vx4;
+    IRAFPointer cp_vy1;
+    IRAFPointer cp_vy2;
+    IRAFPointer cp_vy3;
+    IRAFPointer cp_vy4;
+    IRAFPointer cp_biassecta1;
+    IRAFPointer cp_biassecta2;
+    IRAFPointer cp_biassectb1;
+    IRAFPointer cp_biassectb2;
+    IRAFPointer cp_biassectc1;
+    IRAFPointer cp_biassectc2;
+    IRAFPointer cp_biassectd1;
+    IRAFPointer cp_biassectd2;
+    int nrows;			/* number of rows in table */
 } TblInfo;
 
 typedef struct {
-	char ccdamp[SZ_CBUF+1];
-	int chip;
-	int nx;
-	int ny;
-	int trimx[4];
-	int trimy[2];
-	int vx[4];
-	int vy[4];
-	int biassecta[2];
-	int biassectb[2];	
-	int biassectc[2];	
-	int biassectd[2];	
-	int bin[2];
+    char ccdamp[SZ_CBUF+1];
+    int chip;
+    int nx;
+    int ny;
+    int trimx[4];
+    int trimy[2];
+    int vx[4];
+    int vy[4];
+    int biassecta[2];
+    int biassectb[2];
+    int biassectc[2];
+    int biassectd[2];
+    int bin[2];
 } TblRow;
 
 
 static int OpenOverTab (char *, TblInfo *);
 static int ReadOverTab (TblInfo *, int, TblRow *);
 static int CloseOverTab (TblInfo *);
-	
+
 /* This routine assigns the widths of the overscan region on each edge
    of the image by assuming particular region sizes, depending on the
    binning and which amplifier was used for readout.
-  
-**   
+
+**
 **   This routine reads in the values from the OSCNTAB reference table.
 **
-**   The OSCNTAB refers to all regions in image coordinates, even when 
+**   The OSCNTAB refers to all regions in image coordinates, even when
 **	   the image is binned.
 
 
@@ -84,11 +84,11 @@ static int CloseOverTab (TblInfo *);
 	    v
 	(VX1,VX2)     (VX2,VY2)
   A       /         \     B
-    -----/-----------+--- 
+    -----/-----------+---
    |   |/     |      |   | } TRIMY2
    |   +------+------    |
    |   |      |      |   | <--- serial readout direction, amp A
-   |   |      |      |   | 
+   |   |      |      |   |
    | - | -----+------|---|<-- AMPY
    |   |      |      |   |
    |   |      |      |   |
@@ -97,12 +97,12 @@ static int CloseOverTab (TblInfo *);
    |   |      |      |   | } TRIMY1
     ---------------------
   C /  \      ^       / \ D
-   A1  A2     |      B1  B2 
+   A1  A2     |      B1  B2
    			AMPX
 
 	A,B,C,D   - Amps
 	AMPX 	  - First column affected by second AMP
-	AMPY 	  - First line affected by second set of AMPS 	 
+	AMPY 	  - First line affected by second set of AMPS
 	(VX1,VY1) - image coordinates of virtual overscan region origin
 	(VX2,VY2) - image coordinates of top corner of virtual overscan region
 	A1,A2 	  - beginning and ending columns for leading bias section
@@ -115,15 +115,15 @@ static int CloseOverTab (TblInfo *);
 					contains B1,B2
 	TRIMY1    - Number of lines to trim off beginning of each column
 	TRIMY2    - Number of line to trim off end of each column
-		
+
 
    Warren Hack, 1998 June 2:
    	Initial version based on GetCCDTab...
-	
+
    Warren Hack, 1998 Oct 20:
-	Second version.  Condensed all input/output through ACSInfo 
+	Second version.  Condensed all input/output through ACSInfo
 	structure, and included both trailing and leading overscan
-	region designations.  
+	region designations.
    Warren Hack, 1999 Feb 19:
         Revised to read CCDCHIP column to match CCDCHIP keyword.
    Howard Bushouse, 2000 Aug 29:
@@ -160,298 +160,420 @@ static int CloseOverTab (TblInfo *);
 
 int FindOverscan (WF3Info *wf3, int nx, int ny, int *overscan) {
 
-/* arguments:
-WF3Info *wf3		i: structure with all values from OSCNTAB 
-int nx, ny		i: lengths of first and second image axes
-int offsetx, offsety	i: Trim values from LTV1,2
-*/
+    /* arguments:
+    WF3Info *wf3		i: structure with all values from OSCNTAB
+    int nx, ny		i: lengths of first and second image axes
+    int offsetx, offsety	i: Trim values from LTV1,2
+    */
 
-	extern int status;
-	int row;
-	TblInfo tabinfo;
-	TblRow tabrow;
-	int foundit;
+    extern int status;
+    int row;
+    TblInfo tabinfo;
+    TblRow tabrow;
+    int foundit;
 
-	int cx0, cx1, tx1, tx2;
+    int cx0, cx1, tx1, tx2;
 
-	int SameInt (int, int);
-	int SameString (char *, char *);
+    int SameInt (int, int);
+    int SameString (char *, char *);
 
-	/* Open the CCD parameters table and find columns. */
-	if (OpenOverTab (wf3->oscn.name, &tabinfo))
-	    return (status);
+    /* Open the CCD parameters table and find columns. */
+    if (OpenOverTab (wf3->oscn.name, &tabinfo))
+        return (status);
 
-	foundit = NO;
-	*overscan = NO;
-	
-	/* Check each row for a match with ccdamp, chip, nx, ny,
-	** binx, and biny, and get info from the matching row.  */
-	for (row = 1;  row <= tabinfo.nrows;  row++) {
+    foundit = NO;
+    *overscan = NO;
 
-	    /* Read the current row into tabrow. */
-	    if (ReadOverTab (&tabinfo, row, &tabrow))
-		return (status);
+    /* Check each row for a match with ccdamp, chip, nx, ny,
+    ** binx, and biny, and get info from the matching row.  */
+    for (row = 1;  row <= tabinfo.nrows;  row++) {
 
-	    if (wf3->detector == CCD_DETECTOR &&
-		SameString (tabrow.ccdamp, wf3->ccdamp) &&
-		SameInt (tabrow.chip, wf3->chip) &&
-		SameInt (tabrow.bin[0], wf3->bin[0]) &&
-		SameInt (tabrow.bin[1], wf3->bin[1])) {
+        /* Read the current row into tabrow. */
+        if (ReadOverTab (&tabinfo, row, &tabrow))
+            return (status);
 
-		foundit = YES;
-		*overscan = YES;             
+        if (wf3->detector == CCD_DETECTOR &&
+                SameString (tabrow.ccdamp, wf3->ccdamp) &&
+                SameInt (tabrow.chip, wf3->chip) &&
+                SameInt (tabrow.bin[0], wf3->bin[0]) &&
+                SameInt (tabrow.bin[1], wf3->bin[1])) {
 
-		if (wf3->subarray == YES) {
+            foundit = YES;
+            *overscan = YES;
 
-		    /* We are working with a subarray... */
-		    /* There is never any virtual overscan. */
-		    wf3->trimy[0] = 0; wf3->trimy[1] = 0;
-		    wf3->vx[0] = 0; wf3->vx[1] = 0;
-		    wf3->vx[2] = 0; wf3->vx[3] = 0;
-		    wf3->vy[0] = 0; wf3->vy[1] = 0;
-		    wf3->vy[2] = 0; wf3->vy[3] = 0;
-		    wf3->trimx[2] = 0; wf3->trimx[3] = 0;
-		    wf3->biassectc[0] = 0; wf3->biassectc[1] = 0;
-		    wf3->biassectd[0] = 0; wf3->biassectd[1] = 0;
+            if (wf3->subarray == YES) {
 
-		    /* Determine whether the subarray extends into the
-		    ** physical overscan regions on either side of the chip */
-		    tx1 = (int)(nx - wf3->offsetx);
-		    cx1 = tabrow.nx - tabrow.trimx[1] - tabrow.trimx[0];
-		    cx0 = (int)(tabrow.trimx[0] - wf3->offsetx);
+                /* We are working with a subarray... */
+                /* There is never any virtual overscan. */
+                wf3->trimy[0] = 0;
+                wf3->trimy[1] = 0;
+                wf3->vx[0] = 0;
+                wf3->vx[1] = 0;
+                wf3->vx[2] = 0;
+                wf3->vx[3] = 0;
+                wf3->vy[0] = 0;
+                wf3->vy[1] = 0;
+                wf3->vy[2] = 0;
+                wf3->vy[3] = 0;
+                wf3->trimx[2] = 0;
+                wf3->trimx[3] = 0;
+                wf3->biassectc[0] = 0;
+                wf3->biassectc[1] = 0;
+                wf3->biassectd[0] = 0;
+                wf3->biassectd[1] = 0;
 
-		    if (wf3->offsetx > 0) {
-		        /* Subarray starts in the first overscan region */
-		        wf3->trimx[0] = (wf3->offsetx < tabrow.trimx[0]) ?
-					 wf3->offsetx : tabrow.trimx[0];
-			/* Check to see if it extends into second
-			** overscan region */
-			tx2 = (int)(nx - wf3->trimx[0]) - cx1;
-			wf3->trimx[1] = (tx2 < 0) ? 0 : tx2;
-			wf3->biassecta[0] = (tabrow.biassecta[0]-1 - cx0 > 0) ?
-					    (tabrow.biassecta[0]-1 - cx0) : 0;
-			wf3->biassecta[1] = tabrow.biassecta[1]-1 - cx0;
-			wf3->biassectb[0] = 0;
-			wf3->biassectb[1] = 0;
-		    } else if (tx1 > cx1 && tx1 <= tabrow.nx) {
+                /* Determine whether the subarray extends into the
+                ** physical overscan regions on either side of the chip */
+                tx1 = (int)(nx - wf3->offsetx);
+                cx1 = tabrow.nx - tabrow.trimx[1] - tabrow.trimx[0];
+                cx0 = (int)(tabrow.trimx[0] - wf3->offsetx);
 
-			/* then the subarray overlaps biassectb... */
-			wf3->trimx[0] = 0;
-			wf3->trimx[1] = tx1 - cx1;
-			wf3->biassecta[0] = 0;
-			wf3->biassecta[1] = 0;
-			wf3->biassectb[0] = tabrow.biassecta[0]-1 - cx0;
-			wf3->biassectb[1] = tabrow.biassecta[1]-1 - cx0;
-			if (wf3->biassectb[0] >= nx) {
-			    wf3->biassectb[0] = 0;
-			    wf3->biassectb[1] = 0;
-			}
-			if (wf3->biassectb[1] >= nx) wf3->biassectb[1] = nx-1;
+                if (wf3->offsetx > 0) {
+                    /* Subarray starts in the first overscan region */
+                    wf3->trimx[0] = (wf3->offsetx < tabrow.trimx[0]) ?
+                                    wf3->offsetx : tabrow.trimx[0];
+                    /* Check to see if it extends into second
+                    ** overscan region */
+                    tx2 = (int)(nx - wf3->trimx[0]) - cx1;
+                    wf3->trimx[1] = (tx2 < 0) ? 0 : tx2;
+                    wf3->biassecta[0] = (tabrow.biassecta[0]-1 - cx0 > 0) ?
+                                        (tabrow.biassecta[0]-1 - cx0) : 0;
+                    wf3->biassecta[1] = tabrow.biassecta[1]-1 - cx0;
+                    wf3->biassectb[0] = 0;
+                    wf3->biassectb[1] = 0;
+                } else if (tx1 > cx1 && tx1 <= tabrow.nx) {
 
-		    } else {
+                    /* then the subarray overlaps biassectb... */
+                    wf3->trimx[0] = 0;
+                    wf3->trimx[1] = tx1 - cx1;
+                    wf3->biassecta[0] = 0;
+                    wf3->biassecta[1] = 0;
+                    wf3->biassectb[0] = tabrow.biassecta[0]-1 - cx0;
+                    wf3->biassectb[1] = tabrow.biassecta[1]-1 - cx0;
+                    if (wf3->biassectb[0] >= nx) {
+                        wf3->biassectb[0] = 0;
+                        wf3->biassectb[1] = 0;
+                    }
+                    if (wf3->biassectb[1] >= nx) wf3->biassectb[1] = nx-1;
 
-			/* Subarray doesn't overlap either physical
-			** overscan region */
-			wf3->trimx[0] = 0;
-			wf3->trimx[1] = 0;
-			wf3->biassecta[0] = 0;
-			wf3->biassecta[1] = 0;
-			wf3->biassectb[0] = 0;
-			wf3->biassectb[1] = 0;                               
-			*overscan = NO;             
-		    }
+                } else {
 
-		} else {
+                    /* Subarray doesn't overlap either physical
+                    ** overscan region */
+                    wf3->trimx[0] = 0;
+                    wf3->trimx[1] = 0;
+                    wf3->biassecta[0] = 0;
+                    wf3->biassecta[1] = 0;
+                    wf3->biassectb[0] = 0;
+                    wf3->biassectb[1] = 0;
+                    *overscan = NO;
+                }
 
-		    /* We are working with a full chip image... */		
-		    wf3->trimx[0] = tabrow.trimx[0];
-		    wf3->trimx[1] = tabrow.trimx[1];
-		    wf3->trimx[2] = tabrow.trimx[2];
-		    wf3->trimx[3] = tabrow.trimx[3];
-		    wf3->trimy[0] = tabrow.trimy[0];
-		    wf3->trimy[1] = tabrow.trimy[1];
+            } else {
 
-		    /* Subtract one from table values to
-		    ** conform to C array indexing... */
-		    wf3->vx[0] = tabrow.vx[0]-1;
-		    wf3->vx[1] = tabrow.vx[1]-1;
-		    wf3->vx[2] = tabrow.vx[2]-1;
-		    wf3->vx[3] = tabrow.vx[3]-1;
-		    wf3->vy[0] = tabrow.vy[0]-1;
-		    wf3->vy[1] = tabrow.vy[1]-1;
-		    wf3->vy[2] = tabrow.vy[2]-1;
-		    wf3->vy[3] = tabrow.vy[3]-1;
-		    wf3->biassecta[0] = tabrow.biassecta[0] - 1;
-		    wf3->biassecta[1] = tabrow.biassecta[1] - 1;
-		    wf3->biassectb[0] = tabrow.biassectb[0] - 1;
-		    wf3->biassectb[1] = tabrow.biassectb[1] - 1;
-		    wf3->biassectc[0] = tabrow.biassectc[0] - 1;
-		    wf3->biassectc[1] = tabrow.biassectc[1] - 1;
-		    wf3->biassectd[0] = tabrow.biassectd[0] - 1;
-		    wf3->biassectd[1] = tabrow.biassectd[1] - 1;
-		}
+                /* We are working with a full chip image... */
+                wf3->trimx[0] = tabrow.trimx[0];
+                wf3->trimx[1] = tabrow.trimx[1];
+                wf3->trimx[2] = tabrow.trimx[2];
+                wf3->trimx[3] = tabrow.trimx[3];
+                wf3->trimy[0] = tabrow.trimy[0];
+                wf3->trimy[1] = tabrow.trimy[1];
 
-		break;
+                /* Subtract one from table values to
+                ** conform to C array indexing... */
+                wf3->vx[0] = tabrow.vx[0]-1;
+                wf3->vx[1] = tabrow.vx[1]-1;
+                wf3->vx[2] = tabrow.vx[2]-1;
+                wf3->vx[3] = tabrow.vx[3]-1;
+                wf3->vy[0] = tabrow.vy[0]-1;
+                wf3->vy[1] = tabrow.vy[1]-1;
+                wf3->vy[2] = tabrow.vy[2]-1;
+                wf3->vy[3] = tabrow.vy[3]-1;
+                wf3->biassecta[0] = tabrow.biassecta[0] - 1;
+                wf3->biassecta[1] = tabrow.biassecta[1] - 1;
+                wf3->biassectb[0] = tabrow.biassectb[0] - 1;
+                wf3->biassectb[1] = tabrow.biassectb[1] - 1;
+                wf3->biassectc[0] = tabrow.biassectc[0] - 1;
+                wf3->biassectc[1] = tabrow.biassectc[1] - 1;
+                wf3->biassectd[0] = tabrow.biassectd[0] - 1;
+                wf3->biassectd[1] = tabrow.biassectd[1] - 1;
+            }
 
-	    } else if (wf3->detector == IR_DETECTOR &&
-		SameString (tabrow.ccdamp, wf3->ccdamp) &&
-		SameInt (tabrow.chip, wf3->chip) &&
-		SameInt (tabrow.nx, nx) &&
-		SameInt (tabrow.ny, ny)) {
+            break;
 
-		foundit = YES;
-		*overscan = YES;             
+        } else if (wf3->detector == IR_DETECTOR &&
+                   SameString (tabrow.ccdamp, wf3->ccdamp) &&
+                   SameInt (tabrow.chip, wf3->chip) &&
+                   SameInt (tabrow.nx, nx) &&
+                   SameInt (tabrow.ny, ny)) {
 
-		/* Copy table values to local variables */
-		wf3->trimx[0] = tabrow.trimx[0];
-		wf3->trimx[1] = tabrow.trimx[1];
-		wf3->trimx[2] = tabrow.trimx[2];
-		wf3->trimx[3] = tabrow.trimx[3];
-		wf3->trimy[0] = tabrow.trimy[0];
-		wf3->trimy[1] = tabrow.trimy[1];
+            foundit = YES;
+            *overscan = YES;
 
-		/* Subtract one from table values to
-		** conform to C array indexing... */
-		wf3->vx[0] = tabrow.vx[0]-1;
-		wf3->vx[1] = tabrow.vx[1]-1;
-		wf3->vx[2] = tabrow.vx[2]-1;
-		wf3->vx[3] = tabrow.vx[3]-1;
-		wf3->vy[0] = tabrow.vy[0]-1;
-		wf3->vy[1] = tabrow.vy[1]-1;
-		wf3->vy[2] = tabrow.vy[2]-1;
-		wf3->vy[3] = tabrow.vy[3]-1;
-		wf3->biassecta[0] = tabrow.biassecta[0] - 1;
-		wf3->biassecta[1] = tabrow.biassecta[1] - 1;
-		wf3->biassectb[0] = tabrow.biassectb[0] - 1;
-		wf3->biassectb[1] = tabrow.biassectb[1] - 1;
-		wf3->biassectc[0] = tabrow.biassectc[0] - 1;
-		wf3->biassectc[1] = tabrow.biassectc[1] - 1;
-		wf3->biassectd[0] = tabrow.biassectd[0] - 1;
-		wf3->biassectd[1] = tabrow.biassectd[1] - 1;
-	    }
-	}
+            /* Copy table values to local variables */
+            wf3->trimx[0] = tabrow.trimx[0];
+            wf3->trimx[1] = tabrow.trimx[1];
+            wf3->trimx[2] = tabrow.trimx[2];
+            wf3->trimx[3] = tabrow.trimx[3];
+            wf3->trimy[0] = tabrow.trimy[0];
+            wf3->trimy[1] = tabrow.trimy[1];
 
-	if (foundit == NO) {
-	    status = ROW_NOT_FOUND;
-	    sprintf(MsgText, "Could not find appropriate row from OSCNTAB. ");
-	    trlwarn(MsgText);
-	}	
+            /* Subtract one from table values to
+            ** conform to C array indexing... */
+            wf3->vx[0] = tabrow.vx[0]-1;
+            wf3->vx[1] = tabrow.vx[1]-1;
+            wf3->vx[2] = tabrow.vx[2]-1;
+            wf3->vx[3] = tabrow.vx[3]-1;
+            wf3->vy[0] = tabrow.vy[0]-1;
+            wf3->vy[1] = tabrow.vy[1]-1;
+            wf3->vy[2] = tabrow.vy[2]-1;
+            wf3->vy[3] = tabrow.vy[3]-1;
+            wf3->biassecta[0] = tabrow.biassecta[0] - 1;
+            wf3->biassecta[1] = tabrow.biassecta[1] - 1;
+            wf3->biassectb[0] = tabrow.biassectb[0] - 1;
+            wf3->biassectb[1] = tabrow.biassectb[1] - 1;
+            wf3->biassectc[0] = tabrow.biassectc[0] - 1;
+            wf3->biassectc[1] = tabrow.biassectc[1] - 1;
+            wf3->biassectd[0] = tabrow.biassectd[0] - 1;
+            wf3->biassectd[1] = tabrow.biassectd[1] - 1;
+        }
+    }
 
-	if (CloseOverTab (&tabinfo))
-	    return(status);
-			
-	if (wf3->verbose == YES) {
-	    sprintf (MsgText, "Found trim values of: x(%d,%d,%d,%d) y(%d,%d)",
-		     wf3->trimx[0], wf3->trimx[1], wf3->trimx[2], wf3->trimx[3],
-		     wf3->trimy[0], wf3->trimy[1]);
-	    trlmessage (MsgText);
-	}
+    if (foundit == NO) {
+        status = ROW_NOT_FOUND;
+        sprintf(MsgText, "Could not find appropriate row from OSCNTAB. ");
+        trlwarn(MsgText);
+    }
 
-	return (status);
+    if (CloseOverTab (&tabinfo))
+        return(status);
+
+    if (wf3->verbose == YES) {
+        sprintf (MsgText, "Found trim values of: x(%d,%d,%d,%d) y(%d,%d)",
+                 wf3->trimx[0], wf3->trimx[1], wf3->trimx[2], wf3->trimx[3],
+                 wf3->trimy[0], wf3->trimy[1]);
+        trlmessage (MsgText);
+    }
+
+    return (status);
 }
 
 
 /* This routine opens the overscan parameters table, finds the columns that we
-   need, and gets the total number of rows in the table. 
+   need, and gets the total number of rows in the table.
 */
 
 static int OpenOverTab (char *tname, TblInfo *tabinfo) {
 
-	extern int status;
-	
-	int nocol[NUMCOLS];
-	int i, j, missing;
-	
-	char *colnames[NUMCOLS] =
-	      {"CCDAMP","CCDCHIP","BINX","BINY","NX","NY","TRIMX1","TRIMX2",
-		"TRIMX3","TRIMX4","TRIMY1","TRIMY2","VX1","VX2","VY1","VY2",
-		"VX3","VX4","VY3","VY4",
-		"BIASSECTA1","BIASSECTA2","BIASSECTB1","BIASSECTB2",
-		"BIASSECTC1","BIASSECTC2","BIASSECTD1","BIASSECTD2"};
+    extern int status;
 
-	int PrintMissingCols (int, int, int *, char **, char *, IRAFPointer);
+    int nocol[NUMCOLS];
+    int i, j, missing;
 
-	tabinfo->tp = c_tbtopn (tname, IRAF_READ_ONLY, 0);
-	if (c_iraferr()) {
-	    sprintf (MsgText, "OSCNTAB `%s' not found.", tname);
-	    trlerror (MsgText);
-	    return (status = OPEN_FAILED);
-	}
+    char *colnames[NUMCOLS] =
+    {   "CCDAMP","CCDCHIP","BINX","BINY","NX","NY","TRIMX1","TRIMX2",
+        "TRIMX3","TRIMX4","TRIMY1","TRIMY2","VX1","VX2","VY1","VY2",
+        "VX3","VX4","VY3","VY4",
+        "BIASSECTA1","BIASSECTA2","BIASSECTB1","BIASSECTB2",
+        "BIASSECTC1","BIASSECTC2","BIASSECTD1","BIASSECTD2"
+    };
 
-	tabinfo->nrows = c_tbpsta (tabinfo->tp, TBL_NROWS);
+    int PrintMissingCols (int, int, int *, char **, char *, IRAFPointer);
 
-	for (j = 0; j < NUMCOLS; j++)
-	     nocol[j] = NO;
-	
-	/* Find the columns. */
-	c_tbcfnd1 (tabinfo->tp, "CCDAMP", &tabinfo->cp_amp);
-	c_tbcfnd1 (tabinfo->tp, "CCDCHIP", &tabinfo->cp_chip);
-	c_tbcfnd1 (tabinfo->tp, "BINX", &tabinfo->cp_binx);
-	c_tbcfnd1 (tabinfo->tp, "BINY", &tabinfo->cp_biny);	
-	c_tbcfnd1 (tabinfo->tp, "NX", &tabinfo->cp_nx);
-	c_tbcfnd1 (tabinfo->tp, "NY", &tabinfo->cp_ny);	
-	c_tbcfnd1 (tabinfo->tp, "TRIMX1", &tabinfo->cp_trimx1);
-	c_tbcfnd1 (tabinfo->tp, "TRIMX2", &tabinfo->cp_trimx2);
-	c_tbcfnd1 (tabinfo->tp, "TRIMX3", &tabinfo->cp_trimx3);
-	c_tbcfnd1 (tabinfo->tp, "TRIMX4", &tabinfo->cp_trimx4);
-	c_tbcfnd1 (tabinfo->tp, "TRIMY1", &tabinfo->cp_trimy1);
-	c_tbcfnd1 (tabinfo->tp, "TRIMY2", &tabinfo->cp_trimy2);	
-	c_tbcfnd1 (tabinfo->tp, "VX1", &tabinfo->cp_vx1);
-	c_tbcfnd1 (tabinfo->tp, "VX2", &tabinfo->cp_vx2);
-	c_tbcfnd1 (tabinfo->tp, "VX3", &tabinfo->cp_vx3);
-	c_tbcfnd1 (tabinfo->tp, "VX4", &tabinfo->cp_vx4);
-	c_tbcfnd1 (tabinfo->tp, "VY1", &tabinfo->cp_vy1);	
-	c_tbcfnd1 (tabinfo->tp, "VY2", &tabinfo->cp_vy2);
-	c_tbcfnd1 (tabinfo->tp, "VY3", &tabinfo->cp_vy3);	
-	c_tbcfnd1 (tabinfo->tp, "VY4", &tabinfo->cp_vy4);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTA1", &tabinfo->cp_biassecta1);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTA2", &tabinfo->cp_biassecta2);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTB1", &tabinfo->cp_biassectb1);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTB2", &tabinfo->cp_biassectb2);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTC1", &tabinfo->cp_biassectc1);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTC2", &tabinfo->cp_biassectc2);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTD1", &tabinfo->cp_biassectd1);
-	c_tbcfnd1 (tabinfo->tp, "BIASSECTD2", &tabinfo->cp_biassectd2);
+    tabinfo->tp = c_tbtopn (tname, IRAF_READ_ONLY, 0);
+    if (c_iraferr()) {
+        sprintf (MsgText, "OSCNTAB `%s' not found.", tname);
+        trlerror (MsgText);
+        return (status = OPEN_FAILED);
+    }
 
-	/* Check which columns are missing */
-	i=0; missing = 0;
-	if (tabinfo->cp_amp == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_chip == 0)       { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_binx == 0)       { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biny == 0)       { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_nx == 0)         { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_ny == 0)         { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vx1 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vx2 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vx3 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vx4 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vy1 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vy2 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vy3 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_vy4 == 0)        { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_trimx1 == 0)     { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_trimx2 == 0)     { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_trimx3 == 0)     { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_trimx4 == 0)     { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_trimy1 == 0)     { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_trimy2 == 0)     { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassecta1 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassecta2 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassectb1 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassectb2 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassectc1 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassectc2 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassectd1 == 0) { missing++; nocol[i] = YES; i++;}
-	if (tabinfo->cp_biassectd2 == 0) { missing++; nocol[i] = YES; i++;}
+    tabinfo->nrows = c_tbpsta (tabinfo->tp, TBL_NROWS);
 
-	if (PrintMissingCols (missing, NUMCOLS, nocol, colnames, "OSCNTAB",
-			      tabinfo->tp))
-	    return(status);
+    for (j = 0; j < NUMCOLS; j++)
+        nocol[j] = NO;
 
-	return (status);
+    /* Find the columns. */
+    c_tbcfnd1 (tabinfo->tp, "CCDAMP", &tabinfo->cp_amp);
+    c_tbcfnd1 (tabinfo->tp, "CCDCHIP", &tabinfo->cp_chip);
+    c_tbcfnd1 (tabinfo->tp, "BINX", &tabinfo->cp_binx);
+    c_tbcfnd1 (tabinfo->tp, "BINY", &tabinfo->cp_biny);
+    c_tbcfnd1 (tabinfo->tp, "NX", &tabinfo->cp_nx);
+    c_tbcfnd1 (tabinfo->tp, "NY", &tabinfo->cp_ny);
+    c_tbcfnd1 (tabinfo->tp, "TRIMX1", &tabinfo->cp_trimx1);
+    c_tbcfnd1 (tabinfo->tp, "TRIMX2", &tabinfo->cp_trimx2);
+    c_tbcfnd1 (tabinfo->tp, "TRIMX3", &tabinfo->cp_trimx3);
+    c_tbcfnd1 (tabinfo->tp, "TRIMX4", &tabinfo->cp_trimx4);
+    c_tbcfnd1 (tabinfo->tp, "TRIMY1", &tabinfo->cp_trimy1);
+    c_tbcfnd1 (tabinfo->tp, "TRIMY2", &tabinfo->cp_trimy2);
+    c_tbcfnd1 (tabinfo->tp, "VX1", &tabinfo->cp_vx1);
+    c_tbcfnd1 (tabinfo->tp, "VX2", &tabinfo->cp_vx2);
+    c_tbcfnd1 (tabinfo->tp, "VX3", &tabinfo->cp_vx3);
+    c_tbcfnd1 (tabinfo->tp, "VX4", &tabinfo->cp_vx4);
+    c_tbcfnd1 (tabinfo->tp, "VY1", &tabinfo->cp_vy1);
+    c_tbcfnd1 (tabinfo->tp, "VY2", &tabinfo->cp_vy2);
+    c_tbcfnd1 (tabinfo->tp, "VY3", &tabinfo->cp_vy3);
+    c_tbcfnd1 (tabinfo->tp, "VY4", &tabinfo->cp_vy4);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTA1", &tabinfo->cp_biassecta1);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTA2", &tabinfo->cp_biassecta2);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTB1", &tabinfo->cp_biassectb1);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTB2", &tabinfo->cp_biassectb2);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTC1", &tabinfo->cp_biassectc1);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTC2", &tabinfo->cp_biassectc2);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTD1", &tabinfo->cp_biassectd1);
+    c_tbcfnd1 (tabinfo->tp, "BIASSECTD2", &tabinfo->cp_biassectd2);
+
+    /* Check which columns are missing */
+    i=0;
+    missing = 0;
+    if (tabinfo->cp_amp == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_chip == 0)       {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_binx == 0)       {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biny == 0)       {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_nx == 0)         {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_ny == 0)         {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vx1 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vx2 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vx3 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vx4 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vy1 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vy2 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vy3 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_vy4 == 0)        {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_trimx1 == 0)     {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_trimx2 == 0)     {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_trimx3 == 0)     {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_trimx4 == 0)     {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_trimy1 == 0)     {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_trimy2 == 0)     {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassecta1 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassecta2 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassectb1 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassectb2 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassectc1 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassectc2 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassectd1 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+    if (tabinfo->cp_biassectd2 == 0) {
+        missing++;
+        nocol[i] = YES;
+        i++;
+    }
+
+    if (PrintMissingCols (missing, NUMCOLS, nocol, colnames, "OSCNTAB",
+                          tabinfo->tp))
+        return(status);
+
+    return (status);
 }
 
-/* This routine reads the relevant data from one row. 
+/* This routine reads the relevant data from one row.
 	It reads the amp configuration, chip number, binning factors,
 	and x/y size of the image for selecting the row appropriate
 	for the data.  It also reads the trim regions, virtual overscan
@@ -461,125 +583,125 @@ static int OpenOverTab (char *tname, TblInfo *tabinfo) {
 
 static int ReadOverTab (TblInfo *tabinfo, int row, TblRow *tabrow) {
 
-	extern int status;
+    extern int status;
 
-	c_tbegtt (tabinfo->tp, tabinfo->cp_amp, row, tabrow->ccdamp, SZ_CBUF);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegtt (tabinfo->tp, tabinfo->cp_amp, row, tabrow->ccdamp, SZ_CBUF);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_chip, row, &tabrow->chip);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-		
-	c_tbegti (tabinfo->tp, tabinfo->cp_binx, row, &tabrow->bin[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);		
-	c_tbegti (tabinfo->tp, tabinfo->cp_biny, row, &tabrow->bin[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-		
-	c_tbegti (tabinfo->tp, tabinfo->cp_nx, row, &tabrow->nx);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);	
-	c_tbegti (tabinfo->tp, tabinfo->cp_ny, row, &tabrow->ny);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_chip, row, &tabrow->chip);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_trimx1, row, &tabrow->trimx[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_trimx2, row, &tabrow->trimx[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_trimx3, row, &tabrow->trimx[2]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_trimx4, row, &tabrow->trimx[3]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_trimy1, row, &tabrow->trimy[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_trimy2, row, &tabrow->trimy[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_binx, row, &tabrow->bin[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biny, row, &tabrow->bin[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_vx1, row, &tabrow->vx[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vx2, row, &tabrow->vx[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vx3, row, &tabrow->vx[2]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vx4, row, &tabrow->vx[3]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vy1, row, &tabrow->vy[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vy2, row, &tabrow->vy[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vy3, row, &tabrow->vy[2]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	c_tbegti (tabinfo->tp, tabinfo->cp_vy4, row, &tabrow->vy[3]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_nx, row, &tabrow->nx);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_ny, row, &tabrow->ny);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassecta1, row,
-		  &tabrow->biassecta[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_trimx1, row, &tabrow->trimx[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_trimx2, row, &tabrow->trimx[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_trimx3, row, &tabrow->trimx[2]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_trimx4, row, &tabrow->trimx[3]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_trimy1, row, &tabrow->trimy[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_trimy2, row, &tabrow->trimy[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassecta2, row,
-		  &tabrow->biassecta[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vx1, row, &tabrow->vx[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vx2, row, &tabrow->vx[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vx3, row, &tabrow->vx[2]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vx4, row, &tabrow->vx[3]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vy1, row, &tabrow->vy[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vy2, row, &tabrow->vy[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vy3, row, &tabrow->vy[2]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_vy4, row, &tabrow->vy[3]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassectb1, row,
-		  &tabrow->biassectb[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassecta1, row,
+              &tabrow->biassecta[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassectb2, row,
-		  &tabrow->biassectb[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassecta2, row,
+              &tabrow->biassecta[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassectc1, row,
-		  &tabrow->biassectc[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassectb1, row,
+              &tabrow->biassectb[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassectc2, row,
-		  &tabrow->biassectc[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassectb2, row,
+              &tabrow->biassectb[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassectd1, row,
-		  &tabrow->biassectd[0]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassectc1, row,
+              &tabrow->biassectc[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	c_tbegti (tabinfo->tp, tabinfo->cp_biassectd2, row,
-		  &tabrow->biassectd[1]);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
-	return (status);
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassectc2, row,
+              &tabrow->biassectc[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassectd1, row,
+              &tabrow->biassectd[0]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+
+    c_tbegti (tabinfo->tp, tabinfo->cp_biassectd2, row,
+              &tabrow->biassectd[1]);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
+    return (status);
 }
 
 /* This routine closes the oscn table. */
 
 static int CloseOverTab (TblInfo *tabinfo) {
 
-	extern int status;
+    extern int status;
 
-	c_tbtclo (tabinfo->tp);
-	if (c_iraferr())
-	    return (status = TABLE_ERROR);
+    c_tbtclo (tabinfo->tp);
+    if (c_iraferr())
+        return (status = TABLE_ERROR);
 
-	return (status);
+    return (status);
 }


### PR DESCRIPTION
The WFC3 team realized the new way of flagging full-well saturated data using an image after the BLEVCORR/BIASCORR steps and the old way of flagging the data in DQICORR needed to be reconciled to account properly for any pixels which should have been flagged in the overscan regions. The overscan regions are trimmed in BLEVCORR/BIASCORR. The changes incorporated by the PR address this issue.

1. The ComputeLimits function has been pulled from being a part of the dofwsat.c file to be its own file, /lib/computelimits.c, so it is available to other files.
2. wscript file has been updated to include the new computelimits.c file.
3. The findover.c file was reformatted as it was too difficult to trace through the code and understand the flow. There were no actual code changes.
4. A parameter (int overscan) has been added to the API of doDQi.

- doccd.c/doccd.h changed to accommodate the doDQI change.
- do2d.c changed to accommodate the doDQI change.