### PR TITLE
Bump CALACS to 10.4.1 and add change logs

### DIFF
--- a/pkg/acs/Dates
+++ b/pkg/acs/Dates
@@ -1,4 +1,7 @@
- 07-May-2024   CALACS 10.4.0 Implementation of the "Parallel and Serial CTE correction". This
+08-Aug-2025   CALACS 10.4.1 Post-SM4 subarrays now have MEANBLEV populated with "fat zero"
+                            value. Also report the value before bias level correction,
+                            as well as after.
+07-May-2024   CALACS 10.4.0 Implementation of the "Parallel and Serial CTE correction". This
                              version of the CTE correction (Generation 3) is based upon the
                              algorithm of Generation 2, but includes the additional correction
                              for the serial direction which is amp-dependent.  Previous

--- a/pkg/acs/History
+++ b/pkg/acs/History
@@ -1,3 +1,8 @@
+### 08-Aug-2025 - PLL - Version 10.4.1
+    Post-SM4 subarrays now have MEANBLEV populated with "fat zero"
+    value. Also report the value before bias level correction,
+    as well as after.
+
 ### 07-May-2024 - MDD - Version 10.4.0
     Implementation of the "Parallel and Serial CTE correction". This
     version of the CTE correction (Generation 3) is based upon the

--- a/pkg/acs/Updates
+++ b/pkg/acs/Updates
@@ -1,3 +1,10 @@
+Update for version 10.4.1 - 08-Aug-2025 (PLL)
+    pkg/acs/Dates
+    pkg/acs/History
+    pkg/acs/Updates
+    pkg/acs/include/acsversion.h
+    pkg/acs/lib/acsccd/blev_funcs_postsm4.c
+
 Update for version 10.4.0 - 07-May-2024 (MDD)
     pkg/acs/Dates
     pkg/acs/History

--- a/pkg/acs/include/acsversion.h
+++ b/pkg/acs/include/acsversion.h
@@ -2,8 +2,8 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.4.0 (07-May-2024)"
-#define ACS_CAL_VER_NUM "10.4.0"
+#define ACS_CAL_VER "10.4.1 (08-Aug-2025)"
+#define ACS_CAL_VER_NUM "10.4.1"
 
 /* This Generation of the CTE algorithm is obsolete.  These strings
    are only maintained in case a user has an older version of the

--- a/pkg/acs/lib/acsccd/blev_funcs_postsm4.c
+++ b/pkg/acs/lib/acsccd/blev_funcs_postsm4.c
@@ -54,6 +54,7 @@ static int unmake_amp_array(const int arr_rows, const int arr_cols, SingleGroup 
  * *** This routine should be modified according to issues discussed in PR #312 and noted in IT #334. ***
  *
  * 16-May-2018 M.D. De La Pena: Generalized bias_shift_corr() to handle subarray data.
+ * 08-Aug-2025 P.L. Lim: Populate MEANBLEV for post-SM4 subarrays.
  */
 int bias_shift_corr(ACSInfo *acs, int nGroups, ...) {
 


### PR DESCRIPTION
This follows up on https://github.com/spacetelescope/hstcal/pull/687 that kept some fixes from #685 instead of full reversion. Changes are that not visible to users (e.g., fixing broken link in code comment, etc) are excluded from change logs.

RT: https://github.com/spacetelescope/RegressionTests/actions/runs/23919800504