### PR TITLE
allocSingleGroupHeader: Allocate size of the struct, not the pointer

### DIFF
--- a/hstio/hstio.c
+++ b/hstio/hstio.c
@@ -991,9 +991,9 @@ int allocSingleGroupHeader(Hdr ** hdr, Bool zeroInitialize)
         return 0; //Already allocated
 
     if (zeroInitialize)
-        *hdr = calloc(1,sizeof(*hdr));
+        *hdr = calloc(1,sizeof(**hdr));
     else
-        *hdr = malloc(sizeof(*hdr));
+        *hdr = malloc(sizeof(**hdr));
 
     if (!*hdr)
         return ALLOCATION_PROBLEM;


### PR DESCRIPTION
```
warning: allocation of insufficient size ‘8’ for type ‘Hdr’ with size ‘16’ [-Walloc-size]
```

```
*** ACSCCD complete ***


CALBEG*** ACS2D -- Version 10.4.0 (07-May-2024) ***
Begin    18-Apr-2025 11:46:34 EDT
Input    j6m901bzq_blv_tmp.fits
Output   j6m901bzq_flt.fits
Trying to open j6m901bzq_blv_tmp.fits...
Read in Primary header from j6m901bzq_blv_tmp.fits...
APERTURE HRC
FILTER1 F850LP
FILTER2 CLEAR2S
DETECTOR HRC
Processing 1 IMSETs... 


Imset 1  Begin 11:46:34 EDT


CCDTAB   44h17142j_ccd.fits
CCDTAB   PEDIGREE=inflight
CCDTAB   DESCRIP =CCD table
CCDTAB   DESCRIP =June 2002


DQICORR  OMIT


DARKCORR PERFORM
DARKFILE n3o1205tj_drk.fits
DARKFILE PEDIGREE=INFLIGHT 27/04/2002 21/05/2002
DARKFILE DESCRIP =Superdark created by Doug Van Orsow from proposal 9647
Darktime from header 0.000000
Performing dark subtraction on chip 1 in imset 1
Image has an offset of 0,0
=================================================================
==788522==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000001718 at pc 0x79b06251cabf bp 0x7ffccffe2820 sp 0x7ffccffe2810
WRITE of size 8 at 0x502000001718 thread T0
    #0 0x79b06251cabe in initHdr **/hstcal/hstio/hstio.c:751
    #1 0x79b06251e1d0 in allocSingleGroupHeader **/hstcal/hstio/hstio.c:1001
    #2 0x79b06251e035 in allocSingleGroup **/hstcal/hstio/hstio.c:977
    #3 0x79b061cfb1cc in doDark **/hstcal/pkg/acs/lib/acs2d/dodark.c:177
    #4 0x79b061cf83f8 in Do2D **/hstcal/pkg/acs/lib/acs2d/do2d.c:281
    #5 0x79b061cf5b69 in ACS2d **/hstcal/pkg/acs/lib/acs2d/acs2d.c:153
    #6 0x79b061d7457f in ProcessACSCCD **/hstcal/pkg/acs/lib/calacs/calacs.c:823
    #7 0x79b061d709b0 in CalAcsRun **/hstcal/pkg/acs/lib/calacs/calacs.c:180
    #8 0x60405b8e63ec in main **/hstcal/pkg/acs/src/mainacs.c:235
    #9 0x79b061635487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #10 0x79b06163554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #11 0x60405b8e5284 in _start (**/hstcal/cmake-build-debug/_install/usr/local/bin/calacs.e+0x2284) (BuildId: 36831fbcecaaf884e46a2844420628c6a41ddcec)

0x502000001718 is located 0 bytes after 8-byte region [0x502000001710,0x502000001718)
allocated by thread T0 here:
    #0 0x79b061efd02a in calloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x79b06251e10a in allocSingleGroupHeader **/hstcal/hstio/hstio.c:994
    #2 0x79b06251e035 in allocSingleGroup **/hstcal/hstio/hstio.c:977
    #3 0x79b061cfb1cc in doDark **/hstcal/pkg/acs/lib/acs2d/dodark.c:177
    #4 0x79b061cf83f8 in Do2D **/hstcal/pkg/acs/lib/acs2d/do2d.c:281
    #5 0x79b061cf5b69 in ACS2d **/hstcal/pkg/acs/lib/acs2d/acs2d.c:153
    #6 0x79b061d7457f in ProcessACSCCD **/hstcal/pkg/acs/lib/calacs/calacs.c:823
    #7 0x79b061d709b0 in CalAcsRun **/hstcal/pkg/acs/lib/calacs/calacs.c:180
    #8 0x60405b8e63ec in main **/hstcal/pkg/acs/src/mainacs.c:235
    #9 0x79b061635487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #10 0x79b06163554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #11 0x60405b8e5284 in _start (**/hstcal/cmake-build-debug/_install/usr/local/bin/calacs.e+0x2284) (BuildId: 36831fbcecaaf884e46a2844420628c6a41ddcec)

SUMMARY: AddressSanitizer: heap-buffer-overflow **/hstcal/hstio/hstio.c:751 in initHdr
Shadow bytes around the buggy address:
  0x502000001480: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
  0x502000001500: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x502000001580: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fa
  0x502000001600: fa fa fd fd fa fa 00 00 fa fa fd fa fa fa fd fd
  0x502000001680: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
=>0x502000001700: fa fa 00[fa]fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000001780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000001800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000001880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000001900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000001980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==788522==ABORTING

```