### PR TITLE
cmake: Add option to enable AddressSanitizer

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,9 @@ jobs:
         os: [ubuntu-latest, macos-13, macos-14]
         gcc: [12]
         cmake_options: ["", "-DENABLE_ASAN=ON"]
+        exclude:
+          - os: macos-13
+            cmake_options: "-DENABLE_ASAN=ON"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14]
         gcc: [12]
+        cmake_options: ["", "-DENABLE_ASAN=ON"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -46,7 +47,7 @@ jobs:
         cd build
         cmake .. \
           -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PREFIX }}
+          -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PREFIX }} ${{ matrix.cmake_options }}
         make
 
     - name: MacOS build
@@ -61,7 +62,7 @@ jobs:
         cd build
         cmake .. \
           -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PREFIX }}
+          -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PREFIX }} ${{ matrix.cmake_options }}
         make
 
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,6 +27,8 @@ jobs:
         exclude:
           - os: macos-13
             cmake_options: "-DENABLE_ASAN=ON"
+          - os: macos-14
+            cmake_options: "-DENABLE_ASAN=ON"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(ENABLE_ASAN)
 		#
 		# ASAN will continue past the first detected issue
 		add_compile_options(-fsanitize-recover=address)
-		add_link_options(-fsanitize=address)
+		add_link_options(-fsanitize-recover=address)
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(hstcal)
 enable_language(C)
 set(CMAKE_C_STANDARD 99)
 
+option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+option(ENABLE_ASAN_RECOVER "When ASAN reports a problem, don't halt execution" OFF)
 option(ENABLE_WARNINGS "Enable compiler warnings" ON)
 option(ENABLE_OPENMP "Enable OpenMP" ON)
 set(WITH_CFITSIO "" CACHE STRING "Path to cfitsio (if empty pkg-config is used)")
@@ -48,6 +50,22 @@ configure_file(config.h.in config.h @ONLY)
 
 if(NOT HAVE_SNPRINTF OR NOT HAVE_STRDUP OR NOT HAVE_INT_MAX)
 	message(FATAL_ERROR "Required symbol is missing!")
+endif()
+
+if(ENABLE_ASAN)
+	# Report memory leaks, buffer overflows, etc.
+	# See: https://github.com/google/sanitizers/wiki/AddressSanitizer
+	add_compile_options(-fno-omit-frame-pointer)
+	add_compile_options(-fsanitize=address)
+	add_link_options(-fsanitize=address)
+	if(ENABLE_ASAN_RECOVER)
+		# To use this option set the following in your local environment:
+		# ASAN_OPTIONS="halt_on_error=0"
+		#
+		# ASAN will continue past the first detected issue
+		add_compile_options(-fsanitize-recover=address)
+		add_link_options(-fsanitize=address)
+	endif()
 endif()
 
 if(ENABLE_WARNINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 
 if(ENABLE_ASAN)
 	# Report memory leaks, buffer overflows, etc.
-	# See: https://github.com/google/sanitizers/wiki/AddressSanitizer
+	# See: https://clang.llvm.org/docs/AddressSanitizer.html
 	add_compile_options(-fno-omit-frame-pointer)
 	add_compile_options(-fsanitize=address)
 	add_link_options(-fsanitize=address)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -200,3 +200,11 @@ To enable support for debugging symbols use one of the following defines:
 ```
 cmake .. -DCMAKE_BUILD_TYPE=[RelWithDebInfo|Debug]
 ```
+
+To enable memory leak and heap overflow detection:
+
+```
+cmake .. -DENABLE_ASAN=ON [-DENABLE_ASAN_RECOVER=ON]
+```
+
+When ASAN (aka AddressAnalyzer) encounters a bug it halts execution and dumps information about the type of error, and where it occurred. When `ENABLE_ASAN_RECOVER` is enabled, and the `ASAN_OPTIONS` environment variable contains `halt_on_error=0`, ASAN will continue to dump information as the program runs. This is mode is incredibly noisy, so it should only ever be used to test code changes in development.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,8 @@ GCC may be supplemented by Clang under the following conditions:
 
 - Must be compiled as a shared library.
 
-- If `libcfitsio` has been installed to a non-standard path such as `$HOME/programs/cfitsio`, you will need to adjust `PKG_CONFIG_PATH` so that `pkg-config` is able to find it:
+- If `libcfitsio` has been installed to a non-standard path such as `$HOME/programs/cfitsio`, you will need to adjust
+  `PKG_CONFIG_PATH` so that `pkg-config` is able to find it:
 
     ```bash
     export PKG_CONFIG_PATH=$HOME/programs/cfitsio/lib/pkgconfig:$PKG_CONFIG_PATH
@@ -88,7 +89,8 @@ export LDFLAGS="-Wl,-rpath=$CONDA_PREFIX/lib"
     cd _build
     ```
 
-   If you use Conda/Mamba, you can install it to the env directly; however, note that this would overwrite any previous `hstcal` installation from `conda-forge` channel:
+   If you use Conda/Mamba, you can install it to the env directly; however, note that this would overwrite any previous 
+   `hstcal` installation from `conda-forge` channel:
 
     ```
     cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
@@ -120,7 +122,8 @@ export LDFLAGS="-Wl,-rpath=$CONDA_PREFIX/lib"
 
 ## Build on MacOS / OS X
 
-The LLVM/Clang suite provided by Apple XCode is not sufficient to compile HSTCAL. Please install GCC (C and Fortran compilers) either from source, or using a package management system such as Homebrew, MacPorts, Fink, or Conda.
+The LLVM/Clang suite provided by Apple XCode is not sufficient to compile HSTCAL. Please install GCC (C and Fortran
+compilers) either from source, or using a package management system such as Homebrew, MacPorts, Fink, or Conda.
 
 
 ### MacPorts
@@ -163,7 +166,8 @@ export LDFLAGS="-Wl,-rpath,$CONDA_PREFIX/lib"
     cd _build
     ```
 
-   If you use Conda/Mamba, you can install it to the env directly; however, note that this would overwrite any previous `hstcal` installation from `conda-forge` channel:
+   If you use Conda/Mamba, you can install it to the env directly; however, note that this would overwrite any previous
+   `hstcal` installation from `conda-forge` channel:
 
     ```
     cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
@@ -207,4 +211,7 @@ To enable memory leak and heap overflow detection:
 cmake .. -DENABLE_ASAN=ON [-DENABLE_ASAN_RECOVER=ON]
 ```
 
-When ASAN (aka AddressAnalyzer) encounters a bug it halts execution and dumps information about the type of error, and where it occurred. When `ENABLE_ASAN_RECOVER` is enabled, and the `ASAN_OPTIONS` environment variable contains `halt_on_error=0`, ASAN will continue to dump information as the program runs. This is mode is incredibly noisy, so it should only ever be used to test code changes in development.
+When ASAN (aka AddressAnalyzer) encounters a bug it halts execution and dumps information about the type of error, and
+where it occurred. When `ENABLE_ASAN_RECOVER` is enabled, and the `ASAN_OPTIONS` environment variable contains 
+`halt_on_error=0`, ASAN will continue to dump information as the program runs. This is mode is incredibly noisy, so it
+should only ever be used to test code changes in development.


### PR DESCRIPTION
Allows one to enable the detection of leaks, overflows, and many other violations.