### PR TITLE
HLA-1178:  Garbled text reported in trailer file causes failure in Cloud processinge

### DIFF
--- a/pkg/acs/calacs/acs2d/do2d.c
+++ b/pkg/acs/calacs/acs2d/do2d.c
@@ -508,11 +508,11 @@ static void FlatMsg (ACSInfo *acs2d, int extver) {
                  acs2d->lflt.pedigree, acs2d->lflt.descrip, "");
     }
     if (GotFileName (acs2d->cflt.name)) {		/* coronagraphic flat */
-      PrRefInfo ("cfltfile", acs2d->cflt.name,
-                 acs2d->cflt.pedigree, acs2d->cflt.descrip, "");
-      /* spot position table */
-	    PrRefInfo ("spottab", acs2d->spot.name, acs2d->spot.pedigree,
-                 acs2d->spot.descrip, acs2d->spot.descrip2);
+        PrRefInfo ("cfltfile", acs2d->cflt.name,
+            acs2d->cflt.pedigree, acs2d->cflt.descrip, "");
+        /* spot position table */
+        PrRefInfo ("spottab", acs2d->spot.name, acs2d->spot.pedigree,
+            acs2d->spot.descrip, acs2d->spot.descrip2);
     }
 	}
 }

--- a/pkg/acs/calacs/lib/acsinfo.c
+++ b/pkg/acs/calacs/lib/acsinfo.c
@@ -15,6 +15,7 @@
    29-Apr-2020 MDD - Added overhead for atod_saturate value.
    11-May-2020 MDD - Added variable, satmap - the reference image for full-well saturation.
                      Use of this image renders acs->saturate variable OBSOLETE.
+   11-Jan-2024 MDD - Added "InitRefTab(&(acs->spot))" which has been missing for all this time.
 */
 #include <string.h>
 
@@ -148,6 +149,7 @@ void ACSInit (ACSInfo *acs) {
     InitRefImg (&(acs->shad));
     InitRefTab (&(acs->mlin));
     InitRefTab (&(acs->phot));
+    InitRefTab (&(acs->spot));
 }
 
 


### PR DESCRIPTION
Addressed Jira Ticket: HLA-1178

Fixed the bug where the structure associated with the SPOTTAB variables was not initialized.  Also, fixed the issue where the PEDIGREE and DESCRIP keywords were deliberately being read from the wrong HDU.  Only in the case of tabular reference files were the mentioned keywords being read from the wrong HDU.  Fixed so the keywords are now being read from the primary HDU and properly logged to the trailer file.