### PR TITLE
TST: Cancel duplicate workflow runs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release


### PR DESCRIPTION
This is so commit spam won't result in long CI queue.

CI failure unrelated: https://github.com/spacetelescope/hstcal/issues/631