### PR TITLE
BUG: Restore parity in ACS crosstalk correction

### DIFF
--- a/pkg/acs/CHANGELOG.txt
+++ b/pkg/acs/CHANGELOG.txt
@@ -1,5 +1,8 @@
-### 16-Mar-2026 - PLL - Version 10.5.0
-    Serial CTE correction is now enabled for post-SM4 WFC subarrays.
+### 25-Aug-2026 - PLL - Version 10.5.0
+    - Serial CTE correction is now enabled for post-SM4 WFC subarrays.
+    - Fixed crosstalk bug where right amp operates on corrected pixels
+      from left amp, but not vice versa. Now right amp also operates
+      on uncorrected pixels.
 
 ### 08-Aug-2025 - PLL - Version 10.4.1
     Post-SM4 subarrays now have MEANBLEV populated with "fat zero"

--- a/pkg/acs/include/acsversion.h
+++ b/pkg/acs/include/acsversion.h
@@ -2,7 +2,7 @@
 #define INCL_ACSVERSION_H
 
 /* This string is written to the output primary header as CAL_VER. */
-#define ACS_CAL_VER "10.5.0 (16-Mar-2026)"
+#define ACS_CAL_VER "10.5.0 (25-Aug-2026)"
 #define ACS_CAL_VER_NUM "10.5.0"
 
 /* This Generation of the CTE algorithm is obsolete.  These strings

--- a/pkg/acs/lib/acsccd/blev_funcs_postsm4.c
+++ b/pkg/acs/lib/acsccd/blev_funcs_postsm4.c
@@ -294,6 +294,7 @@ int bias_shift_corr(ACSInfo *acs, int nGroups, ...) {
 void cross_talk_corr(ACSInfo *acs, SingleGroup *im) {
   /* iteration variables */
   int i, j;
+  float *y;
 
   /* cross talk scaling constant */
   double cross_scale = 9.1e-5;
@@ -303,13 +304,22 @@ void cross_talk_corr(ACSInfo *acs, SingleGroup *im) {
   const int arr_rows = im->sci.data.ny;
   const int arr_cols = im->sci.data.nx;
 
+  y = calloc(arr_cols, sizeof(float));
+
   for (i = 0; i < arr_rows; i++) {
+    /* Copy out original row for corr_fac calculation. */
     for (j = 0; j < arr_cols; j++) {
-      temp = Pix(im->sci.data, arr_cols-j-1, i) * cross_scale;
+      y[j] = Pix(im->sci.data, j, i);
+    }
+
+    for (j = 0; j < arr_cols; j++) {
+      temp = y[arr_cols - j - 1] * cross_scale;
 
       Pix(im->sci.data, j, i) += (float) temp;
     }
   }
+
+  free(y);
 }
 
 


### PR DESCRIPTION
Fix #721 

RT: https://github.com/spacetelescope/RegressionTests/actions/runs/32866509360

### TODO

- [ ] Discuss with INS
- [ ] Move the change log to next build