### PR TITLE
ACSCTE: Serial CTE correction for subarrays

### DIFF
--- a/ctests/test_acscte_rotateamp.c
+++ b/ctests/test_acscte_rotateamp.c
@@ -5,7 +5,9 @@
 static int setup_input_array(FloatTwoDArray *, int, int);
 static int compare_arrays(FloatTwoDArray *, float *, int, int);
 static int rectangle_test_case_transpose();
+static int rectangle_test_case_rot(int);
 static int rectangle_test_case_derot(int);
+static int square_test_case_transpose();
 static int square_test_case_rot(int);
 static int square_test_case_derot(int);
 
@@ -87,7 +89,7 @@ static int rectangle_test_case_transpose() {
         return test_status;
     }
 
-    printf("==== transpose array %d x %d ====\n", nx, ny);
+    printf("==== transpose array (%d x %d) ====\n", nx, ny);
     transpose(&da);
 
     /* Array after transpose:
@@ -102,6 +104,57 @@ static int rectangle_test_case_transpose() {
     truth[0] = 0; truth[1] = 3; truth[2] = 6; truth[3] = 9;
     truth[4] = 1; truth[5] = 4; truth[6] = 7; truth[7] = 10;
     truth[8] = 2; truth[9] = 5; truth[10] = 8; truth[11] = 11;
+
+    test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
+    free(truth);
+    freeFloatData(&da);
+    return test_status;
+}
+
+static int rectangle_test_case_rot(int amp_id) {
+    int test_status, nx=3, ny=4;
+    FloatTwoDArray da;
+
+    /* Input array before rotation:
+
+       0 1 2
+       3 4 5
+       6 7 8
+       9 10 11
+     */
+    if ((test_status = setup_input_array(&da, nx, ny))) {
+        freeFloatData(&da);
+        return test_status;
+    }
+
+    printf("====   rotateAmpData_acscte AMP %c (%d x %d) ====\n", amps[amp_id], nx, ny);
+    if ((test_status = rotateAmpData_acscte(&da, amp_id))) {
+        freeFloatData(&da);
+        return test_status;
+    }
+
+    /* AMP_A or AMP_D
+       2 5 8 11
+       1 4 7 10
+       0 3 6 9
+
+       AMP_B or AMP_C
+        9 6 3 0
+       10 7 4 1
+       11 8 5 2
+    */
+    int truth_nx=ny;
+    int truth_ny=nx;
+    float *truth = malloc(sizeof(float) * truth_nx * truth_ny);
+    if (amp_id == AMP_B || amp_id == AMP_C) {
+        truth[0] = 9; truth[1] = 6; truth[2] = 3; truth[3] = 0;
+        truth[4] = 10; truth[5] = 7; truth[6] = 4; truth[7] = 1;
+        truth[8] = 11; truth[9] = 8; truth[10] = 5; truth[11] = 2;
+    } else {
+        truth[0] = 2; truth[1] = 5; truth[2] = 8; truth[3] = 11;
+        truth[4] = 1; truth[5] = 4; truth[6] = 7; truth[7] = 10;
+        truth[8] = 0; truth[9] = 3; truth[10] = 6; truth[11] = 9;
+    }
 
     test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
     free(truth);
@@ -125,7 +178,7 @@ static int rectangle_test_case_derot(int amp_id) {
         return test_status;
     }
 
