### PR TITLE
Add pllim as ACS codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # automatically requests pull request reviews for files matching the given pattern; the last match takes precendence
 
 *       @spacetelescope/ssb-hstcal-maintainers
+* pkg/acs @pllim


### PR DESCRIPTION
Alternative is to add me to https://github.com/orgs/spacetelescope/teams/ssb-hstcal-maintainers . Not sure how much power you want to give me. 😆 

p.s. Ooops, forgot to skip CI, my bad.