### PR TITLE
CI: Disable Stream 10 docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,11 +31,12 @@ jobs:
             version: stable
             build_type: Release
             compiler: gcc
-          - os: centos
-            repo: quay.io/centos/
-            version: stream10
-            build_type: Release
-            compiler: gcc
+          # Stream 10 packages are unstable. Revisit later.
+          #- os: centos
+          #  repo: quay.io/centos/
+          #  version: stream10
+          #  build_type: Release
+          #  compiler: gcc
           - os: centos
             repo: quay.io/centos/
             version: stream9


### PR DESCRIPTION
```
Error: 
 Problem 1: cannot install the best candidate for the job
  - nothing provides libgomp = 14.3.1-2.1.el10 needed by gcc-14.3.1-2.1.el10.x86_64 from appstream
  - nothing provides libgcc >= 14.3.1-2.1.el10 needed by gcc-14.3.1-2.1.el10.x86_64 from appstream
 Problem 2: cannot install the best candidate for the job
  - nothing provides libstdc++ = 14.3.1-2.1.el10 needed by gcc-c++-14.3.1-2.1.el10.x86_64 from appstream
 Problem 3: cannot install the best candidate for the job
  - nothing provides libquadmath = 14.3.1-2.1.el10 needed by gcc-gfortran-14.3.1-2.1.el10.x86_64 from appstream
  - nothing provides libgfortran = 14.3.1-2.1.el10 needed by gcc-gfortran-14.3.1-2.1.el10.x86_64 from appstream
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

Stream 10's base package dependencies are broken. Disabling the image until further notice.