### PR TITLE
allocAsnInfo: Allocate the product array using the number of products

### DIFF
--- a/pkg/acs/lib/calacs/acstable.c
+++ b/pkg/acs/lib/calacs/acstable.c
@@ -954,7 +954,7 @@ int allocAsnInfo (AsnInfo *asn, int numsp, int *spmems) {
 
     /* Allocate the member structures */
     asn->spmems = (int *)calloc(numsp+1,sizeof(int));
-    asn->product = (ProdInfo *)calloc(1,sizeof(ProdInfo ));
+    asn->product = (ProdInfo *)calloc(asn->numprod+1,sizeof(ProdInfo));
 
     /* Initialize each member structure */
     for (i=0; i < asn->numprod; i++) {


### PR DESCRIPTION
* Fixes invalid heap access when `asn->numprod` is `>1`

```
../tests/acs/test_hrc.py::TestMosaic::test_4point_mosaic git tag: 3.1.0-10-g5c16e365-dirty
git branch: sprintf-to-snprintf
HEAD @: 5c16e365655e32b193c28192403af69788e4e8bf
Setting max threads to 16 out of 16 available


CALBEG*** CALACS -- Version 10.4.0 (07-May-2024) ***
Begin    18-Apr-2025 10:45:28 EDT


Input    j6m901020_asn.fits
Processing FULL ASN table...
LoadAsn:  Processing FULL Association
Trying to open j6m901020_asn.fits...
Read in Primary header from j6m901020_asn.fits...
=================================================================
==782080==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x516000000434 at pc 0x7b584bb69cd2 bp 0x7ffd8fdf6820 sp 0x7ffd8fdf6810
WRITE of size 4 at 0x516000000434 thread T0
    #0 0x7b584bb69cd1 in GetAsnTable **/hstcal/pkg/acs/lib/calacs/acstable.c:774
    #1 0x7b584bb66232 in LoadAsn **/hstcal/pkg/acs/lib/calacs/acstable.c:104
    #2 0x7b584bb706f1 in CalAcsRun **/hstcal/pkg/acs/lib/calacs/calacs.c:155
    #3 0x592eeab1f3ec in main **/hstcal/pkg/acs/src/mainacs.c:235
    #4 0x7b584b435487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #5 0x7b584b43554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #6 0x592eeab1e284 in _start (**/hstcal/cmake-build-debug/_install/usr/local/bin/calacs.e+0x2284) (BuildId: 36831fbcecaaf884e46a2844420628c6a41ddcec)

0x516000000434 is located 340 bytes after 608-byte region [0x516000000080,0x5160000002e0)
allocated by thread T0 here:
    #0 0x7b584bcfd02a in calloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7b584bb6c282 in allocAsnInfo **/hstcal/pkg/acs/lib/calacs/acstable.c:957
    #2 0x7b584bb69be4 in GetAsnTable **/hstcal/pkg/acs/lib/calacs/acstable.c:770
    #3 0x7b584bb66232 in LoadAsn **/hstcal/pkg/acs/lib/calacs/acstable.c:104
    #4 0x7b584bb706f1 in CalAcsRun **/hstcal/pkg/acs/lib/calacs/calacs.c:155
    #5 0x592eeab1f3ec in main **/hstcal/pkg/acs/src/mainacs.c:235
    #6 0x7b584b435487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #7 0x7b584b43554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #8 0x592eeab1e284 in _start (**/hstcal/cmake-build-debug/_install/usr/local/bin/calacs.e+0x2284) (BuildId: 36831fbcecaaf884e46a2844420628c6a41ddcec)

SUMMARY: AddressSanitizer: heap-buffer-overflow **/hstcal/pkg/acs/lib/calacs/acstable.c:774 in GetAsnTable
Shadow bytes around the buggy address:
  0x516000000180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x516000000200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x516000000280: 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa
  0x516000000300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x516000000380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x516000000400: fa fa fa fa fa fa[fa]fa fa fa fa fa fa fa fa fa
  0x516000000480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x516000000500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x516000000580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x516000000600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x516000000680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==782080==ABORTING
FAILED
```