### PR TITLE
FLSHCORR: Scale for linear decrease over time

### DIFF
--- a/pkg/acs/Dates
+++ b/pkg/acs/Dates
@@ -1,3 +1,6 @@
+ 08-May-2025   CALACS 10.5.0 FLSHCORR now applies scaling to account for linear decrease of
+                             flash rate with time, because no more new reference image will
+                             be delivered going forward.
  07-May-2024   CALACS 10.4.0 Implementation of the "Parallel and Serial CTE correction". This
                              version of the CTE correction (Generation 3) is based upon the
                              algorithm of Generation 2, but includes the additional correction

--- a/pkg/acs/History
+++ b/pkg/acs/History
@@ -1,3 +1,8 @@
+### 08-May-2025 - PLL - Version 10.5.0
+    FLSHCORR now applies scaling to account for linear decrease of
+    flash rate with time, because no more new reference image will
+    be delivered going forward.
+
 ### 07-May-2024 - MDD - Version 10.4.0
     Implementation of the "Parallel and Serial CTE correction". This
     version of the CTE correction (Generation 3) is based upon the

--- a/pkg/acs/Updates
+++ b/pkg/acs/Updates
@@ -1,3 +1,10 @@
+Update for version 10.5.0 - 08-May-2025 (PLL)
+    pkg/acs/Dates
+    pkg/acs/History
+    pkg/acs/Updates
+    pkg/acs/include/acsversion.h
+    pkg/acs/lib/acs2d/doflash.c
+
 Update for version 10.4.0 - 07-May-2024 (MDD)
     pkg/acs/Dates
     pkg/acs/History

--- a/pkg/acs/include/acsversion.h
+++ b/pkg/acs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.4.0 (07-May-2024)"
-#define ACS_CAL_VER_NUM "10.4.0"
+#define ACS_CAL_VER "10.5.0 (08-May-2025)"
+#define ACS_CAL_VER_NUM "10.5.0"
 
 /* This Generation of the CTE algorithm is obsolete.  These strings
    are only maintained in case a user has an older version of the

--- a/pkg/acs/lib/acs2d/doflash.c
+++ b/pkg/acs/lib/acs2d/doflash.c
@@ -155,15 +155,15 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
        T0      =                60126
        AVGFLASH=          11.76780605
     */
