### PR TITLE
Docker CI: Reenable incompatible pointer type errors

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,8 +96,7 @@ jobs:
           cmake .. \
               -DCMAKE_INSTALL_PREFIX=/tmp/hstcal \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
-              -DCMAKE_C_FLAGS="-Wno-incompatible-pointer-types"
+              -DCMAKE_C_COMPILER=${{ matrix.compiler }}
           make -j$(nproc)
           make install
 


### PR DESCRIPTION
Now that #645 has been merged we no longer need to disable this warning(/error).

New incompatible pointer type issues _should_ cause the CI to fail.