### PR TITLE
MNT: Bump checkout version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
         gcc: [12]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Linux dependencies
       if: matrix.os == 'ubuntu-latest'
@@ -69,4 +69,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-


### PR DESCRIPTION
Looks like your workflow using outdated checkout.

Ehem, @jhunkeler , where is the matrix for OSX ARM?

* https://github.com/actions/runner-images/issues/9254