### PR TITLE
Move test dependency installation to test_cmds list

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -37,13 +37,13 @@ bc.conda_packages = ['python=3.9',
                      'cmake']
 
 bc.build_cmds = ["${configure_cmd} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=\$CONDA_PREFIX",
-                  "make",
-                  "make install",
-                  "calacs.e --version",
-                  "calwf3.e --version",
-                  "cs0.e --version",
-                  "pip install pytest ci-watson"]
-bc.test_cmds = ["pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
+                 "make",
+                 "make install",
+                 "calacs.e --version",
+                 "calwf3.e --version",
+                 "cs0.e --version"]
+bc.test_cmds = ["pip install pytest ci-watson",
+                "pytest tests --basetemp=tests_output --junitxml results.xml --bigdata --slow -v"]
 bc.failedUnstableThresh = 1
 bc.failedFailureThresh = 6
 
@@ -60,12 +60,12 @@ bc1.env_vars += ['LDFLAGS=-L/usr/local/opt/libomp/lib -Wl,-rpath,/usr/local/opt/
                  'CXX=/usr/local/bin/g++-13',
                  'FC=/usr/local/bin/gfortran-13']
 bc1.conda_packages = ['python=3.9',
-                     'bzip2',
-                     'cfitsio',
-                     'pkg-config',
-                     'astropy',
-                     'cmake']
-bc1.test_cmds[0] = "pytest tests --basetemp=tests_output --junitxml results.xml -v"
+                      'bzip2',
+                      'cfitsio',
+                      'pkg-config',
+                      'astropy',
+                      'cmake']
+bc1.test_cmds[1] = "pytest tests --basetemp=tests_output --junitxml results.xml -v"
 bc1.test_configs = []
 
 // Iterate over configurations that define the (distributed) build matrix.


### PR DESCRIPTION
This change avoids the following error produced by the delivery system when `hstcal` is tested _before_ any Python packages have been installed.

```
FileNotFoundError: [Errno 2] No such file or directory: 'pytest'
script returned exit code 1
```