### PR TITLE
RFC: Move bias shift code out of doccd.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,12 @@ _CPack_Packages/
 Testing
 Makefile
 cmake_install.cmake
+cmake-build-debug/
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
-.lock-waf*
-.waf*
 bin.*
 *build
-build
 build.*
 Makefile
 __pycache__
@@ -26,3 +24,4 @@ __pycache__
 *.a
 *.so
 hstcal-*.sh
+.idea/

--- a/pkg/acs/include/wfcsubapertures.h
+++ b/pkg/acs/include/wfcsubapertures.h
@@ -1,0 +1,10 @@
+#ifndef WFCSUBAPERTURES_H
+#define WFCSUBAPERTURES_H
+
+extern const char *subApertures[];
+extern const size_t numSupportedSubApertures;
+
+extern const char *darkSubApertures[];
+extern const size_t numSupportedDarkSubApertures;
+
+#endif

--- a/pkg/acs/lib/CMakeLists.txt
+++ b/pkg/acs/lib/CMakeLists.txt
@@ -22,7 +22,6 @@ add_library(${PROJECT_NAME} SHARED
 	acsccd/doatod.c
 	acsccd/dobias.c
 	acsccd/doblev.c
-	#acsccd/doblev_v504.c # ... what??
 	acsccd/doccd.c
 	acsccd/dofwsat.c
 	acsccd/dosink.c
@@ -125,6 +124,7 @@ add_library(${PROJECT_NAME} SHARED
 	ucalver.c
 	ufilename.c
 	unbinline.c
+        wfcsubapertures.c
 	whicherror.c
 )
 target_include_directories(${PROJECT_NAME}

--- a/pkg/acs/lib/acsccd/doccd.c
+++ b/pkg/acs/lib/acsccd/doccd.c
@@ -33,58 +33,31 @@
 
 ** This code is a trimmed down version of CALSTIS1 do2d.c.
 */
-# include <string.h>
-# include <stdio.h>
+#include <string.h>
+#include <stdio.h>
 
 #include "hstcal_memory.h"
 #include "hstcal.h"
-# include "hstio.h"
+#include "hstio.h"
 
-# include "acs.h"
-# include "acsinfo.h"
-# include "hstcalerr.h"
+#include "acs.h"
+#include "acsinfo.h"
+#include "hstcalerr.h"
 
+/* subApertures, numSupportedSubApertures,
+   darkSubApertures, numSupportedDarkSubApertures */
+#include "wfcsubapertures.h"
 
 static void dqiMsg (ACSInfo *, const int);
 static void BiasMsg (ACSInfo *, const int);
 static void BlevMsg (ACSInfo *, const int);
 static void SinkMsg (ACSInfo *, const int);
 
-/* This variable contains the subarray aperture names for the officially supported
-   subarrays since ~Cycle 24.  The polarizer and ramp subarray apertures did NOT
-   change aperture names, even though the dimensions of the data changed to accommodate
-   overscan.  In addition to checking the aperture name, the dimensions will also need
-   to be checked for pol/ramp data to determine if the bias shift correction
-   can be applied.
-
-   The non-pol and non-ramp data adopted new aperture names for easy identification.
-   These apertures contain physical overscan.  The new "-2K" subarrays also have virtual
-   overscan so the bias shift correction can be applied to this data. At this time,
-   bias shift correction can only be applied to data with both physical and virtual
-   overscan so the "fat zero" value can be computed.
-*/
-static const char *subApertures[] = {"WFC1A-2K", "WFC1B-2K", "WFC2C-2K", "WFC2D-2K",
-                                     "WFC1-IRAMPQ", "WFC1-MRAMPQ", "WFC2-MRAMPQ", "WFC2-ORAMPQ",
-                                     "WFC1-POL0UV", "WFC1-POL0V", "WFC2-POL0UV", "WFC2-POL0V",
-                                     "WFC1-POL60UV", "WFC1-POL60V", "WFC2-POL60UV", "WFC2-POL60V",
-                                     "WFC1-POL120UV", "WFC1-POL120V", "WFC2-POL120UV", "WFC2-POL120V"};
-static const int numSupportedSubApertures = sizeof(subApertures) / sizeof(subApertures[0]);
-
-static const char *darkSubApertures[] = {"WFC1A-2K", "WFC1B-2K", "WFC2C-2K", "WFC2D-2K",
-                                     "WFC1A-1K", "WFC1B-1K", "WFC2C-1K", "WFC2D-1K",
-                                     "WFC1A-512", "WFC1B-512", "WFC2C-512", "WFC2D-512",
-                                     "WFC1-IRAMPQ", "WFC1-MRAMPQ", "WFC2-ORAMPQ",
-                                     "WFC1-POL0UV", "WFC1-POL0V",
-                                     "WFC1-POL60UV", "WFC1-POL60V",
-                                     "WFC1-POL120UV", "WFC1-POL120V",
-                                     "WFC1-SMFL"};
-
-static const int numSupportedDarkSubApertures = sizeof(darkSubApertures) / sizeof(darkSubApertures[0]);
 
 int DoCCD (ACSInfo *acs_info) {
 
     /* arguments:
-       acs   i: calibration switches and info
+       acs_info   i: calibration switches and info
     */
 
     extern int status;

--- a/pkg/acs/lib/wfcsubapertures.c
+++ b/pkg/acs/lib/wfcsubapertures.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include "wfcsubapertures.h"
+
+/* This variable contains the subarray aperture names for the officially supported
+   subarrays since ~Cycle 24.  The polarizer and ramp subarray apertures did NOT
+   change aperture names, even though the dimensions of the data changed to accommodate
+   overscan.  In addition to checking the aperture name, the dimensions will also need
+   to be checked for pol/ramp data to determine if the bias shift correction
+   can be applied.
+
+   The non-pol and non-ramp data adopted new aperture names for easy identification.
+   These apertures contain physical overscan.  The new "-2K" subarrays also have virtual
+   overscan so the bias shift correction can be applied to this data. At this time,
+   bias shift correction can only be applied to data with both physical and virtual
+   overscan so the "fat zero" value can be computed.
+*/
+const char *subApertures[] = {
+    "WFC1A-2K", "WFC1B-2K", "WFC2C-2K", "WFC2D-2K",
+    "WFC1-IRAMPQ", "WFC1-MRAMPQ", "WFC2-MRAMPQ", "WFC2-ORAMPQ",
+    "WFC1-POL0UV", "WFC1-POL0V", "WFC2-POL0UV", "WFC2-POL0V",
+    "WFC1-POL60UV", "WFC1-POL60V", "WFC2-POL60UV", "WFC2-POL60V",
+    "WFC1-POL120UV", "WFC1-POL120V", "WFC2-POL120UV", "WFC2-POL120V"
+};
+const size_t numSupportedSubApertures = sizeof(subApertures) / sizeof(subApertures[0]);
+
+const char *darkSubApertures[] = {
+    "WFC1A-2K", "WFC1B-2K", "WFC2C-2K", "WFC2D-2K",
+    "WFC1A-1K", "WFC1B-1K", "WFC2C-1K", "WFC2D-1K",
+    "WFC1A-512", "WFC1B-512", "WFC2C-512", "WFC2D-512",
+    "WFC1-IRAMPQ", "WFC1-MRAMPQ", "WFC2-ORAMPQ",
+    "WFC1-POL0UV", "WFC1-POL0V", "WFC1-POL60UV", "WFC1-POL60V",
+    "WFC1-POL120UV", "WFC1-POL120V", "WFC1-SMFL"};
+const size_t numSupportedDarkSubApertures = sizeof(darkSubApertures) / sizeof(darkSubApertures[0]);


### PR DESCRIPTION
Fix https://github.com/spacetelescope/hstcal/issues/668 . I don't think it needs a change log because if done properly, user should see no difference. 🤞 

RT: https://github.com/spacetelescope/RegressionTests/actions/runs/16203122170

### TODO

- [x] Move shared variables out.
- [ ] Move bias shift to a new file called `dobiasshift.c`. Update cmake manifest(s).
- [ ] Make sure CI and regression tests are clean.
- ???
- Profit!!!