### PR TITLE
hstio: replace 'int' with intended type 'long'

### DIFF
--- a/hstio/numeric.c
+++ b/hstio/numeric.c
@@ -102,8 +102,8 @@ extern "C" {
      const int minLong = INT_MIN;
      const int maxLong = INT_MAX;
 # else
-     const int minLong = LONG_MIN;
-     const int maxLong = LONG_MAX;
+     const long minLong = LONG_MIN;
+     const long maxLong = LONG_MAX;
 # endif
 const float minFloat = FLT_MIN;
 const float maxFloat = FLT_MAX;


### PR DESCRIPTION
```
warning: overflow in conversion from ‘long int’ to ‘int’ changes value from ‘-9223372036854775808’ to ‘0’ [-Woverflow]
  105 |      const int minLong = LONG_MIN;
      |                          ^~~~~~~~
warning: overflow in conversion from ‘long int’ to ‘int’ changes value from ‘9223372036854775807’ to ‘-1’ [-Woverflow]
  106 |      const int maxLong = LONG_MAX;
```