-    if (GetKeyDbl(&hdr_ptr, "SLOPE", USE_DEFAULT, 0.0, &slope)) {
+    if (GetKeyDbl(&hdr_ptr, "SLOPE", NO_DEFAULT, 0.0, &slope)) {
         WhichError (status);
         is_lastflash = false;
     }
-    if (GetKeyDbl(&hdr_ptr, "T0", USE_DEFAULT, 0.0, &t0)) {
+    if (GetKeyDbl(&hdr_ptr, "T0", NO_DEFAULT, 0.0, &t0)) {
         WhichError (status);
         is_lastflash = false;
     }
-    if (GetKeyDbl(&hdr_ptr, "AVGFLASH", USE_DEFAULT, -1.0, &avglastflash)) {
+    if (GetKeyDbl(&hdr_ptr, "AVGFLASH", NO_DEFAULT, -1.0, &avglastflash)) {
         WhichError (status);
         is_lastflash = false;
     }

--- a/pkg/acs/lib/acs2d/doflash.c
+++ b/pkg/acs/lib/acs2d/doflash.c
@@ -82,6 +82,7 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
     void AvgSciValLine (SingleGroupLine *, short, float *, float *);
     int multk1d (SingleGroupLine *a, float k);
     int streq_ic (char *, char *);
+    void WhichError (int);
 
     /* Check to see whether we need to do any processing at all */
     if (acs2d->flashdur <= 0.) {

--- a/pkg/acs/lib/acs2d/doflash.c
+++ b/pkg/acs/lib/acs2d/doflash.c
@@ -5,8 +5,9 @@
 # include <stdio.h>
 # include <stdlib.h>  /* calloc */
 # include <math.h>    /* fabs */
+# include <stdbool.h> /* true, false */
 
-#include "hstcal.h"
+# include "hstcal.h"
 # include "hstio.h"
 # include "acs.h"
 # include "acsinfo.h"
@@ -23,7 +24,7 @@
  Reference image should have been selected to have
  the same binning factor as the science image, so
  assume ratio of bin factors to be 1.
- 
+
  The value of MEANFLSH is calculated based on the weighted average
  of each lines' post-flash value.  The weighting is based on the percent of
  good pixels in each line, so only pixels not flagged BAD (in some way)
@@ -40,6 +41,8 @@
  Pey Lian Lim, 2012 Dec 12:
  Moved FLSHCORR from ACSCCD to ACS2D.
  Modified algorithm to be similar to dodark.c.
+ Pey Lian Lim, 2025 May 8:
+ Applied scaling for linear decrease over time of flash rate.
  */
 
 int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
@@ -48,10 +51,11 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
        ACSInfo *acs2d     i: calibration switches, etc
        SingleGroup *x    io: image to be calibrated; written to in-place
        float *meanflash   o: mean of post-flash image values subtracted
-     */
+    */
 
     extern int status;
 
+    Hdr hdr_ptr;
     SingleGroupLine y, z;  /* y and z are scratch space */
     int extver = 1;        /* get this imset from post-flash image */
     int rx, ry;            /* for binning post-flash down to size of x */
@@ -62,8 +66,15 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
     int i, j;
     float mean, flash;
     float weight, wflash;  /* weights for line averages */
+    double slope;          /* m of linear decrease over time */
+    double t0;             /* t_0 of linear decrease over time */
+    double avglastflash;   /* F of linear decrease over time */
+    float s_lastflash = 1.0; /* s of linear decrease over time */
+    bool is_lastflash = true; /* flag to apply s or not */
     int update;
 
+    int LoadHdr (char *, Hdr *);
+    int GetKeyDbl(Hdr *, char *, int, double, double *);
     int FindLine (SingleGroup *, SingleGroupLine *, int *, int *, int *, int *, int *);
     int sub1d (SingleGroup *, int, SingleGroupLine *);
     int trim1d (SingleGroupLine *, int, int, int, int, int, SingleGroupLine *);
@@ -95,24 +106,76 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
     /* Start with the actual post-flash subtraction now. */
 
     initSingleGroupLine (&y);
-  
+
     scilines = x->sci.data.ny;
-  
+
     /* Compute correct extension version number to extract from
        reference image to correspond to CHIP in science data.
-     */
+
+       Also load reference image primary header for scaling that is
+       needed because no new reference image is generated going forward
+       and we know that the flash rate decreases linearly over time.
+    */
     if (acs2d->pctecorr == PERFORM) {
         if (DetCCDChip (acs2d->flashcte.name, acs2d->chip, acs2d->nimsets,
                         &extver))
             return (status);
+        if (LoadHdr(acs2d->flashcte.name, &hdr_ptr)) {
+            WhichError (status);
+            return (status);
+        }
     } else {
         if (DetCCDChip (acs2d->flash.name, acs2d->chip, acs2d->nimsets,
                         &extver))
             return (status);
+        if (LoadHdr(acs2d->flash.name, &hdr_ptr)) {
+            WhichError (status);
+            return (status);
+        }
+    }
+
+    /* Get linear decrease parameters from reference image primary header.
+
+       The scaling factor (s) by which to multiply the SCI and ERR arrays
+       of the last available post-flash reference image prior to
+       flash correction in CALACS:
+
+       s = (m * (t_obs - t_0)) / F + 1
+
+       where:
+
+       m = SLOPE in reference image primary header
+       t_obs = DATE-OBS of input image (MJD), approx. by acs2d->expstart
+       t_0 = T0 in reference image primary header (MJD)
+       F = AVGFLASH in reference image primary header (e/s)
+
+       Example reference image header content:
+
+       SLOPE   =         -6.52415E-05
+       T0      =                60126
+       AVGFLASH=          11.76780605
+    */
+    if (GetKeyDbl(&hdr_ptr, "SLOPE", USE_DEFAULT, 0.0, &slope)) {
+        WhichError (status);
+        is_lastflash = false;
+    }
+    if (GetKeyDbl(&hdr_ptr, "T0", USE_DEFAULT, 0.0, &t0)) {
+        WhichError (status);
+        is_lastflash = false;
+    }
+    if (GetKeyDbl(&hdr_ptr, "AVGFLASH", USE_DEFAULT, -1.0, &avglastflash)) {
+        WhichError (status);
+        is_lastflash = false;
+    }
+    if (is_lastflash) {
+        s_lastflash = (float)((slope * (acs2d->expstart - t0)) / avglastflash + 1.0);
     }
 
     if (acs2d->verbose) {
         trlmessage("Performing post-flash subtraction on chip %d in imset %d", acs2d->chip, extver);
+        if (is_lastflash) {
+            trlmessage("Linear decrease over time scaling for post-flash: %e", s_lastflash);
+        }
     }
 
     /* Get the post-flash image data. */
@@ -123,16 +186,16 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
     }
     if (hstio_err())
         return (status = OPEN_FAILED);
-  
+
     /* Compare binning of science image and reference image;
-        get same_size and high_res flags, and get info about
-        binning and offset for use by bin2d.
-     */
+       get same_size and high_res flags, and get info about
+       binning and offset for use by bin2d.
+    */
     if (FindLine (x, &y, &same_size, &rx, &ry, &x0, &y0))
         return (status);
 
     if (rx != 1 || ry != 1) {
-        trlmessage("Reference image and input are not binned to the same pixel size!");
+        trlwarn("Reference image and input are not binned to the same pixel size!");
     }
 
     if (acs2d->verbose) {
@@ -141,16 +204,16 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
 
     mean = 0.0;
     weight = 0.0;
- 
+
     /* Bin the post-flash image down to the actual size of x. */
-  
+
     initSingleGroupLine(&z);
     allocSingleGroupLine(&z, x->sci.data.nx);
     for (i=0, j=y0; i < scilines; i++,j++) {
 
         /* We are working with a sub-array and need to apply the
            proper section from the reference image to the science image.
-         */
+        */
         if (acs2d->pctecorr == PERFORM) {
             getSingleGroupLine (acs2d->flashcte.name, j, &y);
 	} else {
@@ -163,15 +226,19 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
             trlerror("(flshcorr) size mismatch.");
             return (status);
         }
-    
-        multk1d(&z, acs2d->flashdur);
-    
+
+        if (is_lastflash) {
+            multk1d(&z, acs2d->flashdur * s_lastflash);
+        } else {
+            multk1d(&z, acs2d->flashdur);
+        }
+
         AvgSciValLine(&z, acs2d->sdqflags, &flash, &wflash);
 
         /* Sum the contribution from each line */
         mean += flash * wflash;
         weight += wflash;
-    
+
         status = sub1d(x, i, &z);
         if (status)
             return (status);

--- a/pkg/acs/lib/acs2d/doflash.c
+++ b/pkg/acs/lib/acs2d/doflash.c
@@ -155,19 +155,12 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
        T0      =                60126
        AVGFLASH=          11.76780605
     */
-    if (GetKeyDbl(&hdr_ptr, "SLOPE", NO_DEFAULT, 0.0, &slope)) {
-        WhichError (status);
+    if (GetKeyDbl(&hdr_ptr, "SLOPE", NO_DEFAULT, 0.0, &slope) ||
+            GetKeyDbl(&hdr_ptr, "T0", NO_DEFAULT, 0.0, &t0) ||
+            GetKeyDbl(&hdr_ptr, "AVGFLASH", NO_DEFAULT, -1.0, &avglastflash)) {
+        status = 0;  /* Keep going */
         is_lastflash = false;
-    }
-    if (GetKeyDbl(&hdr_ptr, "T0", NO_DEFAULT, 0.0, &t0)) {
-        WhichError (status);
-        is_lastflash = false;
-    }
-    if (GetKeyDbl(&hdr_ptr, "AVGFLASH", NO_DEFAULT, -1.0, &avglastflash)) {
-        WhichError (status);
-        is_lastflash = false;
-    }
-    if (is_lastflash) {
+    } else {
         s_lastflash = (float)((slope * (acs2d->expstart - t0)) / avglastflash + 1.0);
     }
 
@@ -175,6 +168,8 @@ int doFlash (ACSInfo *acs2d, SingleGroup *x, float *meanflash) {
         trlmessage("Performing post-flash subtraction on chip %d in imset %d", acs2d->chip, extver);
         if (is_lastflash) {
             trlmessage("Linear decrease over time scaling for post-flash: %e", s_lastflash);
+        } else {
+            trlmessage("Linear decrease over time scaling for post-flash: SKIPPED");
         }
     }
 


### PR DESCRIPTION
FLSHCORR: Scale for linear decrease over time if the reference image is the last ever to be delivered.

But we do not want to merge this until we know for sure, though I coded it up such that it would still run without the scaling if those new keywords are not found in the reference image primary header.

Fix https://github.com/spacetelescope/hstcal/issues/627

RT https://github.com/spacetelescope/RegressionTests/actions/runs/14917237097

### TODO

- [x] Run CI and RT, and fix any failures.
- [ ] Wait for ACS Team sign off to merge or not. Rerun CI and RT.
- [ ] Add new test case with prototype reference image to regression test.