### PR TITLE
Revert commit 0276e46 as it was pushed prematurely

### DIFF
--- a/pkg/wfc3/Dates
+++ b/pkg/wfc3/Dates
@@ -1,8 +1,3 @@
-15-Apr-2024 - MDD = Version 3.7.2
-    - Allow MJD as a parameterized variable for the PHOTMODE keyword to
-      enable a time-dependent photometric correction for the IR detector.
-      This supplements the change done for the UVIS in 2020 (Version 3.5.2).
-
 18-Oct-2023 - MDD - Version 3.7.1
     - Updates to reconcile the old and new algorithms for flagging full-well saturated pixels.  
       The new algorithm uses a saturation image which is applied after BLECORR/BIASCORR, and

--- a/pkg/wfc3/History
+++ b/pkg/wfc3/History
@@ -1,8 +1,3 @@
-### 15-Apr-2024 - MDD - Version 3.7.2
-    - Allow MJD as a parameterized variable for the PHOTMODE keyword to
-      enable a time-dependent photometric correction for the IR detector.
-      This supplements the change done for the UVIS in 2020 (Version 3.5.2).
-
 ### 18-Oct-2023 - MDD - Version 3.7.1
     - Updates to reconcile the old and new algorithms for flagging full-well saturated pixels.  
       The new algorithm uses a saturation image which is applied after BLECORR/BIASCORR, and

--- a/pkg/wfc3/Updates
+++ b/pkg/wfc3/Updates
@@ -1,8 +1,3 @@
-Updates for Version 3.7.2 15-Apr-2024 - MDD
-    - Allow MJD as a parameterized variable for the PHOTMODE keyword to
-      enable a time-dependent photometric correction for the IR detector.
-      This supplements the change done for the UVIS in 2020 (Version 3.5.2).
-
 Updates for Version 3.7.1 18-Oct-2023 - MDD
     - Updates to reconcile the old and new algorithms for flagging full-well saturated pixels.  
       The new algorithm uses a saturation image which is applied after BLECORR/BIASCORR, and

--- a/pkg/wfc3/include/wf3version.h
+++ b/pkg/wfc3/include/wf3version.h
@@ -4,7 +4,7 @@
 /* This string is written to the output primary header as CAL_VER. */
 
 
-# define WF3_CAL_VER "3.7.2 (Apr-15-2024)"
-# define WF3_CAL_VER_NUM "3.7.2"
+# define WF3_CAL_VER "3.7.1 (Oct-18-2023)"
+# define WF3_CAL_VER_NUM "3.7.1"
 
 #endif /* INCL_WF3VERSION_H */

--- a/pkg/wfc3/lib/wf32d/photmode.c
+++ b/pkg/wfc3/lib/wf32d/photmode.c
@@ -39,10 +39,6 @@
 	for IR exposures because they're now in units of electrons.
    M.De La Pena, 2020 Feb 28:
     Added MJD in order to enable a time-dependent photometric correction.
-   M.De La Pena, 2024 Apr 15:
-    Allow the 'MJD#' value to be added to the PHOTMODE keyword in order to 
-    enable a time-dependent photometric correction for the IR.  This supplements 
-    the change done previously for the UVIS in 2020.
 */
 
 int PhotMode (WF3Info *wf32d, Hdr *hdr) {
@@ -82,10 +78,10 @@ Hdr *hdr	io: image header to be modified
 	    strcat (photstr, wf32d->filter);
 	}
 
-	/* Update: Add 'MJD#' value to the PHOTMODE string for both the 
-		UVIS and IR detectors */
-	sprintf (scratch, " MJD#%0.4f", wf32d->expstart);
-	strcat (photstr, scratch);
+    /* Add 'MJD#' keyword to PHOTMODE string for UVIS detector only */
+	if (wf32d->detector == CCD_DETECTOR)
+        sprintf (scratch, " MJD#%0.4f", wf32d->expstart);
+        strcat (photstr, scratch);
 
 	if (wf32d->verbose) {
 	    sprintf (MsgText, "Keyword PHOTMODE built as: %s", photstr);


### PR DESCRIPTION
This commit was pushed to main prematurely, and the repository is now being prepared for a build.

Revert "WIP: HLA-1036: An 'MJD#' value is added to the PHOTMODE keyword in the PHDU (#612)"

This reverts commit 0276e46c51512eb4969a86004642c8bb2add703e.