### PR TITLE
Update call to download_crds() to accommodate new function signature

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -231,7 +231,7 @@ class BaseCal:
                         os.environ[var] = ref_path  # hacky hack hack
 
                 # Download reference files, if needed only.
-                download_crds(ref_file, timeout=self.timeout)
+                download_crds(ref_file)
 
     def compare_outputs(self, outputs, atol=0, rtol=1e-7, raise_error=True,
                         ignore_keywords_overwrite=None, verbose=True):


### PR DESCRIPTION
The helpers.py module uses **ci-watson** utilities to assist in the functionality of the **hstcal** PyTests.  A new version of **ci-watson** was released to PyPi today (09 July 2024), and the function signature of download_crds() has changed.  This PR addresses this change.