### PR TITLE
TST: Add tests for ACSCTE rotate amp functions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,6 +57,13 @@ GCC may be supplemented by Clang under the following conditions:
     cmake .. -DENABLE_OPENMP=OFF
     ```
 
+### C unit tests
+
+- If you want to be able to run unit tests written in C.
+
+    ```
+    cmake .. -DTESTS=ON
+    ```
 
 ## Build on Linux
 

--- a/ctests/CMakeLists.txt
+++ b/ctests/CMakeLists.txt
@@ -7,3 +7,17 @@ add_test(NAME testphot
 target_link_libraries(testphot
     PUBLIC hstcalib
 )
+file(COPY w3m17171j_extrap_imp.fits
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_executable(test_acscte_rotateamp
+    test_acscte_rotateamp.c
+)
+add_test(NAME test_acscte_rotateamp
+    COMMAND $<TARGET_FILE:test_acscte_rotateamp>
+)
+target_link_libraries(test_acscte_rotateamp
+    PUBLIC acs
+    PUBLIC hstcalib
+)

--- a/ctests/test_acscte_rotateamp.c
+++ b/ctests/test_acscte_rotateamp.c
@@ -2,52 +2,117 @@
 #include "acs.h"
 #include "pcte_gen3_funcs.h"
 
-int main(int argc, char **argv) {
-    extern int status;
-    int iy, ix, amp_id, test_status=0;
+static int setup_input_array(FloatTwoDArray *, int, int);
+static int compare_arrays(FloatTwoDArray *, float *, int, int);
+static int worker();
+
+static int setup_input_array(FloatTwoDArray *da, int nx, int ny) {
+    int iy, ix;
+
+    initFloatData(da);
+    if (allocFloatData(da, nx, ny, False)) {
+        return OUT_OF_MEMORY;
+    }
+    for (iy=0; iy<ny; iy++) {
+        for (ix=0; ix<nx; ix++) {
+            Pix(*da, ix, iy) = iy * nx + ix;
+        }
+    }
+
+    return ACS_OK;
+}
+
+static int compare_arrays(FloatTwoDArray *da, float *truth, int truth_nx, int truth_ny) {
+    int iy, ix, ii, test_status=ACS_OK;
+
+    if (da->nx != truth_nx || da->ny != truth_ny) {
+        printf("ERROR: Dimension mismatch!\n\n  Expected: nx=%d ny=%d\n       Got: nx=%d ny=%d\n\n",
+               truth_nx, truth_ny, da->nx, da->ny);
+        test_status = SIZE_MISMATCH;
+    }
+
+    for (iy=0; iy<truth_ny; iy++) {
+        for (ix=0; ix<truth_nx; ix++) {
+            ii = iy * truth_nx + ix;
+            if (Pix(*da, ix, iy) != truth[ii]) {
+                test_status = ERROR_RETURN;
+                break;
+            }
+        }
+        if (test_status) {
+            break;
+        }
+    }
+
+    if (test_status) {
+        printf("ERROR: Arrays are different!\n\n  Expected:\n    ");
+        for (iy=0; iy<truth_ny; iy++) {
+            for (ix=0; ix<truth_nx; ix++) {
+                ii = iy * truth_nx + ix;
+                printf("%.1f ", truth[ii]);
+            }
+            printf("\n    ");
+        }
+        printf("\n  Got:\n    ");
+        for (iy=0; iy<da->ny; iy++) {
+            for (ix=0; ix<da->nx; ix++) {
+                printf("%.1f ", Pix(*da, ix, iy));
+            }
+            printf("\n    ");
+        }
+        printf("\n");
+    }
+
+    return test_status;
+}
+
+static int worker() {
+    const char amps[5] = "ABCD\0";
+    int amp_id=AMP_C, test_status;
     FloatTwoDArray da;
+    int nx=3, ny=4;
 
-    /* AMP_B or AMP_C, [ny][nx] */
-    float expected[3][4] = {{9, 6, 3, 0},
-                            {10, 7, 4, 1},
-                            {11, 8, 5, 2}};
-
-    /* Input array before rotation (nx=3, ny=4):
+    /* Input array before rotation:
 
        0 1 2
        3 4 5
        6 7 8
        9 10 11
      */
-    initFloatData(&da);
-    if (allocFloatData(&da, 3, 4, False)) {
-        return -1;
-    }
-    for (iy=0; iy<4; iy++) {
-        for (ix=0; ix<3; ix++) {
-            Pix(da, ix, iy) = iy * 3 + ix;
-        }
+    if ((test_status = setup_input_array(&da, nx, ny))) {
+        freeFloatData(&da);
+        return test_status;
     }
 
     // TODO: Need to test all amps
-    amp_id = AMP_C;
-    if ((status = rotateAmpData_acscte(&da, amp_id))) {
-        return status;
+    printf("==== rotateAmpData_acscte AMP %c ====\n", amps[amp_id]);
+    if ((test_status = rotateAmpData_acscte(&da, amp_id))) {
+        freeFloatData(&da);
+        return test_status;
     }
 
-    // TODO: check against truth
-    for (iy=0; iy<3; iy++) {
-        for (ix=0; ix<4; ix++) {
-            if (Pix(da, ix, iy) != expected[iy][ix]) {
-                if (!test_status) {
-                    printf("test_acscte_rotateamp failed for amp=%d\n", amp_id);
-                    test_status = 1;
-                }
-                printf("ix=%d, iy=%d\n  expected=%.1f\n  got=%.1f\n", ix, iy, expected[iy][ix], Pix(da, ix, iy));
-            }
-        }
-    }
+    /* AMP_B or AMP_C
+        9 6 3 0
+       10 7 4 1
+       11 8 5 2
+    */
+    int truth_nx=ny;
+    int truth_ny=nx;
+    float *truth = malloc(sizeof(float) * truth_nx * truth_ny);
+    truth[0] = 9; truth[1] = 6; truth[2] = 3; truth[3] = 0;
+    truth[4] = 10; truth[5] = 7; truth[6] = 4; truth[7] = 1;
+    truth[8] = 11; truth[9] = 8; truth[10] = 5; truth[11] = 2;
 
+    test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
+    free(truth);
     freeFloatData(&da);
+    return test_status;
+}
+
+int main(int argc, char **argv) {
+    int test_status;
+
+    test_status = worker();
+
     return test_status;
 }

--- a/ctests/test_acscte_rotateamp.c
+++ b/ctests/test_acscte_rotateamp.c
@@ -1,0 +1,53 @@
+#include "hstio.h"
+#include "acs.h"
+#include "pcte_gen3_funcs.h"
+
+int main(int argc, char **argv) {
+    extern int status;
+    int iy, ix, amp_id, test_status=0;
+    FloatTwoDArray da;
+
+    /* AMP_B or AMP_C, [ny][nx] */
+    float expected[3][4] = {{9, 6, 3, 0},
+                            {10, 7, 4, 1},
+                            {11, 8, 5, 2}};
+
+    /* Input array before rotation (nx=3, ny=4):
+
+       0 1 2
+       3 4 5
+       6 7 8
+       9 10 11
+     */
+    initFloatData(&da);
+    if (allocFloatData(&da, 3, 4, False)) {
+        return -1;
+    }
+    for (iy=0; iy<4; iy++) {
+        for (ix=0; ix<3; ix++) {
+            Pix(da, ix, iy) = iy * 3 + ix;
+        }
+    }
+
+    // TODO: Need to test all amps
+    amp_id = AMP_C;
+    if ((status = rotateAmpData_acscte(&da, amp_id))) {
+        return status;
+    }
+
+    // TODO: check against truth
+    for (iy=0; iy<3; iy++) {
+        for (ix=0; ix<4; ix++) {
+            if (Pix(da, ix, iy) != expected[iy][ix]) {
+                if (!test_status) {
+                    printf("test_acscte_rotateamp failed for amp=%d\n", amp_id);
+                    test_status = 1;
+                }
+                printf("ix=%d, iy=%d\n  expected=%.1f\n  got=%.1f\n", ix, iy, expected[iy][ix], Pix(da, ix, iy));
+            }
+        }
+    }
+
+    freeFloatData(&da);
+    return test_status;
+}

--- a/ctests/test_acscte_rotateamp.c
+++ b/ctests/test_acscte_rotateamp.c
@@ -4,7 +4,10 @@
 
 static int setup_input_array(FloatTwoDArray *, int, int);
 static int compare_arrays(FloatTwoDArray *, float *, int, int);
-static int worker();
+static int rectangle_test_case(int);
+static int square_test_case(int);
+
+const char amps[5] = "ABCD\0";
 
 static int setup_input_array(FloatTwoDArray *da, int nx, int ny) {
     int iy, ix;
@@ -66,11 +69,9 @@ static int compare_arrays(FloatTwoDArray *da, float *truth, int truth_nx, int tr
     return test_status;
 }
 
-static int worker() {
-    const char amps[5] = "ABCD\0";
-    int amp_id=AMP_C, test_status;
+static int rectangle_test_case(int amp_id) {
+    int test_status, nx=3, ny=4;;
     FloatTwoDArray da;
-    int nx=3, ny=4;
 
     /* Input array before rotation:
 
@@ -91,17 +92,79 @@ static int worker() {
         return test_status;
     }
 
-    /* AMP_B or AMP_C
+    /* AMP_A or AMP_D
         9 6 3 0
        10 7 4 1
        11 8 5 2
+
+       AMP_B or AMP_C
+       2 5 8 11
+       1 4 7 10
+       0 3 6  9
     */
     int truth_nx=ny;
     int truth_ny=nx;
     float *truth = malloc(sizeof(float) * truth_nx * truth_ny);
-    truth[0] = 9; truth[1] = 6; truth[2] = 3; truth[3] = 0;
-    truth[4] = 10; truth[5] = 7; truth[6] = 4; truth[7] = 1;
-    truth[8] = 11; truth[9] = 8; truth[10] = 5; truth[11] = 2;
+    if (amp_id == AMP_B || amp_id == AMP_C) {
+        truth[0] = 2; truth[1] = 5; truth[2] = 8; truth[3] = 11;
+        truth[4] = 1; truth[5] = 4; truth[6] = 7; truth[7] = 10;
+        truth[8] = 0; truth[9] = 3; truth[10] = 6; truth[11] = 9;
+    } else {
+        truth[0] = 9; truth[1] = 6; truth[2] = 3; truth[3] = 0;
+        truth[4] = 10; truth[5] = 7; truth[6] = 4; truth[7] = 1;
+        truth[8] = 11; truth[9] = 8; truth[10] = 5; truth[11] = 2;
+    }
+
+    test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
+    free(truth);
+    freeFloatData(&da);
+    return test_status;
+}
+
+static int square_test_case(int amp_id) {
+    int test_status, nx=3;
+    FloatTwoDArray da;
+
+    /* Input array before rotation:
+
+       0 1 2
+       3 4 5
+       6 7 8
+     */
+    if ((test_status = setup_input_array(&da, nx, nx))) {
+        freeFloatData(&da);
+        return test_status;
+    }
+
+    // TODO: Need to test all amps
+    printf("==== rotateAmpData_acscte AMP %c ====\n", amps[amp_id]);
+    if ((test_status = rotateAmpData_acscte(&da, amp_id))) {
+        freeFloatData(&da);
+        return test_status;
+    }
+
+    /* AMP_A or AMP_D
+       6 3 0
+       7 4 1
+       8 5 2
+
+       AMP_B or AMP_C
+       2 5 8
+       1 4 7
+       0 3 6
+    */
+    int truth_nx=nx;
+    int truth_ny=nx;
+    float *truth = malloc(sizeof(float) * truth_nx * truth_ny);
+    if (amp_id == AMP_B || amp_id == AMP_C) {
+        truth[0] = 2; truth[1] = 5; truth[2] = 8;
+        truth[3] = 1; truth[4] = 4; truth[5] = 7;
+        truth[6] = 0; truth[7] = 3; truth[8] = 6;
+    } else {
+        truth[0] = 6; truth[1] = 3; truth[2] = 0;
+        truth[3] = 7; truth[4] = 4; truth[5] = 1;
+        truth[6] = 8; truth[7] = 5; truth[8] = 2;
+    }
 
     test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
     free(truth);
@@ -110,9 +173,16 @@ static int worker() {
 }
 
 int main(int argc, char **argv) {
-    int test_status;
+    int i, test_status;
 
-    test_status = worker();
+    for (i=0; i<4; i++) {
+        test_status = square_test_case(i);
+    }
+
+    /* FIXME: da dimension would need fixing in dopcte-gen3.c */
+    for (i=0; i<4; i++) {
+        test_status = rectangle_test_case(i);
+    }
 
     return test_status;
 }

--- a/pkg/acs/include/pcte_gen3_funcs.h
+++ b/pkg/acs/include/pcte_gen3_funcs.h
@@ -1,0 +1,6 @@
+/* These functions are for dopcte-gen3.c in ACSCTE.
+   They are not meant to be used outside that module and they were static.
+   We are only exposing them here so they can be tested in CI. */
+
+int rotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID);
+int derotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID);

--- a/pkg/acs/lib/acscte/dopcte-gen3.c
+++ b/pkg/acs/lib/acscte/dopcte-gen3.c
@@ -15,6 +15,7 @@
 #include "trlbuf.h"
 
 #include "pcte.h"
+#include "pcte_gen3_funcs.h"  /* rotateAmpData_acscte and derotateAmpData_acscte */
 
 # ifdef _OPENMP
 #  include <omp.h>
@@ -31,8 +32,6 @@ static int insertAmp(SingleGroup * amp, const SingleGroup * image, const unsigne
 static int alignAmpData(FloatTwoDArray * amp, const unsigned ampID);
 static int alignAmp(SingleGroup * amp, const unsigned ampID);
 static int rotateAmp(SingleGroup * amp, const unsigned ampID, bool derotate, char ccdamp);
-static int rotateAmpData(FloatTwoDArray * amp, const unsigned ampID);
-static int derotateAmpData(FloatTwoDArray * amp, const unsigned ampID);
 
 static void transpose(FloatTwoDArray *amp);
 static void side2sideFlip(FloatTwoDArray *amp);
@@ -370,14 +369,14 @@ static int rotateAmp(SingleGroup * amp, const unsigned ampID, bool derotate, cha
         if (amp->sci.data.data)
         {
             trlmessage("(pctecorr) Rotation for Amp: %c", ccdamp);
-            if ((status = rotateAmpData(&amp->sci.data, ampID)))
+            if ((status = rotateAmpData_acscte(&amp->sci.data, ampID)))
                 return status;
         }
 
         //err data
         if (amp->err.data.data)
         {
-            if ((status = rotateAmpData(&amp->err.data, ampID)))
+            if ((status = rotateAmpData_acscte(&amp->err.data, ampID)))
                 return status;
         }
     }
@@ -388,14 +387,14 @@ static int rotateAmp(SingleGroup * amp, const unsigned ampID, bool derotate, cha
         if (amp->sci.data.data)
         {
             trlmessage("(pctecorr) Derotation for Amp: %c", ccdamp);
-            if ((status = derotateAmpData(&amp->sci.data, ampID)))
+            if ((status = derotateAmpData_acscte(&amp->sci.data, ampID)))
                 return status;
         }
 
         //err data
         if (amp->err.data.data)
         {
-            if ((status = derotateAmpData(&amp->err.data, ampID)))
+            if ((status = derotateAmpData_acscte(&amp->err.data, ampID)))
                 return status;
         }
     }
@@ -403,7 +402,7 @@ static int rotateAmp(SingleGroup * amp, const unsigned ampID, bool derotate, cha
     return status;
 }
 
-static int rotateAmpData(FloatTwoDArray * amp, const unsigned ampID)
+int rotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID)
 {
     extern int status;
     if (!amp || !amp->data)
@@ -431,7 +430,7 @@ static int rotateAmpData(FloatTwoDArray * amp, const unsigned ampID)
     return status;
 }
 
-static int derotateAmpData(FloatTwoDArray * amp, const unsigned ampID)
+int derotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID)
 {
     extern int status;
     if (!amp || !amp->data)


### PR DESCRIPTION
This is a pre-cursor for #700 . Does not affect functionality.

`cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DTESTS=ON`

or

`cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DENABLE_ASAN=ON -DTESTS=ON`

## TODO 

- [x] Generalize test code to support different cases.
- [x] Implement a square test and see if that pass.
- [x] If square works but not rectangle, mark it as xfail for now (`WILL_FAIL`, see https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#test-properties)
- [x] Run RT: https://github.com/spacetelescope/RegressionTests/actions/runs/22317755490