### PR TITLE
Restore acscteforwardmodel.e hardlink to acscte.e

### DIFF
--- a/pkg/acs/CMakeLists.txt
+++ b/pkg/acs/CMakeLists.txt
@@ -51,23 +51,14 @@ install(TARGETS ${PROJECT_NAME}
 	DESTINATION bin
 )
 
-
-#project(acscteforwardmodel)
-#add_executable(${PROJECT_NAME}
-#	src/mainacscteforwardmodel.c
-#)
-#target_include_directories(${PROJECT_NAME}
-#	PUBLIC ${HSTCAL_include}
-#	PUBLIC ${PROJECT_NAME}/../include
-#)
-#target_link_libraries(${PROJECT_NAME}
-#	PUBLIC acs
-#	PUBLIC ctegen2
-#	PUBLIC hstcalib
-#)
-#install(TARGETS ${PROJECT_NAME}
-#	DESTINATION bin
-#)
+# Handle acscteforwardmodel.e link creation
+add_custom_target(${PROJECT_NAME}forwardmodel ALL
+	COMMAND ${CMAKE_COMMAND} -E create_hardlink ${PROJECT_NAME}.e ${PROJECT_NAME}forwardmodel.e
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}forwardmodel.e
+	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+	DESTINATION bin
+)
 
 
 project(acsrej)


### PR DESCRIPTION
The link wrapper for `acscteforwardmodel.e` was lost when I ported hstcal from WAF to CMake.

The wrapper is used by the following code:
https://github.com/spacetelescope/hstcal/blob/main/pkg/acs/lib/acscte/domaincte.c#L155-L157

My apologies, @mdlpstsci!