### PR TITLE
CloseTrlBuf: Prevent testing for empty message when buf->buffer is NULL

### DIFF
--- a/lib/trlbuf.c
+++ b/lib/trlbuf.c
@@ -601,7 +601,7 @@ void CloseTrlBuf (struct TrlBuf * buf)
     FILE *ofp;
 
     /* Do we have any messages which need to be written out? */
-    if (buf->buffer[0] != '\0') {
+    if (buf->buffer && buf->buffer[0] != '\0') {
         /* We do, so open last known trailer file and
             append these messages to that file...
         */


### PR DESCRIPTION
Reported by @mdlpstsci

```
End      13-Feb-2024 17:18:56 EST

*** WF3CCD complete ***

 

End      13-Feb-2024 17:18:58 EST

*** CALWF3 complete ***

CALWF3 completion for some_file.fits

Segmentation fault: 11
```

Trace session

```shell
lldb -- calwf3.e some_file.fits
```

```gdb
(lldb) r
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000010048a750 libhstcalib.dylib`CloseTrlBuf(buf=0x0000000100008190) at trlbuf.c:606:9
   603 	    FILE *ofp;
   604
   605 	    /* Do we have any messages which need to be written out? */
-> 606 	    if (buf->buffer[0] != '\0') {
   607 	        /* We do, so open last known trailer file and
   608 	            append these messages to that file...
   609 	        */
Target 0: (calwf3.e) stopped.

# Frame Variables

(lldb) v
(TrlBuf *) buf = 0x0000000100008190
(FILE *) ofp = 0xffffffffffffffff

# Contents of buf

(lldb) p *buf
(TrlBuf) {
  overwrite = 0
  quiet = 0
  usepref = 0
  init = 0
  buffer = 0x0000000000000000
  preface = 0x0000000000000000
  trlfile = ""
  fp = NULL
}
```