### PR TITLE
ACS: Fix incompatible pointer types

### DIFF
--- a/pkg/acs/lib/getacskeys.c
+++ b/pkg/acs/lib/getacskeys.c
@@ -77,7 +77,7 @@ int getACSKeys (ACSInfo *acs, Hdr *phdr) {
     if (GetKeyInt (phdr, "NEXTEND", USE_DEFAULT, EXT_PER_GROUP, &acs->nextend))
         return (status);
 
-	if (GetKeyBool (phdr, "SUBARRAY", NO_DEFAULT, 0, &acs->subarray))
+	if (GetKeyInt (phdr, "SUBARRAY", NO_DEFAULT, 0, &acs->subarray))
 	  return (status);
   
 	/* Get CCD-specific parameters. */
@@ -145,9 +145,9 @@ int checkACSKeys(ACSInfo *acs)
         return INVALID_EXPTIME;
     }
 
-    upperCase(&acs->aperture);
-    upperCase(&acs->jwrotype);
-    upperCase(&acs->flashstatus);
+    upperCase(acs->aperture);
+    upperCase(acs->jwrotype);
+    upperCase(acs->flashstatus);
 
     // Convert number of extensions to number of SingleGroups.
     // NOTE: this is technically incorrect and instead findTotalNumberOfImsets()
@@ -163,7 +163,7 @@ int checkACSKeys(ACSInfo *acs)
     /* Get CCD-specific parameters. */
     if (acs->detector != MAMA_DETECTOR)
     {
-        upperCase(&acs->ccdamp);
+        upperCase(acs->ccdamp);
         /* Verify that only the letters 'ABCD' are in the string. */
         const char * ampAlphabet = "ABCD";
         if (!isStrInLanguage(acs->ccdamp, ampAlphabet))


### PR DESCRIPTION
See #618 

```c
[..]/hstcal/pkg/acs/lib/getacskeys.c:80:61: error: passing argument 5 of ‘GetKeyBool’ makes pointer from integer without a cast [-Wint-conversion]
   80 |         if (GetKeyBool (phdr, "SUBARRAY", NO_DEFAULT, 0, &acs->subarray))
      |                                                          ~~~^~~~~~~~~~
      |                                                             |
      |                                                             int
[..]/hstcal/pkg/acs/lib/getacskeys.c: In function ‘checkACSKeys’:
[..]/hstcal/pkg/acs/lib/getacskeys.c:148:15: error: passing argument 1 of ‘upperCase’ from incompatible pointer type [-Wincompatible-pointer-types]
  148 |     upperCase(&acs->aperture);
      |               ^~~~~~~~~~~~~~
      |               |
      |               char (*)[25]
In file included from [..]/hstcal/pkg/acs/lib/getacskeys.c:11:
[..]/hstcal/include/str_util.h:6:23: note: expected ‘char *’ but argument is of type ‘char (*)[25]’
    6 | void upperCase(char * str);
      |                ~~~~~~~^~~
[..]/hstcal/pkg/acs/lib/getacskeys.c:149:15: error: passing argument 1 of ‘upperCase’ from incompatible pointer type [-Wincompatible-pointer-types]
  149 |     upperCase(&acs->jwrotype);
      |               ^~~~~~~~~~~~~~
      |               |
      |               char (*)[25]
[..]/hstcal/include/str_util.h:6:23: note: expected ‘char *’ but argument is of type ‘char (*)[25]’
    6 | void upperCase(char * str);
      |                ~~~~~~~^~~
[..]/hstcal/pkg/acs/lib/getacskeys.c:150:15: error: passing argument 1 of ‘upperCase’ from incompatible pointer type [-Wincompatible-pointer-types]
  150 |     upperCase(&acs->flashstatus);
      |               ^~~~~~~~~~~~~~~~~
      |               |
      |               char (*)[25]
[..]/hstcal/include/str_util.h:6:23: note: expected ‘char *’ but argument is of type ‘char (*)[25]’
    6 | void upperCase(char * str);
      |                ~~~~~~~^~~
[..]/hstcal/pkg/acs/lib/getacskeys.c:166:19: error: passing argument 1 of ‘upperCase’ from incompatible pointer type [-Wincompatible-pointer-types]
  166 |         upperCase(&acs->ccdamp);
      |                   ^~~~~~~~~~~~
      |                   |
      |                   char (*)[5]
[..]/hstcal/include/str_util.h:6:23: note: expected ‘char *’ but argument is of type ‘char (*)[5]’
    6 | void upperCase(char * str);
      |                ~~~~~~~^~~
```