### PR TITLE
Fixes incompatible pointer type error

### DIFF
--- a/pkg/acs/lib/acscte/docte.c
+++ b/pkg/acs/lib/acscte/docte.c
@@ -449,7 +449,7 @@ int DoCTE (ACSInfo *acs_info, const bool forwardModelOnly) {
                     if ((acs_info->expstart >= SM4MJD) && (!acs[i].subarray)) {
                         /* Serial correction */
                         strcpy(corrType, "serial");
-                        if ((status = doPCTEGen3(&acs[i], &ctePars, &x[i], forwardModelOnly, corrType, &ccdamp, nthAmp, amploc, ampID)))
+                        if ((status = doPCTEGen3(&acs[i], &ctePars, &x[i], forwardModelOnly, corrType, ccdamp, nthAmp, amploc, ampID)))
                         {
                             freeOnExit(&ptrReg);
                             freeOnExit(&ptrParallelReg);
@@ -459,7 +459,7 @@ int DoCTE (ACSInfo *acs_info, const bool forwardModelOnly) {
 
                     /* Parallel correction */
                     strcpy(corrType, "parallel");
-                    if ((status = doPCTEGen3(&acs[i], &cteParallelPars, &x[i], forwardModelOnly, corrType, &ccdamp, nthAmp, amploc, ampID)))
+                    if ((status = doPCTEGen3(&acs[i], &cteParallelPars, &x[i], forwardModelOnly, corrType, ccdamp, nthAmp, amploc, ampID)))
                     {
                         freeOnExit(&ptrReg);
                         freeOnExit(&ptrParallelReg);


### PR DESCRIPTION
* `doPCTEGen3` expects `ccdamp` to be a pointer to char (`char  *`)

This PR fixes the following:
```
docte.c:454:104: warning: passing argument 6 of ‘doPCTEGen3’ from incompatible pointer type [-Wincompatible-pointer-types]
  454 |                         if ((status = doPCTEGen3(&acs[i], &ctePars, &x[i], forwardModelOnly, corrType, &ccdamp, nthAmp, amploc, ampID)))
      |                                                                                                        ^~~~~~~
      |                                                                                                        |
      |                                                                                                        char (*)[(0, 2)]
```

Modern GCC and CLang both promote this warning to an error.