-    printf("==== derotateAmpData_acscte AMP %c ====\n", amps[amp_id]);
+    printf("==== derotateAmpData_acscte AMP %c (%d x %d) ====\n", amps[amp_id], nx, ny);
     if ((test_status = derotateAmpData_acscte(&da, amp_id))) {
         freeFloatData(&da);
         return test_status;
@@ -160,6 +213,43 @@ static int rectangle_test_case_derot(int amp_id) {
     return test_status;
 }
 
+static int square_test_case_transpose() {
+    int test_status, nx=3;
+    FloatTwoDArray da;
+
+    /* Array before transpose:
+
+       0 1 2
+       3 4 5
+       6 7 8
+    */
+    if ((test_status = setup_input_array(&da, nx, nx))) {
+        freeFloatData(&da);
+        return test_status;
+    }
+
+    printf("==== transpose array (%d x %d) ====\n", nx, nx);
+    transpose(&da);
+
+    /* Array after transpose:
+
+       0 3 6
+       1 4 7
+       2 5 8
+    */
+    int truth_nx=nx;
+    int truth_ny=nx;
+    float *truth = malloc(sizeof(float) * truth_nx * truth_ny);
+    truth[0] = 0; truth[1] = 3; truth[2] = 6;
+    truth[3] = 1; truth[4] = 4; truth[5] = 7;
+    truth[6] = 2; truth[7] = 5; truth[8] = 8;
+
+    test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
+    free(truth);
+    freeFloatData(&da);
+    return test_status;
+}
+
 static int square_test_case_rot(int amp_id) {
     int test_status, nx=3;
     FloatTwoDArray da;
@@ -175,7 +265,7 @@ static int square_test_case_rot(int amp_id) {
         return test_status;
     }
 
-    printf("==== rotateAmpData_acscte AMP %c ====\n", amps[amp_id]);
+    printf("====   rotateAmpData_acscte AMP %c (%d x %d) ====\n", amps[amp_id], nx, nx);
     if ((test_status = rotateAmpData_acscte(&da, amp_id))) {
         freeFloatData(&da);
         return test_status;
@@ -225,7 +315,7 @@ static int square_test_case_derot(int amp_id) {
         return test_status;
     }
 
-    printf("==== derotateAmpData_acscte AMP %c ====\n", amps[amp_id]);
+    printf("==== derotateAmpData_acscte AMP %c (%d x %d) ====\n", amps[amp_id], nx, nx);
     if ((test_status = derotateAmpData_acscte(&da, amp_id))) {
         freeFloatData(&da);
         return test_status;
@@ -263,14 +353,14 @@ static int square_test_case_derot(int amp_id) {
 int main(int argc, char **argv) {
     int i, test_status=0;
 
+    test_status += square_test_case_transpose();
     test_status += rectangle_test_case_transpose();
 
     for (i=0; i<4; i++) {
         test_status += square_test_case_rot(i);
         test_status += square_test_case_derot(i);
-
-        /* FIXME: da dimension would need fixing in dopcte-gen3.c */
-        //test_status += rectangle_test_case_derot(i);
+        test_status += rectangle_test_case_rot(i);
+        test_status += rectangle_test_case_derot(i);
     }
 
     return test_status;

--- a/ctests/test_acscte_rotateamp.c
+++ b/ctests/test_acscte_rotateamp.c
@@ -261,16 +261,16 @@ static int square_test_case_derot(int amp_id) {
 }
 
 int main(int argc, char **argv) {
-    int i, test_status;
+    int i, test_status=0;
 
-    test_status = rectangle_test_case_transpose();
+    test_status += rectangle_test_case_transpose();
 
     for (i=0; i<4; i++) {
-        test_status = square_test_case_rot(i);
-        test_status = square_test_case_derot(i);
+        test_status += square_test_case_rot(i);
+        test_status += square_test_case_derot(i);
 
         /* FIXME: da dimension would need fixing in dopcte-gen3.c */
-        //test_status = rectangle_test_case_derot(i);
+        //test_status += rectangle_test_case_derot(i);
     }
 
     return test_status;

--- a/ctests/test_acscte_rotateamp.c
+++ b/ctests/test_acscte_rotateamp.c
@@ -4,6 +4,7 @@
 
 static int setup_input_array(FloatTwoDArray *, int, int);
 static int compare_arrays(FloatTwoDArray *, float *, int, int);
+static int rectangle_test_case_transpose();
 static int rectangle_test_case_derot(int);
 static int square_test_case_rot(int);
 static int square_test_case_derot(int);
@@ -70,8 +71,46 @@ static int compare_arrays(FloatTwoDArray *da, float *truth, int truth_nx, int tr
     return test_status;
 }
 
+static int rectangle_test_case_transpose() {
+    int test_status, nx=3, ny=4;
+    FloatTwoDArray da;
+
+    /* Array before transpose:
+
+       0 1 2
+       3 4 5
+       6 7 8
+       9 10 11
+    */
+    if ((test_status = setup_input_array(&da, nx, ny))) {
+        freeFloatData(&da);
+        return test_status;
+    }
+
+    printf("==== transpose array %d x %d ====\n", nx, ny);
+    transpose(&da);
+
+    /* Array after transpose:
+
+       0 3 6 9
+       1 4 7 10
+       2 5 8 11
+    */
+    int truth_nx=ny;
+    int truth_ny=nx;
+    float *truth = malloc(sizeof(float) * truth_nx * truth_ny);
+    truth[0] = 0; truth[1] = 3; truth[2] = 6; truth[3] = 9;
+    truth[4] = 1; truth[5] = 4; truth[6] = 7; truth[7] = 10;
+    truth[8] = 2; truth[9] = 5; truth[10] = 8; truth[11] = 11;
+
+    test_status = compare_arrays(&da, truth, truth_nx, truth_ny);
+    free(truth);
+    freeFloatData(&da);
+    return test_status;
+}
+
 static int rectangle_test_case_derot(int amp_id) {
-    int test_status, nx=3, ny=4;;
+    int test_status, nx=3, ny=4;
     FloatTwoDArray da;
 
     /* Input array before rotation:
@@ -223,6 +262,8 @@ static int square_test_case_derot(int amp_id) {
 
 int main(int argc, char **argv) {
     int i, test_status;
+
+    test_status = rectangle_test_case_transpose();
 
     for (i=0; i<4; i++) {
         test_status = square_test_case_rot(i);

--- a/pkg/acs/Dates
+++ b/pkg/acs/Dates
@@ -1,3 +1,4 @@
+ 16-Mar-2026   CALACS 10.5.0 Serial CTE correction is now enabled for post-SM4 WFC subarrays.
  07-May-2024   CALACS 10.4.0 Implementation of the "Parallel and Serial CTE correction". This
                              version of the CTE correction (Generation 3) is based upon the
                              algorithm of Generation 2, but includes the additional correction

--- a/pkg/acs/Dates
+++ b/pkg/acs/Dates
@@ -1,3 +1,4 @@
+16-Mar-2026   CALACS 10.5.0 Serial CTE correction is now enabled for post-SM4 WFC subarrays.
 08-Aug-2025   CALACS 10.4.1 Post-SM4 subarrays now have MEANBLEV populated with "fat zero"
                             value. Also report the value before bias level correction,
                             as well as after.

--- a/pkg/acs/History
+++ b/pkg/acs/History
@@ -1,3 +1,5 @@
+### 16-Mar-2026 - PLL - Version 10.5.0
+    Serial CTE correction is now enabled for post-SM4 WFC subarrays.
 ### 07-May-2024 - MDD - Version 10.4.0
     Implementation of the "Parallel and Serial CTE correction". This
     version of the CTE correction (Generation 3) is based upon the

--- a/pkg/acs/History
+++ b/pkg/acs/History
@@ -1,3 +1,6 @@
+### 16-Mar-2026 - PLL - Version 10.5.0
+    Serial CTE correction is now enabled for post-SM4 WFC subarrays.
+
 ### 08-Aug-2025 - PLL - Version 10.4.1
     Post-SM4 subarrays now have MEANBLEV populated with "fat zero"
     value. Also report the value before bias level correction,

--- a/pkg/acs/Updates
+++ b/pkg/acs/Updates
@@ -1,3 +1,12 @@
+Update for version 10.5.0 - 16-Mar-2026 (PLL)
+    pkg/acs/Dates
+    pkg/acs/History
+    pkg/acs/Updates
+    pkg/acs/include/acsversion.h
+    pkg/acs/include/pcte_gen3_funcs.h
+    pkg/acs/lib/acscte/docte.c
+    pkg/acs/lib/acscte/dopcte-gen3.c
+
 Update for version 10.4.0 - 07-May-2024 (MDD)
     pkg/acs/Dates
     pkg/acs/History

--- a/pkg/acs/Updates
+++ b/pkg/acs/Updates
@@ -1,3 +1,12 @@
+Update for version 10.5.0 - 16-Mar-2026 (PLL)
+    pkg/acs/Dates
+    pkg/acs/History
+    pkg/acs/Updates
+    pkg/acs/include/acsversion.h
+    pkg/acs/include/pcte_gen3_funcs.h
+    pkg/acs/lib/acscte/docte.c
+    pkg/acs/lib/acscte/dopcte-gen3.c
+
 Update for version 10.4.1 - 08-Aug-2025 (PLL)
     pkg/acs/Dates
     pkg/acs/History

--- a/pkg/acs/include/acsversion.h
+++ b/pkg/acs/include/acsversion.h
@@ -21,6 +21,6 @@
 
 /* name and version number of generation 3 CTE correction algorithm */
 #define ACS_GEN3_CTE_NAME "Par/Serial PixelCTE 2023"
-#define ACS_GEN3_CTE_VER "3.1"
+#define ACS_GEN3_CTE_VER "3.0"
 
 #endif /* INCL_ACSVERSION_H */

--- a/pkg/acs/include/acsversion.h
+++ b/pkg/acs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.4.0 (07-May-2024)"
-#define ACS_CAL_VER_NUM "10.4.0"
+#define ACS_CAL_VER "10.5.0 (16-Mar-2026)"
+#define ACS_CAL_VER_NUM "10.5.0"
 
 /* This Generation of the CTE algorithm is obsolete.  These strings
    are only maintained in case a user has an older version of the
@@ -21,6 +21,6 @@
 
 /* name and version number of generation 3 CTE correction algorithm */
 #define ACS_GEN3_CTE_NAME "Par/Serial PixelCTE 2023"
-#define ACS_GEN3_CTE_VER "3.0"
+#define ACS_GEN3_CTE_VER "3.1"
 
 #endif /* INCL_ACSVERSION_H */

--- a/pkg/acs/include/acsversion.h
+++ b/pkg/acs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.4.1 (08-Aug-2025)"
-#define ACS_CAL_VER_NUM "10.4.1"
+#define ACS_CAL_VER "10.5.0 (16-Mar-2026)"
+#define ACS_CAL_VER_NUM "10.5.0"
 
 /* This Generation of the CTE algorithm is obsolete.  These strings
    are only maintained in case a user has an older version of the
@@ -21,6 +21,6 @@
 
 /* name and version number of generation 3 CTE correction algorithm */
 #define ACS_GEN3_CTE_NAME "Par/Serial PixelCTE 2023"
-#define ACS_GEN3_CTE_VER "3.0"
+#define ACS_GEN3_CTE_VER "3.1"
 
 #endif /* INCL_ACSVERSION_H */

--- a/pkg/acs/include/pcte_gen3_funcs.h
+++ b/pkg/acs/include/pcte_gen3_funcs.h
@@ -2,5 +2,6 @@
    They are not meant to be used outside that module and they were static.
    We are only exposing them here so they can be tested in CI. */
 
+void transpose(FloatTwoDArray *amp);
 int rotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID);
 int derotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID);

--- a/pkg/acs/lib/acscte/docte.c
+++ b/pkg/acs/lib/acscte/docte.c
@@ -6,7 +6,7 @@
  14-Sep-2023 MDD: Updated to accommodate only the "Parallel/Serial PixelCTE 2023"
      (aka Generation 3) correction. Code now applies a serial CTE correction for
      full-frame data.
-
+ 16-Mar-2026 PLL: Enabled serial CTE correction for subarrays.
 */
 # include <string.h>
 # include <stdio.h>
@@ -326,8 +326,7 @@ int DoCTE (ACSInfo *acs_info, const bool forwardModelOnly) {
         trlwarn("(pctecorr) IGNORING read noise level PCTERNOI from PCTETAB: %f. Using amp dependent values from CCDTAB instead", cteParallelPars.rn_amp);
         trlmessage("(pctecorr) Readout simulation forward modeling iterations PCTENFOR: %i\n"
                    "(pctecorr) Number of iterations used in the parallel transfer PCTENPAR: %i\n"
-                   "(pctecorr) CTE_FRAC: %f\n\n"
-                   "(pctecorr) NOTE: No serial CTE correction is done for any subarray data.\n",
+                   "(pctecorr) CTE_FRAC: %f\n\n",
                    cteParallelPars.n_forward, cteParallelPars.n_par, cteParallelPars.scale_frac);
         /* End read of the parallel CTE parameters */
 
@@ -364,9 +363,9 @@ int DoCTE (ACSInfo *acs_info, const bool forwardModelOnly) {
                     ampIDInCalib = amplocInCalib - AMPCALIBORDER; // This is a number.
 
                     /*
-                       Only perform the serial CTE correction for full-frame, post-SM4 data
+                       Only perform the serial CTE correction for post-SM4 data.
                     */
-                    if ((acs_info->expstart >= SM4MJD) && (!acs[i].subarray)) {
+                    if (acs_info->expstart >= SM4MJD) {
 
                         startOfSetInCalib = SET_TO_PROCESS[ampIDInCalib];
                         strcpy(corrType, "serial");
@@ -443,8 +442,8 @@ int DoCTE (ACSInfo *acs_info, const bool forwardModelOnly) {
 
                     clock_t begin = (double)clock();
 
-                    /* Perform the serial CTE correction for only full-frame, post-SM4 data */
-                    if ((acs_info->expstart >= SM4MJD) && (!acs[i].subarray)) {
+                    /* Perform the serial CTE correction for only post-SM4 data */
+                    if (acs_info->expstart >= SM4MJD) {
                         /* Serial correction */
                         strcpy(corrType, "serial");
                         if ((status = doPCTEGen3(&acs[i], &ctePars, &x[i], forwardModelOnly, corrType, ccdamp, nthAmp, amploc, ampID)))

--- a/pkg/acs/lib/acscte/dopcte-gen3.c
+++ b/pkg/acs/lib/acscte/dopcte-gen3.c
@@ -126,6 +126,8 @@ int doPCTEGen3 (ACSInfo *acs, CTEParamsFast * ctePars, SingleGroup * chipImage, 
             freeOnExit(&ptrReg);
             return (status);
         }
+        nColumns = ampImage.sci.data.nx;
+        nRows = ampImage.sci.data.ny;
     }
 
     if ((status = alignAmp(&ampImage, ampID)))
@@ -297,6 +299,10 @@ int doPCTEGen3 (ACSInfo *acs, CTEParamsFast * ctePars, SingleGroup * chipImage, 
             freeOnExit(&ptrReg);
             return (status);
         }
+        /* UNCOMMENT IF NEEDED IN THE FUTURE.
+        nColumns = ampImage.sci.data.nx;
+        nRows = ampImage.sci.data.ny;
+        */
     }
 
     if ((status = insertAmp(chipImage, &ampImage, ampID, ctePars)))

--- a/pkg/acs/lib/acscte/dopcte-gen3.c
+++ b/pkg/acs/lib/acscte/dopcte-gen3.c
@@ -411,7 +411,6 @@ int rotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID)
        Rotate the amp to put the serial trails in the same orientation
        as the parallel trails would be. A rotation requires a transpose
        and then a flip. Always transpose the data first.
-
     */
     transpose(amp);
 
@@ -600,7 +599,7 @@ static int alignAmpData(FloatTwoDArray * amp, const unsigned ampID)
    Flip the amp about the X-axis central row (i.e., flip from top to bottom)
 
    Note: This routine was originally in alignAmpData flow of processing.  It
-   is now encapulated here as it is used multiple times due to the rotations
+   is now encapsulated here as it is used multiple times due to the rotations
    needed to accommodate the serial CTE correction.  The original OPENMP
    specifications have been left intact.
 */

--- a/pkg/acs/lib/acscte/dopcte-gen3.c
+++ b/pkg/acs/lib/acscte/dopcte-gen3.c
@@ -462,17 +462,34 @@ int derotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID)
 */
 void transpose(FloatTwoDArray * amp)
 {
-    const unsigned nRows = amp->ny;
-    const unsigned nColumns = amp->nx;
-    float temp;
+    FloatTwoDArray orig_amp;
+    const int nRows = amp->ny, nColumns = amp->nx;
+    int i, j;
 
-    for (unsigned i = 0; i < nRows; i++) {
-        for (unsigned j = i; j < nColumns; j++) {
-            temp = PPix(amp, j, i);
-            PPix(amp, j, i) = PPix(amp, i, j);
-            PPix(amp, i, j) = temp;
+    initFloatData(&orig_amp);
+    allocFloatData(&orig_amp, nColumns, nRows, False);
+    for (i = 0; i < nRows; i++) {
+        for (j = 0; j < nColumns; j++) {
+            PPix(&orig_amp, j, i) = PPix(amp, j, i);
         }
     }
+
+    if (amp->tot_nx != amp->tot_ny) {
+        amp->nx = nRows;
+        amp->ny = nColumns;
+        j = amp->tot_nx;
+        i = amp->tot_ny;
+        amp->tot_nx = i;
+        amp->tot_ny = j;
+    }
+
+    for (i = 0; i < nRows; i++) {
+        for (j = 0; j < nColumns; j++) {
+            PPix(amp, i, j) = PPix(&orig_amp, j, i);
+        }
+    }
+
+    freeFloatData(&orig_amp);
 }
 
 /*

--- a/pkg/acs/lib/acscte/dopcte-gen3.c
+++ b/pkg/acs/lib/acscte/dopcte-gen3.c
@@ -33,7 +33,6 @@ static int alignAmpData(FloatTwoDArray * amp, const unsigned ampID);
 static int alignAmp(SingleGroup * amp, const unsigned ampID);
 static int rotateAmp(SingleGroup * amp, const unsigned ampID, bool derotate, char ccdamp);
 
-static void transpose(FloatTwoDArray *amp);
 static void side2sideFlip(FloatTwoDArray *amp);
 static void top2bottomFlip(FloatTwoDArray *amp);
 
@@ -461,7 +460,7 @@ int derotateAmpData_acscte(FloatTwoDArray * amp, const unsigned ampID)
 /*
    Transpose the amp data
 */
-static void transpose(FloatTwoDArray * amp)
+void transpose(FloatTwoDArray * amp)
 {
     const unsigned nRows = amp->ny;
     const unsigned nColumns = amp->nx;


### PR DESCRIPTION
Follow-up of #707 . Towards #700

`cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DTESTS=ON`

### TODO

- [x] Test transpose for rectangle
- [x] ~Test flips for rectangle~ (flip is not the problem and tested indirectly)
- [x] Figure out why `rectangle_test_case_derot` is behaving not as expected initially
    - RT: https://github.com/spacetelescope/RegressionTests/actions/runs/23168884162 (passed)
-  Option A:
    - [x] See if transpose fix is enough to expand subarray support with the dataset Jenna provided 
    - RT: https://github.com/spacetelescope/RegressionTests/actions/runs/23175450071
    - [x] Fix serial logic for subarrays; something isn't right. Awaiting good data from Jenna for comparison.
    - RT: https://github.com/spacetelescope/RegressionTests/actions/runs/23266217079
    - Rebased RT: https://github.com/spacetelescope/RegressionTests/actions/runs/25767151533
- ~Option B:~
    - ~Write new function to flip amp data only once for use of both serial and parallel (originally I was very tempted to do this but now I feel like this cost does not justify the lack of benefit, maybe we defer to future if not doing this is somehow a bottleneck in processing but I don't think so because adding serial only adds a second to run time somehow)~
    - ~Retire any unused rotation functions after new function is in effect~
- [x] Make sure changes do not affect existing pipeline functionality besides affected subarrays