### PR TITLE
Fixed bug for gcc 14.1+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(WITH_CFITSIO "" CACHE STRING "Path to cfitsio (if empty pkg-config is used)"
 set(WITH_CFITSIO_CFLAGS "" CACHE STRING "CFITSIO compiler flags")
 set(WITH_CFITSIO_LDFLAGS "-lcfitsio" CACHE STRING "CFITSIO linker flags")
 
+# Add the -fpermissive flag
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpermissive")
 
 # Use git to set package version
 # Caveat: unix-only


### PR DESCRIPTION
Hello everyone,

It is my first time trying to change something on a github repository that I do now own, so I am not sure if forking it and then making a pull request is the way to go so sorry about that part.

So, in Source Installation, it says that you need to have "gcc >=4.4.7" but there is an issue with it now. In the newest version which is 14.1+ , the GCC compiler no longer tolerates some errors and thus it terminates the installation when using "make" (https://gcc.gnu.org/gcc-14/porting_to.html#c). The only way to bypass it is to add the following line on the CMakeList.txt : 

# Add the -fpermissive flag
set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpermissive")

After doing that, I managed to finish the installation and check that the executables were running fine. If there is something else that I need to mention or do please tell me!

I have attached an image of the error that I was getting.

![Screenshot_20240721_213553](https://github.com/user-attachments/assets/b96abce8-186f-4b78-8517-eb17c5b58072)



